### PR TITLE
Fixed the items pointed out in the security audit in envoy charts

### DIFF
--- a/charts/envoy/Chart.yaml
+++ b/charts/envoy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: envoy
 description: Envoy Proxy for Scalar applications
 type: application
-version: 1.1.1
+version: 2.0.0
 appVersion: 1.2.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -1,9 +1,9 @@
 # envoy
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Envoy Proxy for Scalar applications
-Current chart version is `1.1.1`
+Current chart version is `2.0.0`
 
 **Homepage:** <https://scalar-labs.com/>
 
@@ -21,12 +21,17 @@ Current chart version is `1.1.1`
 | image.version | string | `"1.2.0"` |  |
 | imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
+| podAnnotations | object | `{"seccomp.security.alpha.kubernetes.io/pod":"runtime/default"}` | Pod annotations for the envoy Deployment |
 | podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
+| podSecurityPolicy.enabled | bool | `true` | enable pod security policy |
 | prometheusRule.enabled | bool | `false` | enable rules for prometheus |
 | prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | replicaCount | int | `3` | number of replicas to deploy |
 | resources | object | `{}` | resources allowed to the pod |
-| securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod |
+| securityContext.allowPrivilegeEscalation | bool | `false` | AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process |
+| securityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default |
+| securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege) |
 | service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | service.ports.envoy-priv.port | int | `50052` | nvoy public port |
 | service.ports.envoy-priv.protocol | string | `"TCP"` | envoy protocol |

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -26,6 +26,8 @@ Current chart version is `2.0.0`
 | podSecurityPolicy.enabled | bool | `true` | enable pod security policy |
 | prometheusRule.enabled | bool | `false` | enable rules for prometheus |
 | prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
+| rbac.create | bool | `true` | If true, create and use RBAC resources |
+| rbac.serviceAccountAnnotations | object | `{}` | Annotations for the Service Account |
 | replicaCount | int | `3` | number of replicas to deploy |
 | resources | object | `{}` | resources allowed to the pod |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod |

--- a/charts/envoy/templates/deployment.yaml
+++ b/charts/envoy/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
   {{- end }}
   template:
     metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+    {{- end }}
       labels:
         {{- include "envoy.selectorLabels" . | nindent 8 }}
     spec:
@@ -26,6 +30,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: Always
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 60
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/envoy/templates/deployment.yaml
+++ b/charts/envoy/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.rbac.create }}
+      serviceAccountName: {{ include "envoy.fullname" . }}-envoy
+      {{- end }}
       restartPolicy: Always
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 60

--- a/charts/envoy/templates/podsecuritypolicy.yaml
+++ b/charts/envoy/templates/podsecuritypolicy.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "envoy.fullname" . }}-envoy-psp
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - configMap
+    - emptyDir
+    - projected
+    - downwardAPI
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/envoy/templates/psp-clusterrole.yaml
+++ b/charts/envoy/templates/psp-clusterrole.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "envoy.fullname" . }}-envoy-psp
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
+rules:
+- apiGroups: [{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}'policy'{{ else }}'extensions'{{ end }}]
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "envoy.fullname" . }}-envoy-psp
+{{- end }}

--- a/charts/envoy/templates/psp-clusterrolebinding.yaml
+++ b/charts/envoy/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and ( .Values.podSecurityPolicy.enabled ) ( .Values.rbac.create ) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "envoy.fullname" . }}-envoy-psp
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "envoy.fullname" . }}-envoy-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "envoy.fullname" . }}-envoy
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/envoy/templates/serviceaccount.yaml
+++ b/charts/envoy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "envoy.fullname" . }}-envoy
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
+{{- end }}
+{{- if .Values.rbac.serviceAccountAnnotations }}
+  annotations:
+{{ toYaml .Values.rbac.serviceAccountAnnotations | nindent 4 }}
+{{- end }}

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -69,6 +69,12 @@ service:
       # service.ports.envoy-priv.protocol -- envoy protocol
       protocol: TCP
 
+rbac:
+  # rbac.create -- If true, create and use RBAC resources
+  create: true
+  # rbac.serviceAccountAnnotations -- Annotations for the Service Account
+  serviceAccountAnnotations: {}
+
 podSecurityPolicy:
   # podSecurityPolicy.enabled -- enable pod security policy
   enabled: true

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -32,13 +32,22 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 # securityContext -- Setting security context at the pod applies those settings to all containers in the pod
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  # securityContext.capabilities -- Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_BIND_SERVICE
+  # securityContext.runAsNonRoot -- Containers should be run as a non-root user with the minimum required permissions (principle of least privilege)
+  runAsNonRoot: true
+  # securityContext.allowPrivilegeEscalation -- AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process
+  allowPrivilegeEscalation: false
+
+# podAnnotations -- Pod annotations for the envoy Deployment
+podAnnotations:
+  seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
+
 service:
   # service.type -- service types in kubernetes
   type: ClusterIP
@@ -59,6 +68,10 @@ service:
       targetPort: 50052
       # service.ports.envoy-priv.protocol -- envoy protocol
       protocol: TCP
+
+podSecurityPolicy:
+  # podSecurityPolicy.enabled -- enable pod security policy
+  enabled: true
 
 serviceMonitor:
   # serviceMonitor.enabled -- enable metrics collect with prometheus


### PR DESCRIPTION
## Summary
- We used [kubeauidt](https://github.com/Shopify/kubeaudit) to conducted a security audit in envoy charts.
- I fixed the items pointed out in the security audit.
- I created pod security policy to envoy charts
- The reason for creating the `pod security policy` is to avoid violating the settings that comply with the security audit log.

## Security audit summary
``` sh
$ kubeaudit all -k kube-audit.yaml -f <(helm template scalr-envoy charts/envoy) -m error

-- [error] AutomountServiceAccountTokenTrueAndDefaultSA
   Message: Default service account with token mounted. automountServiceAccountToken should be set to 'false' on either the ServiceAccount or on the PodSpec or a non-default service account should be used.

-- [error] CapabilityOrSecurityContextMissing
   Message: Security Context not set. The Security Context should be specified and all Capabilities should be dropped by setting the Drop list to ALL.
   Metadata:
      Container: envoy

-- [error] RunAsNonRootPSCNilCSCNil
   Message: runAsNonRoot should be set to true or runAsUser should be set to a value > 0 either in the container SecurityContext or PodSecurityContext.
   Metadata:
      Container: envoy

-- [error] AllowPrivilegeEscalationNil
   Message: allowPrivilegeEscalation not set which allows privilege escalation. It should be set to 'false'.
   Metadata:
      Container: envoy

-- [error] SeccompAnnotationMissing
   Message: Seccomp annotation is missing. The annotation seccomp.security.alpha.kubernetes.io/pod: runtime/default should be added.
   Metadata:
      MissingAnnotation: seccomp.security.alpha.kubernetes.io/pod

```
* kube-auidt.yaml
``` kube-auidt.yaml
enabledAuditors:
  apparmor: false
  asat: true
  capabilities: true
  hostns: true
  image: true
  limits: true
  mounts: true
  netpols: true
  nonroot: true
  privesc: true
  privileged: true
  rootfs: false
  seccomp: true
auditors:
  capabilities:
    allowAddList: ['NET_BIND_SERVICE']
```

