### PR TITLE
Modify index.yaml for scalardl 3.1.1

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -218,6 +218,37 @@ entries:
     - https://github.com/scalar-labs/helm-charts/releases/download/scalardl-3.2.0/scalardl-3.2.0.tgz
     version: 3.2.0
   - apiVersion: v2
+    appVersion: 3.1.1
+    created: "2021-11-05T06:14:54.009954637Z"
+    dependencies:
+    - condition: envoy.enabled
+      name: envoy
+      repository: https://scalar-labs.github.io/helm-charts
+      version: ~1.1.1
+    description: Scalar DL is a tamper-evident and scalable distributed database.
+    digest: c7e7176c759f3f09c40720e72aac66f21de7c81bbed92749aac507d5be60b1a7
+    home: https://scalar-labs.com/
+    icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
+    keywords:
+    - database
+    - distributed ledger
+    - scalar
+    - scalar dl
+    maintainers:
+    - email: yusuke.morimoto@scalar-labs.com
+      name: Yusuke Morimoto
+    - email: kun.tei@scalar-labs.com
+      name: Kun Tei
+    - email: hiroyuki.yamada@scalar-labs.com
+      name: Hiroyuki Yamada
+    name: scalardl
+    sources:
+    - https://github.com/scalar-labs/scalardl
+    type: application
+    urls:
+    - https://github.com/scalar-labs/helm-charts/releases/download/scalardl-3.1.3/scalardl-3.1.3.tgz
+    version: 3.1.3
+  - apiVersion: v2
     appVersion: 3.1.0
     created: "2021-10-29T07:51:54.009954637Z"
     dependencies:
@@ -420,6 +451,38 @@ entries:
     urls:
     - https://github.com/scalar-labs/helm-charts/releases/download/scalardl-audit-1.2.0/scalardl-audit-1.2.0.tgz
     version: 1.2.0
+  - apiVersion: v2
+    appVersion: 3.1.1
+    created: "2021-11-05T05:12:54.140209509Z"
+    dependencies:
+    - condition: envoy.enabled
+      name: envoy
+      repository: https://scalar-labs.github.io/helm-charts
+      version: ~1.1.1
+    description: Scalar DL is a tamper-evident and scalable distributed database.
+      This chart adds an auditing capability to Ledger (scalardl chart).
+    digest: 0e8866b20eb6f8dd109e5d88db70b74c9e35ec5a3cef662298e5677bcb9fb026
+    home: https://scalar-labs.com/
+    icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
+    keywords:
+    - database
+    - distributed ledger
+    - scalar
+    - scalar dl
+    maintainers:
+    - email: yusuke.morimoto@scalar-labs.com
+      name: Yusuke Morimoto
+    - email: kun.tei@scalar-labs.com
+      name: Kun Tei
+    - email: hiroyuki.yamada@scalar-labs.com
+      name: Hiroyuki Yamada
+    name: scalardl-audit
+    sources:
+    - https://github.com/scalar-labs/scalardl
+    type: application
+    urls:
+    - https://github.com/scalar-labs/helm-charts/releases/download/scalardl-audit-1.1.2/scalardl-audit-1.1.2.tgz
+    version: 1.1.2
   - apiVersion: v2
     appVersion: 3.1.0
     created: "2021-10-29T07:51:54.140209509Z"


### PR DESCRIPTION
## Summary
- bumpup scalard app to 3.1.1
- I'm releasing this manually because I wanted to give a patch version of the previous major version, since the minor version was updated first!

## Detail 
### package sha256
```
$ sha256sum scalardl-audit-1.1.2.tgz
0e8866b20eb6f8dd109e5d88db70b74c9e35ec5a3cef662298e5677bcb9fb026

$ sha256sum scalardl-3.1.3.tgz
c7e7176c759f3f09c40720e72aac66f21de7c81bbed92749aac507d5be60b1a7
```

### scalardl diff
https://github.com/scalar-labs/helm-charts/compare/scalardl-3.1.2...scalardl-3.1.3

### scalardl-audit diff
https://github.com/scalar-labs/helm-charts/compare/scalardl-audit-1.1.1...scalardl-audit-1.1.2
