### PR TITLE
Upgrade k8s patch version for CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -51,9 +51,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.18.15
-          - v1.19.7
-          - v1.20.2
+          - v1.18.19
+          - v1.19.11
+          - v1.20.7
 
     steps:
       - name: Checkout
@@ -99,9 +99,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.18.15
-          - v1.19.7
-          - v1.20.2
+          - v1.18.19
+          - v1.19.11
+          - v1.20.7
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why
https://github.com/scalar-labs/helm-charts/runs/3867651052?check_suite_focus=true
```
Error updating Endpoint Slices for Service default/scalardl-7q0a7l77to-metrics: failed to update scalardl-7q0a7l77to-metrics-j9sqw EndpointSlice for Service default/scalardl-7q0a7l77to-metrics: Operation cannot be fulfilled on endpointslices.discovery.k8s.io "scalardl-7q0a7l77to-metrics-j9sqw": the object has been modified; please apply your changes to the latest version and try again       3m46s        1       scalardl-7q0a7l77to-metrics.16adc279d21070aa
```

The error on the CI of helm-charts seems to be an error that can happen depending on the version of k8s.
1.19 version seems to be solved by making it 19.9+, so I'll try to raise the version of k8s to run in CI.

https://github.com/kubernetes/kubernetes/issues/92928


In addition, we have updated the patch versions of other k8s versions.

### EKS
https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

### AKS
``` sh
$ az aks get-versions --location eastus --output table
KubernetesVersion    Upgrades
-------------------  -----------------------
1.22.1(preview)      None available
1.21.2               1.22.1(preview)
1.21.1               1.21.2, 1.22.1(preview)
1.20.9               1.21.1, 1.21.2
1.20.7               1.20.9, 1.21.1, 1.21.2
1.19.13              1.20.7, 1.20.9
1.19.11              1.19.13, 1.20.7, 1.20.9

$ az aks get-versions --location eastasia --output table
KubernetesVersion    Upgrades
-------------------  -----------------------
1.22.1(preview)      None available
1.21.2               1.22.1(preview)
1.21.1               1.21.2, 1.22.1(preview)
1.20.9               1.21.1, 1.21.2
1.20.7               1.20.9, 1.21.1, 1.21.2
1.19.13              1.20.7, 1.20.9
1.19.11              1.19.13, 1.20.7, 1.20.9
```


### Kind
``` sh
$ curl  https://hub.docker.com/v2/repositories/kindest/node/tags/?page_size=25\&page=1\&name=v1.20 | jq -r '.results[].name'
v1.20.7
v1.20.2
v1.20.0

$ curl  https://hub.docker.com/v2/repositories/kindest/node/tags/?page_size=25\&page=1\&name=v1.19 | jq -r '.results[].name'
v1.19.11
v1.19.7
v1.19.4
v1.19.3
v1.19.1
v1.19.0

$ curl  https://hub.docker.com/v2/repositories/kindest/node/tags/?page_size=25\&page=1\&name=v1.18 | jq -r '.results[].name'
v1.18.19
v1.18.15
v1.18.8
v1.18.6
v1.18.4
v1.18.2
v1.18.0
```