### PR TITLE
Bump up Scalar DL version to 3.0.0

### DIFF
--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalardl
 description: Scalar DL is a tamper-evident and scalable distributed database.
 type: application
-version: 2.1.0
+version: 3.0.0
 appVersion: 3.0.1
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,7 +1,7 @@
 # scalardl
 
 Scalar DL is a tamper-evident and scalable distributed database.
-Current chart version is `2.1.0`
+Current chart version is `3.0.0`
 
 ## Requirements
 


### PR DESCRIPTION
# Summary
- This is the corresponding version of `scalardl charts` with `envoy` charts applied. (major version release)
- The `scalardb charts` and `scalardl-audit charts` are not yet released and will be released with the `scalardl charts` upgrade.
