### PR TITLE
Bumpup scalardb charts minor version to 1.3.0

### DIFF
--- a/charts/scalardb/Chart.yaml
+++ b/charts/scalardb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardb
 description: Scalar DB server
 type: application
-version: 1.2.1
-appVersion: 3.3.1
+version: 1.3.0
+appVersion: 3.4.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -1,7 +1,7 @@
 # scalardb
 
 Scalar DB server
-Current chart version is `1.2.1`
+Current chart version is `1.3.0`
 
 ## Requirements
 
@@ -51,7 +51,7 @@ Current chart version is `1.2.1`
 | scalardb.grafanaDashboard.namespace | string | `"monitoring"` | Which namespace grafana dashboard is located. by default monitoring. |
 | scalardb.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | scalardb.image.repository | string | `"ghcr.io/scalar-labs/scalardb-server"` | Docker image reposiory of Scalar DB server. |
-| scalardb.image.tag | string | `"3.3.1"` | Docker tag of the image. |
+| scalardb.image.tag | string | `"3.4.0"` | Docker tag of the image. |
 | scalardb.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalardb.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalardb.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings. |

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -129,7 +129,7 @@ scalardb:
     # -- Specify a image pulling policy.
     pullPolicy: IfNotPresent
     # -- Docker tag of the image.
-    tag: 3.3.1
+    tag: 3.4.0
 
   # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: []


### PR DESCRIPTION
## Summary
* Now that the patch version(3.4.0) of scalardb has been upgraded, update the patch version(1.3.0) of the helm charts in scalardb.