### PR TITLE
helm-docs: Use New-style comments

### DIFF
--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -37,6 +37,7 @@ Current chart version is `1.0.0`
 | scalardb.storageConfiguration.password | string | `"cassandra"` | The password of the database. For Cosmos DB, Dynamo DB please specify a secret key here. |
 | scalardb.storageConfiguration.storage | string | `"cassandra"` | Storage implementation. Either cassandra or cosmos or dynamo or jdbc can be set. |
 | scalardb.storageConfiguration.username | string | `"cassandra"` | The username of the database. For Cosmos DB please leave blank. For Dynamo DB please specify key id here. |
-| scalardb.strategy.rollingUpdate | object | `{"maxSurge":"25%","maxUnavailable":"25%"}` | The number of pods that can be unavailable during the update process |
+| scalardb.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
+| scalardb.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | scalardb.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | scalardb.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -2,87 +2,87 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# nameOverride -- String to partially override scalardb.fullname template (will maintain the release name)
+# -- String to partially override scalardb.fullname template (will maintain the release name)
 nameOverride: ""
-# fullnameOverride -- String to fully override scalardb.fullname template
+# -- String to fully override scalardb.fullname template
 fullnameOverride: ""
 
 scalardb:
-  # scalardb.replicaCount -- Default values for number of replicas.
+  # -- Default values for number of replicas.
   replicaCount: 3
 
   storageConfiguration:
-    # scalardb.storageConfiguration.contactPoints -- The database contanct point such as a hostname of Cassandra or a URL of Cosmos DB account.
+    # -- The database contanct point such as a hostname of Cassandra or a URL of Cosmos DB account.
     contactPoints: cassandra
-    # scalardb.storageConfiguration.contactPort -- The database port number.
+    # -- The database port number.
     contactPort: 9042
-    # scalardb.storageConfiguration.username -- The username of the database. For Cosmos DB please leave blank. For Dynamo DB please specify key id here.
+    # -- The username of the database. For Cosmos DB please leave blank. For Dynamo DB please specify key id here.
     username: cassandra
-    # scalardb.storageConfiguration.password -- The password of the database. For Cosmos DB, Dynamo DB please specify a secret key here.
+    # -- The password of the database. For Cosmos DB, Dynamo DB please specify a secret key here.
     password: cassandra
-    # scalardb.storageConfiguration.storage -- Storage implementation. Either cassandra or cosmos or dynamo or jdbc can be set.
+    # -- Storage implementation. Either cassandra or cosmos or dynamo or jdbc can be set.
     storage: cassandra
-    # scalardb.storageConfiguration.dbLogLevel -- The log level of Scalar DB
+    # -- The log level of Scalar DB
     dbLogLevel: INFO
 
   image:
-    # scalardb.image.repository -- Docker image reposiory of Scalar DB server.
+    # -- Docker image reposiory of Scalar DB server.
     repository: ghcr.io/scalar-labs/scalardb-server
     # scalardb.image.pullPolicy Specify a image pulling policy.
     pullPolicy: IfNotPresent
-    # scalardb.image.tag -- Docker tag of the image.
+    # -- Docker tag of the image.
     tag: 3.1.0
 
-  # scalardb.imagePullSecrets -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: []
 
   strategy:
     rollingUpdate:
-      # scalardb.strategy.rollingUpdate -- The number of pods that can be created above the desired amount of pods during an update
+      # -- The number of pods that can be created above the desired amount of pods during an update
       maxSurge: 25%
-      # scalardb.strategy.rollingUpdate -- The number of pods that can be unavailable during the update process
+      # -- The number of pods that can be unavailable during the update process
       maxUnavailable: 25%
-    # scalardb.strategy.type -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
+    # -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
     type: RollingUpdate
 
   service:
-    # scalardb.service.type -- service types in kubernetes.
+    # -- service types in kubernetes.
     type: ClusterIP
     ports:
       scalardb:
-        # scalardb.service.ports.scalardb.port -- Scalar DB server port.
+        # -- Scalar DB server port.
         port: 60051
-        # scalardb.service.ports.scalardb.targetPort -- Scalar DB server target port.
+        # -- Scalar DB server target port.
         targetPort: 60051
-        # scalardb.service.ports.scalardb.protocol -- Scalar DB server protocol.
+        # -- Scalar DB server protocol.
         protocol: TCP
 
   serviceMonitor:
