### PR TITLE
Update index.yaml for envoy-charts

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -92,4 +92,30 @@ entries:
     urls:
     - https://github.com/scalar-labs/helm-charts/releases/download/schema-loading-1.3.0/schema-loading-1.3.0.tgz
     version: 1.3.0
-generated: "2021-07-15T08:09:06.854762872Z"
+  envoy:
+  - apiVersion: v2
+    appVersion: 1.1.0
+    created: "2021-09-17T15:44:08.01326+09:00"
+    description: Envoy Proxy for Scalar applications
+    digest: 1c8b4801539faef21bafa40ae01210562df0f911b07636042dbf5a9d44558dd3
+    home: https://scalar-labs.com/
+    icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
+    keywords:
+    - envoy
+    - grpc
+    - grpc-server
+    maintainers:
+    - email: yusuke.morimoto@scalar-labs.com
+      name: Yusuke Morimoto
+    - email: yuji.mise@scalar-labs.com
+      name: Yuji Mise
+    - email: hiroyuki.yamada@scalar-labs.com
+      name: Hiroyuki Yamada
+    name: envoy
+    sources:
+    - https://github.com/scalar-labs/scalar-envoy
+    type: application
+    urls:
+    - https://github.com/scalar-labs/helm-charts/releases/download/envoy-1.0.0/envoy-1.0.0.tgz
+    version: 1.0.0
+generated: "2021-09-17T15:44:08.013269+09:00"


### PR DESCRIPTION
## Summary
- update index.yaml for envoy charts

## Detail
- If I use the release workflow of 'github-actions', `scalardb-charts` and `scalar-audit-charts` will also be released, so this time I manually released envoy-charts first. https://github.com/scalar-labs/helm-charts/releases/tag/envoy-1.0.0
```
cr index
```
- Check the checksum.

```
curl -L https://github.com/scalar-labs/helm-charts/releases/download/envoy-1.0.0/envoy-1.0.0.tgz | sha256sum
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   623  100   623    0     0   1117      0 --:--:-- --:--:-- --:--:--  1116
100  7696  100  7696    0     0   7760      0 --:--:-- --:--:-- --:--:--  7760
1c8b4801539faef21bafa40ae01210562df0f911b07636042dbf5a9d44558dd3  -
```

```
digest: 1c8b4801539faef21bafa40ae01210562df0f911b07636042dbf5a9d44558dd3
```