### PR TITLE
Bump up scalar DL  patch version

### DIFF
--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalardl
 description: Scalar DL is a tamper-evident and scalable distributed database.
 type: application
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.1.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,7 +1,7 @@
 # scalardl
 
 Scalar DL is a tamper-evident and scalable distributed database.
-Current chart version is `3.1.0`
+Current chart version is `3.1.1`
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Bump up scalar DL helm chart version (3.1.0 → 3.1.1)

## Changelog
- https://github.com/scalar-labs/helm-charts/commit/8586d54838c7b6375744a100adb047e23f983972