-    # scalardb.serviceMonitor.enabled -- Enable metrics collect with prometheus.
+    # -- Enable metrics collect with prometheus.
     enabled: false
-    # scalardb.serviceMonitor.interval -- Custom interval to retrieve the metrics.
+    # -- Custom interval to retrieve the metrics.
     interval: "15s"
-    # scalardb.serviceMonitor.namespace -- Which namespace prometheus is located. by default monitoring.
+    # -- Which namespace prometheus is located. by default monitoring.
     namespace: monitoring
 
   prometheusRule:
-    # scalardb.prometheusRule.enabled -- Enable rules for prometheus.
+    # -- Enable rules for prometheus.
     enabled: false
-    # scalardb.prometheusRule.namespace -- Which namespace prometheus is located. by default monitoring.
+    # -- Which namespace prometheus is located. by default monitoring.
     namespace: monitoring
 
   grafanaDashboard:
-    # scalardb.grafanaDashboard.enabled -- Enable grafana dashboard.
+    # -- Enable grafana dashboard.
     enabled: false
-    # scalardb.grafanaDashboard.namespace -- Which namespace grafana dashboard is located. by default monitoring.
+    # -- Which namespace grafana dashboard is located. by default monitoring.
     namespace: monitoring
 
-  # scalardb.podSecurityContext -- PodSecurityContext holds pod-level security attributes and common container settings.
+  # -- PodSecurityContext holds pod-level security attributes and common container settings.
   podSecurityContext:
     {}
     # fsGroup: 2000
 
-  # scalardb.securityContext -- Setting security context at the pod applies those settings to all containers in the pod.
+  # -- Setting security context at the pod applies those settings to all containers in the pod.
   securityContext:
     {}
     # capabilities:
@@ -92,7 +92,7 @@ scalardb:
     # runAsNonRoot: true
     # runAsUser: 1000
 
