### PR TITLE
Bumpup major version of each `charts` with the upgrade of `envoy-charts`.

### DIFF
--- a/charts/scalardb/Chart.lock
+++ b/charts/scalardb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 1.1.1
-digest: sha256:d94483741a8cd086fee1479a628b051a786044dd9f99c2a014771aa8ed737b13
-generated: "2021-10-29T10:40:15.563205+09:00"
+  version: 2.0.0
+digest: sha256:f5a5633b88391c5cf39b38262ac33a44cacef9c0d423608277b9e57bfb00da76
+generated: "2021-12-08T10:31:16.133835+09:00"

--- a/charts/scalardb/Chart.yaml
+++ b/charts/scalardb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalardb
 description: Scalar DB server
 type: application
-version: 1.3.0
+version: 2.0.0
 appVersion: 3.4.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardb
 dependencies:
 - name: envoy
-  version: ~1.1.1
+  version: ~2.0.0
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -1,13 +1,13 @@
 # scalardb
 
 Scalar DB server
-Current chart version is `1.3.0`
+Current chart version is `2.0.0`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~1.1.1 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.0 |
 
 ## Values
 

--- a/charts/scalardl-audit/Chart.lock
+++ b/charts/scalardl-audit/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 1.1.1
-digest: sha256:d94483741a8cd086fee1479a628b051a786044dd9f99c2a014771aa8ed737b13
-generated: "2021-10-29T10:42:35.846069+09:00"
+  version: 2.0.0
+digest: sha256:f5a5633b88391c5cf39b38262ac33a44cacef9c0d423608277b9e57bfb00da76
+generated: "2021-12-08T10:31:50.667584+09:00"

--- a/charts/scalardl-audit/Chart.yaml
+++ b/charts/scalardl-audit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalardl-audit
 description: Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
 type: application
-version: 1.3.0
+version: 2.0.0
 appVersion: 3.3.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardl
 dependencies:
 - name: envoy
-  version: ~1.1.1
+  version: ~2.0.0
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -1,13 +1,13 @@
 # scalardl-audit
 
 Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
-Current chart version is `1.3.0`
+Current chart version is `2.0.0`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~1.1.1 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.0 |
 
 ## Values
 

--- a/charts/scalardl/Chart.lock
+++ b/charts/scalardl/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 1.1.1
-digest: sha256:d94483741a8cd086fee1479a628b051a786044dd9f99c2a014771aa8ed737b13
-generated: "2021-10-29T10:37:58.855929+09:00"
+  version: 2.0.0
+digest: sha256:f5a5633b88391c5cf39b38262ac33a44cacef9c0d423608277b9e57bfb00da76
+generated: "2021-12-08T10:30:24.574499+09:00"

--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalardl
 description: Scalar DL is a tamper-evident and scalable distributed database.
 type: application
-version: 3.3.0
+version: 4.0.0
 appVersion: 3.3.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardl
 dependencies:
 - name: envoy
-  version: ~1.1.1
+  version: ~2.0.0
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,13 +1,13 @@
 # scalardl
 
 Scalar DL is a tamper-evident and scalable distributed database.
-Current chart version is `3.3.0`
+Current chart version is `4.0.0`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~1.1.1 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.0 |
 
 ## Values
 


### PR DESCRIPTION
## Summary
- Now that the major version(2.0.0) of envoy charts has been upgraded, update the major version of the helm charts in scalardl(4.0.0), scalardl-audit(2.0.0) and scalardb(2.0.0).

## References
- Upgraded envoy charts PR
  - https://github.com/scalar-labs/helm-charts/pull/49