### PR TITLE
Update scalardb, scalardl and scalardl-audit chart for grafana

### DIFF
--- a/charts/scalardb/files/scalardb_grafana_dashboard.json
+++ b/charts/scalardb/files/scalardb_grafana_dashboard.json
@@ -79,7 +79,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_Metrics_totalSucceeded{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_total_success{pod=~\"$pod\"}[1m])) by (pod)",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -173,7 +173,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_Metrics_totalFailed{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_total_failure{pod=~\"$pod\"}[1m])) by (pod)",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -304,7 +304,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedStorageService_get_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_storage_get_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -384,7 +384,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_get{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_get{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -392,7 +392,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_get{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_get{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -400,7 +400,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_get{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_get{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -408,7 +408,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_get{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_get{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -416,7 +416,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_get{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_get{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -424,7 +424,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_get{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_get{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -504,7 +504,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedStorageService_scan_openScanner_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_storage_scan_open_scanner_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -584,7 +584,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_openScanner{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_openScanner{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -592,7 +592,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_openScanner{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_openScanner{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -600,7 +600,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_openScanner{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_openScanner{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -608,7 +608,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_openScanner{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_openScanner{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -616,7 +616,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_openScanner{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_openScanner{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -624,7 +624,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_openScanner{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_openScanner{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -704,7 +704,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedStorageService_scan_next_count{pod=~\"$pod\"} [1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_storage_scan_next_count{pod=~\"$pod\"} [1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -784,7 +784,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_next{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_next{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -792,7 +792,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_next{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_next{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -800,7 +800,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_next{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_next{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -808,7 +808,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_next{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_next{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -816,7 +816,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_next{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_next{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -824,7 +824,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_scan_next{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_scan_next{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -904,7 +904,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedStorageService_mutate_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_storage_mutate_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -984,7 +984,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_mutate{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_mutate{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -992,7 +992,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_mutate{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_mutate{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1000,7 +1000,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_mutate{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_mutate{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1008,7 +1008,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_mutate{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_mutate{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1016,7 +1016,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_mutate{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_mutate{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1024,7 +1024,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageService_mutate{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_mutate{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1118,7 +1118,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedStorageAdminService_createTable_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_storage_admin_service_create_table_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -1198,7 +1198,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_createTable{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_create_table{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1206,7 +1206,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_createTable{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_create_table{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1214,7 +1214,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_createTable{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_create_table{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1222,7 +1222,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_createTable{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_create_table{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1230,7 +1230,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_createTable{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_create_table{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1238,7 +1238,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_createTable{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_create_table{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1318,7 +1318,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedStorageAdminService_dropTable_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_storage_admin_service_drop_table_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -1398,7 +1398,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_dropTable{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_drop_table{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1406,7 +1406,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_dropTable{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_drop_table{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1414,7 +1414,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_dropTable{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_drop_table{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1422,7 +1422,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_dropTable{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_drop_table{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1430,7 +1430,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_dropTable{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_drop_table{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1438,7 +1438,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_dropTable{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_drop_table{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1518,7 +1518,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedStorageAdminService_truncateTable_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_storage_admin_service_truncate_table_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -1598,7 +1598,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_truncateTable{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_truncate_table{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1606,7 +1606,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_truncateTable{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_truncate_table{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1614,7 +1614,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_truncateTable{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_truncate_table{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1622,7 +1622,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_truncateTable{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_truncate_table{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1630,7 +1630,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_truncateTable{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_truncate_table{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1638,7 +1638,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_truncateTable{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_truncate_table{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1718,7 +1718,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedStorageAdminService_getTableMetadata_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_storage_admin_service_get_table_metadata_count{pod=~\"$pod\"}[1m])) by (pod)",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -1797,7 +1797,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_getTableMetadata{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_get_table_metadata{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1805,7 +1805,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_getTableMetadata{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_get_table_metadata{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1813,7 +1813,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_getTableMetadata{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_get_table_metadata{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1821,7 +1821,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_getTableMetadata{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_get_table_metadata{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1829,7 +1829,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_getTableMetadata{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_get_table_metadata{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1837,7 +1837,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedStorageAdminService_getTableMetadata{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_storage_admin_service_get_table_metadata{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -1931,7 +1931,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedTransactionService_transaction_start_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_transaction_service_transaction_start_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -2011,7 +2011,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_start{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_start{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2019,7 +2019,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_start{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_start{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2027,7 +2027,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_start{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_start{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2035,7 +2035,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_start{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_start{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2043,7 +2043,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_start{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_start{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2051,7 +2051,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_start{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_start{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2131,7 +2131,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedTransactionService_transaction_get_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_transaction_service_transaction_get_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -2211,7 +2211,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_get{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_get{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2219,7 +2219,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_get{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_get{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2227,7 +2227,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_get{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_get{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2235,7 +2235,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_get{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_get{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2243,7 +2243,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_get{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_get{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2251,7 +2251,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_get{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_get{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2331,7 +2331,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedTransactionService_transaction_scan_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_transaction_service_transaction_scan_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -2411,7 +2411,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_scan{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_scan{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2419,7 +2419,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_scan{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_scan{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2427,7 +2427,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_scan{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_scan{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2435,7 +2435,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_scan{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_scan{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2443,7 +2443,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_scan{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_scan{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2451,7 +2451,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_scan{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_scan{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2531,7 +2531,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedTransactionService_transaction_mutate_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_transaction_service_transaction_mutate_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -2611,7 +2611,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_mutate{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_mutate{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2619,7 +2619,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_mutate{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_mutate{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2627,7 +2627,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_mutate{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_mutate{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2635,7 +2635,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_mutate{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_mutate{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2643,7 +2643,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_mutate{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_mutate{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2651,7 +2651,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_mutate{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_mutate{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2731,7 +2731,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedTransactionService_transaction_commit_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_transaction_service_transaction_commit_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -2811,7 +2811,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_commit{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_commit{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2819,7 +2819,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_commit{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_commit{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2827,7 +2827,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_commit{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_commit{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2835,7 +2835,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_commit{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_commit{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2843,7 +2843,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_commit{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_commit{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2851,7 +2851,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_commit{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_commit{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -2931,7 +2931,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedTransactionService_transaction_abort_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_transaction_service_transaction_abort_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -3011,7 +3011,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_abort{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_abort{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3019,7 +3019,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_abort{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_abort{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3027,7 +3027,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_abort{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_abort{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3035,7 +3035,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_abort{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_abort{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3043,7 +3043,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_abort{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_abort{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3051,7 +3051,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_transaction_abort{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_transaction_abort{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3131,7 +3131,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedTransactionService_getState_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_transaction_service_get_state_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -3211,7 +3211,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_getState{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_get_state{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3219,7 +3219,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_getState{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_get_state{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3227,7 +3227,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_getState{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_get_state{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3235,7 +3235,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_getState{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_get_state{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3243,7 +3243,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_getState{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_get_state{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3251,7 +3251,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_getState{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_get_state{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3331,7 +3331,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(com_scalar_db_server_DistributedTransactionService_abort_count{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(irate(scalardb_stats_distributed_transaction_service_abort_count{pod=~\"$pod\"}[1m])) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -3411,7 +3411,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_abort{quantile=\"0.5\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_abort{quantile=\"0.5\",pod=~\"$pod\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3419,7 +3419,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_abort{quantile=\"0.75\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_abort{quantile=\"0.75\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3427,7 +3427,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_abort{quantile=\"0.95\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_abort{quantile=\"0.95\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3435,7 +3435,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_abort{quantile=\"0.98\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_abort{quantile=\"0.98\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3443,7 +3443,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_abort{quantile=\"0.99\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_abort{quantile=\"0.99\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",
@@ -3451,7 +3451,7 @@
         },
         {
           "exemplar": true,
-          "expr": "com_scalar_db_server_DistributedTransactionService_abort{quantile=\"0.999\",pod=~\"$pod\"}",
+          "expr": "scalardb_stats_distributed_transaction_service_abort{quantile=\"0.999\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}} - {{quantile}}",

--- a/charts/scalardb/templates/scalardb/servicemonitor.yaml
+++ b/charts/scalardb/templates/scalardb/servicemonitor.yaml
@@ -15,6 +15,6 @@ spec:
       {{- include "scalardb.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: scalardb-prometheus
-    path: /metrics
+    path: /stats/prometheus
     interval: {{ .Values.scalardb.serviceMonitor.interval }}
 {{- end }}

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -48,6 +48,9 @@ Current chart version is `1.0.0`
 | auditor.service.ports.scalardl-auditor.protocol | string | `"TCP"` | scalardl protocol |
 | auditor.service.ports.scalardl-auditor.targetPort | int | `50051` | scalardl k8s internal name |
 | auditor.service.type | string | `"ClusterIP"` | service types in kubernetes |
+| auditor.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
+| auditor.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
+| auditor.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | auditor.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | auditor.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | auditor.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |

--- a/charts/scalardl-audit/files/envoy_grafana_dashboard.json
+++ b/charts/scalardl-audit/files/envoy_grafana_dashboard.json
@@ -24,7 +24,7 @@
       "colorBackground": false,
       "colorValue": true,
       "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "none",
       "gauge": {
         "maxValue": 3,
@@ -103,7 +103,7 @@
       "colorBackground": false,
       "colorValue": true,
       "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "s",
       "gauge": {
         "maxValue": 100,
@@ -181,7 +181,7 @@
       "colorBackground": false,
       "colorValue": false,
       "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "decbytes",
       "gauge": {
         "maxValue": 104857600,
@@ -259,7 +259,7 @@
       "colorBackground": false,
       "colorValue": false,
       "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "decbytes",
       "gauge": {
         "maxValue": 104857600,
@@ -337,7 +337,7 @@
       "colorBackground": false,
       "colorValue": false,
       "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -415,7 +415,7 @@
       "colorBackground": false,
       "colorValue": true,
       "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -503,7 +503,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -593,7 +593,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -711,7 +711,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -801,7 +801,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -919,7 +919,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1016,7 +1016,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1113,7 +1113,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1219,7 +1219,7 @@
           "text": "scalar-service",
           "value": "scalar-service"
         },
-        "datasource": "prometheus",
+        "datasource": "Prometheus",
         "definition": "",
         "hide": 0,
         "includeAll": false,
@@ -1246,7 +1246,7 @@
           "text": "All",
           "value": ["$__all"]
         },
-        "datasource": "prometheus",
+        "datasource": "Prometheus",
         "definition": "",
         "hide": 0,
         "includeAll": true,

--- a/charts/scalardl-audit/files/scalardl-audit_grafana_dashboard.json
+++ b/charts/scalardl-audit/files/scalardl-audit_grafana_dashboard.json
@@ -24,7 +24,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 8,
       "gridPos": {
         "h": 15,

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -45,6 +45,7 @@ spec:
           - containerPort: 50051
           - containerPort: 50052
           - containerPort: 50053
+          - containerPort: 8080
           env:
           - name: SCALAR_DB_CONTACT_POINTS
             value: "{{ .Values.auditor.scalarAuditorConfiguration.dbContactPoints }}"

--- a/charts/scalardl-audit/templates/auditor/service.yaml
+++ b/charts/scalardl-audit/templates/auditor/service.yaml
@@ -17,3 +17,19 @@ spec:
   {{- end }}
   selector:
     {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scalardl-audit.fullname" . }}-metrics
+  labels:
+    {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: scalardl-audit-prometheus
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 4 }}
+  type: ClusterIP

--- a/charts/scalardl-audit/templates/auditor/servicemonitor.yaml
+++ b/charts/scalardl-audit/templates/auditor/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.auditor.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "scalardl-audit.fullname" . }}-metrics
+{{- if .Values.auditor.serviceMonitor.namespace }}
+  namespace: {{ .Values.auditor.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: scalardl-audit-prometheus
+    path: /stats/prometheus
+    interval: {{ .Values.auditor.serviceMonitor.interval }}
+{{- end }}

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -216,6 +216,14 @@ auditor:
     # -- which namespace grafana dashboard is located. by default monitoring
     namespace: monitoring
 
+  serviceMonitor:
+    # -- enable metrics collect with prometheus
+    enabled: false
+    # -- custom interval to retrieve the metrics
+    interval: "15s"
+    # -- which namespace prometheus is located. by default monitoring
+    namespace: monitoring
+
   # -- resources allowed to the pod
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -74,6 +74,9 @@ Current chart version is `2.1.0`
 | ledger.service.ports.scalardl.protocol | string | `"TCP"` | scalardl protocol |
 | ledger.service.ports.scalardl.targetPort | int | `50051` | scalardl k8s internal name |
 | ledger.service.type | string | `"ClusterIP"` | service types in kubernetes |
+| ledger.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
+| ledger.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
+| ledger.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | ledger.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | ledger.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |

--- a/charts/scalardl/files/envoy_grafana_dashboard.json
+++ b/charts/scalardl/files/envoy_grafana_dashboard.json
@@ -24,7 +24,7 @@
       "colorBackground": false,
       "colorValue": true,
       "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "none",
       "gauge": {
         "maxValue": 3,
@@ -103,7 +103,7 @@
       "colorBackground": false,
       "colorValue": true,
       "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "s",
       "gauge": {
         "maxValue": 100,
@@ -181,7 +181,7 @@
       "colorBackground": false,
       "colorValue": false,
       "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "decbytes",
       "gauge": {
         "maxValue": 104857600,
@@ -259,7 +259,7 @@
       "colorBackground": false,
       "colorValue": false,
       "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "decbytes",
       "gauge": {
         "maxValue": 104857600,
@@ -337,7 +337,7 @@
       "colorBackground": false,
       "colorValue": false,
       "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -415,7 +415,7 @@
       "colorBackground": false,
       "colorValue": true,
       "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -503,7 +503,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -593,7 +593,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -711,7 +711,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -801,7 +801,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -919,7 +919,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1016,7 +1016,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1113,7 +1113,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1219,7 +1219,7 @@
           "text": "scalar-service",
           "value": "scalar-service"
         },
-        "datasource": "prometheus",
+        "datasource": "Prometheus",
         "definition": "",
         "hide": 0,
         "includeAll": false,
@@ -1246,7 +1246,7 @@
           "text": "All",
           "value": ["$__all"]
         },
-        "datasource": "prometheus",
+        "datasource": "Prometheus",
         "definition": "",
         "hide": 0,
         "includeAll": true,

--- a/charts/scalardl/files/scalardl_grafana_dashboard.json
+++ b/charts/scalardl/files/scalardl_grafana_dashboard.json
@@ -24,7 +24,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "Prometheus",
       "fill": 8,
       "gridPos": {
         "h": 15,

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -49,6 +49,7 @@ spec:
           - containerPort: 50051
           - containerPort: 50052
           - containerPort: 50053
+          - containerPort: 8080
           env:
           - name: SCALAR_DB_CONTACT_POINTS
             value: "{{ .Values.ledger.scalarLedgerConfiguration.dbContactPoints }}"

--- a/charts/scalardl/templates/ledger/service.yaml
+++ b/charts/scalardl/templates/ledger/service.yaml
@@ -17,3 +17,19 @@ spec:
   {{- end }}
   selector:
     {{- include "scalardl-ledger.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scalardl.fullname" . }}-metrics
+  labels:
+    {{- include "scalardl-ledger.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: scalardl-prometheus
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    {{- include "scalardl-ledger.selectorLabels" . | nindent 4 }}
+  type: ClusterIP

--- a/charts/scalardl/templates/ledger/servicemonitor.yaml
+++ b/charts/scalardl/templates/ledger/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.ledger.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "scalardl.fullname" . }}-metrics
+{{- if .Values.ledger.serviceMonitor.namespace }}
+  namespace: {{ .Values.ledger.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "scalardl-ledger.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: scalardl-prometheus
+    path: /stats/prometheus
+    interval: {{ .Values.ledger.serviceMonitor.interval }}
+{{- end }}

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -207,6 +207,14 @@ ledger:
     # -- which namespace grafana dashboard is located. by default monitoring
     namespace: monitoring
 
+  serviceMonitor:
+    # -- enable metrics collect with prometheus
+    enabled: false
+    # -- custom interval to retrieve the metrics
+    interval: "15s"
+    # -- which namespace prometheus is located. by default monitoring
+    namespace: monitoring
+
   # -- resources allowed to the pod
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
# Summary
- Fixed the dashboard because the `scalardb` metrics name changed.
- Changed datasource name to `Prometheus`.
- Add and fix missing manifest for metrics.

# Related
- https://github.com/scalar-labs/scalardb/pull/274