### PR TITLE
Modify legend labels in the total succeeded graph

### DIFF
--- a/charts/scalardl-audit/files/grafana/scalardl_audit_grafana_dashboard.json
+++ b/charts/scalardl-audit/files/grafana/scalardl_audit_grafana_dashboard.json
@@ -99,7 +99,7 @@
           "exemplar": true,
           "expr": "sum(irate(scalardl_stats_auditor_total_success{pod=~\"$pod\"}[1m])) by (pod)",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],

--- a/charts/scalardl/files/grafana/scalardl_grafana_dashboard.json
+++ b/charts/scalardl/files/grafana/scalardl_grafana_dashboard.json
@@ -102,7 +102,7 @@
           "exemplar": true,
           "expr": "sum(irate(scalardl_stats_ledger_total_success{pod=~\"$pod\"}[1m])) by (pod)",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Current `Total succeded` graph
<img width="573" alt="Screen Shot 2021-10-29 at 1 25 25 AM" src="https://user-images.githubusercontent.com/58680313/139296827-87ea8332-8490-488f-b753-3cf8aa85d266.png">

After this change

<img width="605" alt="Screen Shot 2021-10-29 at 1 26 32 AM" src="https://user-images.githubusercontent.com/58680313/139297088-bd297027-779c-44fa-b0b2-50caacf05697.png">

