### PR TITLE
Bumpup scalardl and scalardl audit application patch version to 3.2.1

### DIFF
--- a/charts/scalardl-audit/Chart.yaml
+++ b/charts/scalardl-audit/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl-audit
 description: Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
 type: application
-version: 1.2.0
-appVersion: 3.2.0
+version: 1.2.1
+appVersion: 3.2.1
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -1,7 +1,7 @@
 # scalardl-audit
 
 Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
-Current chart version is `1.2.0`
+Current chart version is `1.2.1`
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Current chart version is `1.2.0`
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | auditor.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | auditor.image.repository | string | `"ghcr.io/scalar-labs/scalar-auditor"` | Docker image |
-| auditor.image.version | string | `"3.2.0"` | Docker tag |
+| auditor.image.version | string | `"3.2.1"` | Docker tag |
 | auditor.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | auditor.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | auditor.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -153,7 +153,7 @@ auditor:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-auditor
     # -- Docker tag
-    version: 3.2.0
+    version: 3.2.1
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 

--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl
 description: Scalar DL is a tamper-evident and scalable distributed database.
 type: application
-version: 3.2.0
-appVersion: 3.2.0
+version: 3.2.1
+appVersion: 3.2.1
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,7 +1,7 @@
 # scalardl
 
 Scalar DL is a tamper-evident and scalable distributed database.
-Current chart version is `3.2.0`
+Current chart version is `3.2.1`
 
 ## Requirements
 
@@ -53,7 +53,7 @@ Current chart version is `3.2.0`
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
-| ledger.image.version | string | `"3.2.0"` | Docker tag |
+| ledger.image.version | string | `"3.2.1"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | ledger.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -144,7 +144,7 @@ ledger:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger
     # -- Docker tag
-    version: 3.2.0
+    version: 3.2.1
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
# Summary
- Now that the patch version(3.2.1) of scalardl and scalardl audit has been upgraded, update the patch version(3.2.1, 1.2.1) of the helm charts in scalardl and scalardl-audit.