### PR TITLE
Update scalar-envoy to 1.1.0

### DIFF
--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalardl
 description: Implementation scalardl.
 type: application
-version: 2.0.1
+version: 2.1.0
 appVersion: 3.0.1
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,7 +1,7 @@
 # scalardl
 
 Implementation scalardl.
-Current chart version is `2.0.1`
+Current chart version is `2.1.0`
 
 ## Values
 
@@ -13,7 +13,7 @@ Current chart version is `2.0.1`
 | envoy.grafanaDashboard.namespace | string | `"monitoring"` |  |
 | envoy.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | envoy.image.repository | string | `"ghcr.io/scalar-labs/scalar-envoy"` | Docker image |
-| envoy.image.version | string | `"1.0.1"` |  |
+| envoy.image.version | string | `"1.1.0"` |  |
 | envoy.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | envoy.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | envoy.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -20,7 +20,7 @@ envoy:
     # envoy.image.repository -- Docker image
     repository: ghcr.io/scalar-labs/scalar-envoy
     # envoy.image.tag -- Docker tag
-    version: 1.0.1
+    version: 1.1.0
     # envoy.image.pullPolicy -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
# Description

[v1.1.0](https://github.com/scalar-labs/scalar-envoy/releases/tag/v1.1.0) released for `scalar-envoy`.

Image:
https://github.com/orgs/scalar-labs/packages/container/scalar-envoy/6459590?tag=1.1.0