-  # scalardb.resources -- Resources allowed to the pod.
+  # -- Resources allowed to the pod.
   resources:
     {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -106,14 +106,14 @@ scalardb:
     #   cpu: 100m
     #   memory: 128Mi
 
-  # scalardb.nodeSelector -- nodeSelector is form of node selection constraint.
+  # -- nodeSelector is form of node selection constraint.
   nodeSelector: {}
 
-  # scalardb.tolerations -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
+  # -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
   tolerations: []
 
-  # scalardb.affinity -- The affinity/anti-affinity feature, greatly expands the types of constraints you can express.
+  # -- The affinity/anti-affinity feature, greatly expands the types of constraints you can express.
   affinity: {}
 
-  # scalardb.existingSecret -- Name of existing secret to use for storing database username and password.
+  # -- Name of existing secret to use for storing database username and password.
   existingSecret: null

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -9,11 +9,11 @@ Current chart version is `2.1.0`
 |-----|------|---------|-------------|
 | envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
-| envoy.grafanaDashboard.enabled | bool | `false` |  |
-| envoy.grafanaDashboard.namespace | string | `"monitoring"` |  |
+| envoy.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
+| envoy.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | envoy.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | envoy.image.repository | string | `"ghcr.io/scalar-labs/scalar-envoy"` | Docker image |
-| envoy.image.version | string | `"1.1.0"` |  |
+| envoy.image.version | string | `"1.1.0"` | Docker tag |
 | envoy.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | envoy.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | envoy.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
@@ -33,7 +33,8 @@ Current chart version is `2.1.0`
 | envoy.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | envoy.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
 | envoy.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
-| envoy.strategy.rollingUpdate | object | `{"maxSurge":"25%","maxUnavailable":"25%"}` | The number of pods that can be unavailable during the update process |
+| envoy.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
+| envoy.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | envoy.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | envoy.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | fullnameOverride | string | `""` | String to fully override scalardl.fullname template |
@@ -69,7 +70,8 @@ Current chart version is `2.1.0`
 | ledger.service.ports.scalardl.protocol | string | `"TCP"` | scalardl protocol |
 | ledger.service.ports.scalardl.targetPort | int | `50051` | scalardl k8s internal name |
 | ledger.service.type | string | `"ClusterIP"` | service types in kubernetes |
-| ledger.strategy.rollingUpdate | object | `{"maxSurge":"25%","maxUnavailable":"25%"}` | The number of pods that can be unavailable during the update process |
+| ledger.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
+| ledger.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | ledger.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | nameOverride | string | `""` | String to partially override scalardl.fullname template (will maintain the release name) |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -2,45 +2,45 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# nameOverride -- String to partially override scalardl.fullname template (will maintain the release name)
+# -- String to partially override scalardl.fullname template (will maintain the release name)
 nameOverride: ""
 
-# fullnameOverride -- String to fully override scalardl.fullname template
+# -- String to fully override scalardl.fullname template
 fullnameOverride: ""
 
 envoy:
-  # envoy.replicaCount -- number of replicas to deploy
+  # -- number of replicas to deploy
   replicaCount: 3
 
   envoyConfiguration:
-    # envoy.envoyConfiguration.adminAccessLogPath -- admin log path
+    # -- admin log path
     adminAccessLogPath: /dev/stdout
 
   image:
-    # envoy.image.repository -- Docker image
+    # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-envoy
-    # envoy.image.tag -- Docker tag
+    # -- Docker tag
     version: 1.1.0
-    # envoy.image.pullPolicy -- Specify a imagePullPolicy
+    # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 
-  # envoy.imagePullSecrets -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: []
 
   strategy:
     rollingUpdate:
-      # envoy.strategy.rollingUpdate -- The number of pods that can be created above the desired amount of pods during an update
+      # -- The number of pods that can be created above the desired amount of pods during an update
       maxSurge: 25%
-      # envoy.strategy.rollingUpdate -- The number of pods that can be unavailable during the update process
+      # -- The number of pods that can be unavailable during the update process
       maxUnavailable: 25%
-    # envoy.strategy.type -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
+    # -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
     type: RollingUpdate
 
-  # envoy.podSecurityContext -- PodSecurityContext holds pod-level security attributes and common container settings
+  # -- PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext: {}
     # fsGroup: 2000
 
-  # envoy.securityContext -- Setting security context at the pod applies those settings to all containers in the pod
+  # -- Setting security context at the pod applies those settings to all containers in the pod
   securityContext: {}
     # capabilities:
     #   drop:
@@ -49,47 +49,47 @@ envoy:
     # runAsNonRoot: true
     # runAsUser: 1000
   service:
-    # envoy.service.type -- service types in kubernetes
+    # -- service types in kubernetes
     type: ClusterIP
-    # envoy.service.annotations -- Service annotations, e.g: prometheus, etc.
+    # -- Service annotations, e.g: prometheus, etc.
     annotations: {}
     ports:
       envoy:
-        # envoy.service.ports.envoy.port -- envoy public port
+        # -- envoy public port
         port: 50051
-        # envoy.service.ports.envoy.targetPort -- envoy k8s internal name
+        # -- envoy k8s internal name
         targetPort: 50051
-        # envoy.service.ports.envoy.protocol -- envoy protocol
+        # -- envoy protocol
         protocol: TCP
       envoy-priv:
-        # envoy.service.ports.envoy-priv.port -- nvoy public port
+        # -- nvoy public port
         port: 50052
-        # envoy.service.ports.envoy-priv.targetPort -- envoy k8s internal name
+        # -- envoy k8s internal name
         targetPort: 50052
-        # envoy.service.ports.envoy-priv.protocol -- envoy protocol
+        # -- envoy protocol
         protocol: TCP
 
   serviceMonitor:
-    # envoy.serviceMonitor.enabled -- enable metrics collect with prometheus
+    # -- enable metrics collect with prometheus
     enabled: false
-    # envoy.serviceMonitor.interval -- custom interval to retrieve the metrics
+    # -- custom interval to retrieve the metrics
     interval: "15s"
-    # envoy.serviceMonitor.namespace -- which namespace prometheus is located. by default monitoring
+    # -- which namespace prometheus is located. by default monitoring
     namespace: monitoring
 
   prometheusRule:
-    # envoy.prometheusRule.enabled -- enable rules for prometheus
+    # -- enable rules for prometheus
     enabled: false
-    # envoy.prometheusRule.namespace -- which namespace prometheus is located. by default monitoring
+    # -- which namespace prometheus is located. by default monitoring
     namespace: monitoring
 
   grafanaDashboard:
-    # ledger.grafanaDashboard.enabled -- enable grafana dashboard
+    # -- enable grafana dashboard
     enabled: false
-    # ledger.grafanaDashboard.namespace -- which namespace grafana dashboard is located. by default monitoring
+    # -- which namespace grafana dashboard is located. by default monitoring
     namespace: monitoring
 
-  # envoy.resources -- resources allowed to the pod
+  # -- resources allowed to the pod
   resources: {}
     # limits:
     #   cpu: 100m
@@ -98,59 +98,59 @@ envoy:
     #   cpu: 100m
     #   memory: 128Mi
 
-  # envoy.nodeSelector -- nodeSelector is form of node selection constraint
+  # -- nodeSelector is form of node selection constraint
   nodeSelector: {}
 
-  # envoy.tolerations -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
+  # -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
   tolerations: []
 
-  # envoy.affinity -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
+  # -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
   affinity: {}
 
 ledger:
-  # ledger.replicaCount -- number of replicas to deploy
+  # -- number of replicas to deploy
   replicaCount: 3
 
   scalarLedgerConfiguration:
-    # ledger.scalarLedgerConfiguration.dbContactPoints -- The contact points of the database such as hostnames or URLs
+    # -- The contact points of the database such as hostnames or URLs
     dbContactPoints: cassandra
-    # ledger.scalarLedgerConfiguration.dbContactPort -- The port number of the contact points
+    # -- The port number of the contact points
     dbContactPort: 9042
-    # ledger.scalarLedgerConfiguration.dbUsername -- The username of the database
+    # -- The username of the database
     dbUsername: cassandra
-    # ledger.scalarLedgerConfiguration.dbPassword -- The password of the database
+    # -- The password of the database
     dbPassword: cassandra
-    # ledger.scalarLedgerConfiguration.dbStorage -- The storage of the database: cassandra or cosmos
+    # -- The storage of the database: cassandra or cosmos
     dbStorage: cassandra
-    # ledger.scalarLedgerConfiguration.ledgerLogLevel -- The log level of Scalar ledger
+    # -- The log level of Scalar ledger
     ledgerLogLevel: INFO
 
   image:
-    # ledger.image.repository -- Docker image
+    # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger
-    # ledger.image.version -- Docker tag
+    # -- Docker tag
     version: 3.0.1
-    # ledger.image.pullPolicy -- Specify a imagePullPolicy
+    # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 
 
-  # ledger.imagePullSecrets -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: [name: reg-docker-secrets]
 
   strategy:
     rollingUpdate:
-      # ledger.strategy.rollingUpdate -- The number of pods that can be created above the desired amount of pods during an update
+      # -- The number of pods that can be created above the desired amount of pods during an update
       maxSurge: 25%
-      # ledger.strategy.rollingUpdate -- The number of pods that can be unavailable during the update process
+      # -- The number of pods that can be unavailable during the update process
       maxUnavailable: 25%
-    # ledger.strategy.type -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
+    # -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
     type: RollingUpdate
 
-  # ledger.podSecurityContext -- PodSecurityContext holds pod-level security attributes and common container settings
+  # -- PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext: {}
     # fsGroup: 2000
 
-  # ledger.securityContext -- Setting security context at the pod applies those settings to all containers in the pod
+  # -- Setting security context at the pod applies those settings to all containers in the pod
   securityContext: {}
     # capabilities:
     #   drop:
@@ -160,45 +160,45 @@ ledger:
     # runAsUser: 1000
 
   service:
-    # ledger.service.type -- service types in kubernetes
+    # -- service types in kubernetes
     type: ClusterIP
     annotations: {}
     ports:
       scalardl:
-        # ledger.service.ports.scalardl.port -- scalardl target port
+        # -- scalardl target port
         port: 50051
-        # ledger.service.ports.scalardl.targetPort -- scalardl k8s internal name
+        # -- scalardl k8s internal name
         targetPort: 50051
-        # ledger.service.ports.scalardl.protocol -- scalardl protocol
+        # -- scalardl protocol
         protocol: TCP
       scalardl-priv:
-        # ledger.service.ports.scalardl-priv.port -- scalardl-priv target port
+        # -- scalardl-priv target port
         port: 50052
-        # ledger.service.ports.scalardl-priv.targetPort -- scalardl-priv k8s internal name
+        # -- scalardl-priv k8s internal name
         targetPort: 50052
-        # ledger.service.ports.scalardl-priv.protocol -- scalardl-priv protocol
+        # -- scalardl-priv protocol
         protocol: TCP
       scalardl-admin:
-        # ledger.service.ports.scalardl-admin.port -- scalardl-admin target port
+        # -- scalardl-admin target port
         port: 50053
-        # ledger.service.ports.scalardl-admin.targetPort -- scalardl-admin k8s internal name
+        # -- scalardl-admin k8s internal name
         targetPort: 50053
-        # ledger.service.ports.scalardl-admin.protocol -- scalardl-admin protocol
+        # -- scalardl-admin protocol
         protocol: TCP
 
   prometheusRule:
-    # ledger.prometheusRule.enabled -- enable rules for prometheus
+    # -- enable rules for prometheus
     enabled: false
-    # ledger.prometheusRule.namespace -- which namespace prometheus is located. by default monitoring
+    # -- which namespace prometheus is located. by default monitoring
     namespace: monitoring
 
   grafanaDashboard:
-    # ledger.grafanaDashboard.enabled -- enable grafana dashboard
+    # -- enable grafana dashboard
     enabled: false
-    # ledger.grafanaDashboard.namespace -- which namespace grafana dashboard is located. by default monitoring
+    # -- which namespace grafana dashboard is located. by default monitoring
     namespace: monitoring
 
-  # ledger.resources -- resources allowed to the pod
+  # -- resources allowed to the pod
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -211,14 +211,14 @@ ledger:
     #   cpu: 100m
     #   memory: 128Mi
 
-  # ledger.nodeSelector -- nodeSelector is form of node selection constraint
+  # -- nodeSelector is form of node selection constraint
   nodeSelector: {}
 
-  # ledger.tolerations -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
+  # -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
   tolerations: []
 
-  # ledger.affinity -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
+  # -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
   affinity: {}
 
-  # ledger.existingSecret -- Name of existing secret to use for storing database username and password
+  # -- Name of existing secret to use for storing database username and password
   existingSecret: null

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -3,33 +3,33 @@
 # Declare variables to be passed into your templates.
 
 schemaLoading:
-  # schemaLoading.database -- The database to which the schema is loaded. `cassandra` and `cosmos` are supported.
+  # -- The database to which the schema is loaded. `cassandra` and `cosmos` are supported.
   database: cassandra
-  # schemaLoading.contactPoints -- The database contanct point such as a hostname of Cassandra or a URL of Cosmos DB account.
+  # -- The database contanct point such as a hostname of Cassandra or a URL of Cosmos DB account.
   contactPoints: cassandra
-  # schemaLoading.contactPort -- The database port number. (Ignored if the database is `cosmos`.)
+  # -- The database port number. (Ignored if the database is `cosmos`.)
   contactPort: 9042
-  # schemaLoading.username -- The username of the database. (Ignored if the database is `cosmos`.)
+  # -- The username of the database. (Ignored if the database is `cosmos`.)
   username: cassandra
-  # schemaLoading.password -- The password of the database. For Cosmos DB, please specify a key here.
+  # -- The password of the database. For Cosmos DB, please specify a key here.
   password: cassandra
-  # schemaLoading.cassandraReplicationFactor -- The replication factor value of the Cassandra schema. This is a Cassandra specific option.
+  # -- The replication factor value of the Cassandra schema. This is a Cassandra specific option.
   cassandraReplicationFactor: 3
-  # schemaLoading.cosmosBaseResourceUnit -- The resource unit value of the Cosmos DB schema. This is a Cosmos DB specific option.
+  # -- The resource unit value of the Cosmos DB schema. This is a Cosmos DB specific option.
   cosmosBaseResourceUnit: 400
-  # schemaLoading.dynamoBaseResourceUnit -- The resource unit value of the DynamoDB schema. This is a DynamoDB specific option.
+  # -- The resource unit value of the DynamoDB schema. This is a DynamoDB specific option.
   dynamoBaseResourceUnit: 10
 
   image:
-    # schemaLoading.image.repository -- Docker image
+    # -- Docker image
     repository: ghcr.io/scalar-labs/scalardl-schema-loader
-    # schemaLoading.image.version -- Docker tag
+    # -- Docker tag
     version: 3.0.0
-    # schemaLoading.image.pullPolicy -- Specify a imagePullPolicy
+    # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 
-  # schemaLoading.imagePullSecrets -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: [name: reg-docker-secrets]
 
-  # schemaLoading.existingSecret -- Name of existing secret to use for storing database username and password
+  # -- Name of existing secret to use for storing database username and password
   existingSecret: null


### PR DESCRIPTION
helm-docs comments in `values.yaml` need to contain the full path, which is sometimes wrong. The new style comments do not need to have the full path instead they need to be appeared just before the field (currently all comments are appeared just before the field).

- https://github.com/norwoodj/helm-docs#valuesyaml-metadata