### PR TITLE
Update to make it runnable without custom config and make auditor work

### DIFF
--- a/charts/schema-loading/README.md
+++ b/charts/schema-loading/README.md
@@ -7,7 +7,8 @@ Current chart version is `2.0.0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| schemaLoading.cassandraReplicationFactor | int | `3` | The replication factor value of the Cassandra schema. This is a Cassandra specific option. |
+| schemaLoading.cassandraReplicationFactor | int | `1` | The replication factor value of the Cassandra schema. This is a Cassandra specific option. |
+| schemaLoading.cassandraReplicationStrategy | string | `"SimpleStrategy"` | The replication strategy of the Cassandra schema. This is a Cassandra specific option. |
 | schemaLoading.contactPoints | string | `"cassandra"` | The database contanct point such as a hostname of Cassandra or a URL of Cosmos DB account. |
 | schemaLoading.contactPort | int | `9042` | The database port number. (Ignored if the database is `cosmos`.) |
 | schemaLoading.cosmosBaseResourceUnit | int | `400` | The resource unit value of the Cosmos DB schema. This is a Cosmos DB specific option. |
@@ -19,4 +20,5 @@ Current chart version is `2.0.0`
 | schemaLoading.image.version | string | `"3.0.0"` | Docker tag |
 | schemaLoading.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | schemaLoading.password | string | `"cassandra"` | The password of the database. For Cosmos DB, please specify a key here. |
+| schemaLoading.schemaType | string | `"ledger"` | Type of schema to apply (ledger or auditor). |
 | schemaLoading.username | string | `"cassandra"` | The username of the database. (Ignored if the database is `cosmos`.) |

--- a/charts/schema-loading/templates/batchjob-schema-loading.yaml
+++ b/charts/schema-loading/templates/batchjob-schema-loading.yaml
@@ -30,7 +30,7 @@ spec:
         - "-h"
         - "{{ .Values.schemaLoading.contactPoints }}"
         - "-n"
-        - "NetworkTopologyStrategy"
+        - "{{ .Values.schemaLoading.cassandraReplicationStrategy }}"
         - "-R"
         - "{{ .Values.schemaLoading.cassandraReplicationFactor }}"
         {{- else if eq .Values.schemaLoading.database "cosmos" }}
@@ -65,5 +65,7 @@ spec:
               name: {{ include "schema-loading.fullname" . }}
             {{- end }}
               key: db-password
+        - name: SCHEMA_TYPE
+          value: "{{ .Values.schemaLoading.schemaType }}"
       restartPolicy: Never
   backoffLimit: 0

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -15,7 +15,7 @@ schemaLoading:
   password: cassandra
   # schemaLoading.cassandraReplicationFactor -- The replication factor value of the Cassandra schema. This is a Cassandra specific option.
   cassandraReplicationFactor: 1
-  # schemaLoading.cassandraReplicationFactor -- The replication strategy of the Cassandra schema. This is a Cassandra specific option.
+  # schemaLoading.cassandraReplicationStrategy -- The replication strategy of the Cassandra schema. This is a Cassandra specific option.
   cassandraReplicationStrategy: SimpleStrategy
   # schemaLoading.cosmosBaseResourceUnit -- The resource unit value of the Cosmos DB schema. This is a Cosmos DB specific option.
   cosmosBaseResourceUnit: 400

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -14,7 +14,9 @@ schemaLoading:
   # schemaLoading.password -- The password of the database. For Cosmos DB, please specify a key here.
   password: cassandra
   # schemaLoading.cassandraReplicationFactor -- The replication factor value of the Cassandra schema. This is a Cassandra specific option.
-  cassandraReplicationFactor: 3
+  cassandraReplicationFactor: 1
+  # schemaLoading.cassandraReplicationFactor -- The replication strategy of the Cassandra schema. This is a Cassandra specific option.
+  cassandraReplicationStrategy: SimpleStrategy
   # schemaLoading.cosmosBaseResourceUnit -- The resource unit value of the Cosmos DB schema. This is a Cosmos DB specific option.
   cosmosBaseResourceUnit: 400
   # schemaLoading.dynamoBaseResourceUnit -- The resource unit value of the DynamoDB schema. This is a DynamoDB specific option.
@@ -33,3 +35,6 @@ schemaLoading:
 
   # schemaLoading.existingSecret -- Name of existing secret to use for storing database username and password
   existingSecret: null
+
+  # schemaLoading.schemaType -- Type of schema to apply (ledger or auditor).
+  schemaType: ledger


### PR DESCRIPTION
Updated the following:
* Make it able to specify `cassandraReplicationStrategy`
* Make the default replication strategy Simple to make it runnable without custom configs. (NetworkTopology with replication factor 1 will fail in C*)
* Make it able to specify `schemaType` to create Auditor schema.

See [another PR](https://github.com/scalar-labs/scalar-kubernetes/pull/142) for the custom config.