### PR TITLE
Fix github actions for release chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Add Helm repos
+        run: |
+          helm repo add scalar https://scalar-labs.github.io/helm-charts
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
         env:


### PR DESCRIPTION
## Summary
- The `github actions` for the release failed, so this has been fixed.
- For the first time, we released each `charts` on envoy-charts on `github actions` for a release, so the process of adding `helm repos add` was not included and failed.

https://github.com/scalar-labs/helm-charts/runs/3821859858?check_suite_focus=true
```
Adding cr directory to PATH...
Packaging chart 'charts/scalardb'...
Error: no repository definition for https://scalar-labs.github.io/helm-charts
```