### PR TITLE
Modify index yaml from helm repo

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -49,28 +49,31 @@ entries:
     version: 1.2.3
   schema-loading:
   - apiVersion: v2
-    appVersion: 3.0.0
-    created: "2021-07-15T08:09:06.854752472Z"
-    description: Implementation schema loading for scalar-ledger
-    digest: d6b851bee94b714fa5317f8aac452616ea9325a0daa9ffeb0f0466f4b9e54ecb
+    appVersion: 3.1.0
+    created: "2021-09-30T11:39:31.35263+09:00"
+    description: A schema loading tool for Scalar DL.
+    digest: acefc50780952e14fa7c13ee8e2cf52a12230cc315e608f579e2b5dae89dd2b3
     home: https://scalar-labs.com/
     icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
     keywords:
-    - scalar-ledger
-    - DLT
-    - schema-loading
+    - database
+    - distributed ledger
+    - scalar
+    - scalar dl
     maintainers:
-    - email: paul.dozancuk@scalar-labs.com
-      name: Paul Dozancuk
     - email: yusuke.morimoto@scalar-labs.com
       name: Yusuke Morimoto
+    - email: kun.tei@scalar-labs.com
+      name: Kun Tei
+    - email: hiroyuki.yamada@scalar-labs.com
+      name: Hiroyuki Yamada
     name: schema-loading
     sources:
     - https://github.com/scalar-labs/scalardb/tree/master/tools/scalar-schema
     type: application
     urls:
-    - https://github.com/scalar-labs/helm-charts/releases/download/schema-loading-2.0.0/schema-loading-2.0.0.tgz
-    version: 2.0.0
+    - https://github.com/scalar-labs/helm-charts/releases/download/schema-loading-2.1.0/schema-loading-2.1.0.tgz
+    version: 2.1.0
   - apiVersion: v2
     appVersion: 1.3.0
     created: "2021-05-09T23:57:33.679872111Z"

--- a/index.yaml
+++ b/index.yaml
@@ -61,6 +61,8 @@ entries:
     - scalar
     - scalar dl
     maintainers:
+    - email: yuji.mise@scalar-labs.com
+      name: Yuji Mise
     - email: yusuke.morimoto@scalar-labs.com
       name: Yusuke Morimoto
     - email: kun.tei@scalar-labs.com


### PR DESCRIPTION
# Summary
- Only Schema loading Charts will be sync in the index yaml.

## Checksum
```
$ curl -L https://github.com/scalar-labs/helm-charts/releases/download/schema-loading-2.1.0/schema-loading-2.1.0.tgz | sha256sum
acefc50780952e14fa7c13ee8e2cf52a12230cc315e608f579e2b5dae89dd2b3
```
