### PR TITLE
[WIP] Fix grpc-health-probe path

### DIFF
--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           livenessProbe:
             exec:
               command:
-              - /bin/grpc_health_probe
+              - /usr/local/bin/grpc_health_probe
               - -addr=:50051
             failureThreshold: 3
             initialDelaySeconds: 10


### PR DESCRIPTION
# Description

Because the `grpc_health_probe` path was changed in [PR#531](https://github.com/scalar-labs/scalar/pull/531)
