### PR TITLE
envoy: Fix to add common labels to prometheus-operator CRs

### DIFF
--- a/charts/envoy/templates/prometheusrules.yaml
+++ b/charts/envoy/templates/prometheusrules.yaml
@@ -2,10 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  labels:
-    app: prometheus-operator
-    release: prometheus
   name: {{ include "envoy.fullname" . }}-envoy-prometheus-alerts-rules
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
 {{- if .Values.prometheusRule.namespace }}
   namespace: {{ .Values.prometheusRule.namespace }}
 {{- end }}

--- a/charts/envoy/templates/servicemonitor.yaml
+++ b/charts/envoy/templates/servicemonitor.yaml
@@ -3,6 +3,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "envoy.fullname" . }}-envoy-metrics
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
 {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
 {{- end }}


### PR DESCRIPTION
This PR fixes to add common labels to PrometheusRule and ServiceMonitor CRs in envoy chart.

```diff
--- /tmp/main.yaml      2021-09-20 15:41:08.615481407 +0900
+++ /tmp/envoy-prometheus-operator-labels.yaml  2021-09-20 15:41:27.523784820 +0900
@@ -124,10 +124,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  labels:
-    app: prometheus-operator
-    release: prometheus
   name: RELEASE-NAME-envoy-envoy-prometheus-alerts-rules
+  labels:
+    helm.sh/chart: envoy-1.0.0
+    app.kubernetes.io/name: envoy
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/app: envoy
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/managed-by: Helm
   namespace: monitoring
 spec:
   groups:
@@ -178,6 +182,13 @@
 kind: ServiceMonitor
 metadata:
   name: RELEASE-NAME-envoy-envoy-metrics
+  labels:
+    helm.sh/chart: envoy-1.0.0
+    app.kubernetes.io/name: envoy
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/app: envoy
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/managed-by: Helm
   namespace: monitoring
 spec:
   namespaceSelector:
```