### PR TITLE
Bump up scalar-envoy version to 1.2.0 for envoy charts

### DIFF
--- a/charts/envoy/Chart.yaml
+++ b/charts/envoy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: envoy
 description: Envoy Proxy for Scalar applications
 type: application
-version: 1.0.0
-appVersion: 1.1.0
+version: 1.1.0
+appVersion: 1.2.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -1,9 +1,9 @@
 # envoy
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Envoy Proxy for Scalar applications
-Current chart version is `1.0.0`
+Current chart version is `1.1.0`
 
 **Homepage:** <https://scalar-labs.com/>
 
@@ -13,11 +13,12 @@ Current chart version is `1.0.0`
 |-----|------|---------|-------------|
 | affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
+| envoyConfiguration.serviceListeners | string | `"scalar-service:50051,scalar-privileged:50052"` | list of service name and port |
 | grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | image.repository | string | `"ghcr.io/scalar-labs/scalar-envoy"` | Docker image |
-| image.version | string | `"1.1.0"` |  |
+| image.version | string | `"1.2.0"` |  |
 | imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/envoy/templates/deployment.yaml
+++ b/charts/envoy/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
             value: "{{ .Values.envoyConfiguration.adminAccessLogPath }}"
           - name: scalardl_address
             value: {{ include "envoy.fullname" . }}-headless
+          - name: service_listeners
+            value: "{{ .Values.envoyConfiguration.serviceListeners }}"
           livenessProbe:
             httpGet:
               path: /ready

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -4,12 +4,14 @@ replicaCount: 3
 envoyConfiguration:
   # envoyConfiguration.adminAccessLogPath -- admin log path
   adminAccessLogPath: /dev/stdout
+  # envoyConfiguration.serviceListeners -- list of service name and port
+  serviceListeners: scalar-service:50051,scalar-privileged:50052
 
 image:
   # image.repository -- Docker image
   repository: ghcr.io/scalar-labs/scalar-envoy
   # image.tag -- Docker tag
-  version: 1.1.0
+  version: 1.2.0
   # image.pullPolicy -- Specify a imagePullPolicy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- bump up scalar-envoy version to 1.2.0 (https://github.com/orgs/scalar-labs/packages/container/scalar-envoy/8462600?tag=1.2.0)
- add serviceListeners environment

## Detail 
### Verify that environment variables are applied.
``` yaml
envoyConfiguration:
  serviceListeners: ledger-service:40051,ledger-privileged:40052
```

* Envoy SDS API
``` sh
curl http://0.0.0.0:9001/listeners?format=json
{
 "listener_statuses": [
  {
   "name": "ledger-service",
   "local_address": {
    "socket_address": {
     "address": "0.0.0.0",
     "port_value": 40051
    }
   }
  },
  {
   "name": "ledger-privileged",
   "local_address": {
    "socket_address": {
     "address": "0.0.0.0",
     "port_value": 40052
    }
   }
  }
 ]
}

```