### PR TITLE
Add k8s support version for CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -54,6 +54,7 @@ jobs:
           - v1.18.19
           - v1.19.11
           - v1.20.7
+          - v1.21.2
 
     steps:
       - name: Checkout
@@ -102,6 +103,7 @@ jobs:
           - v1.18.19
           - v1.19.11
           - v1.20.7
+          - v1.21.2
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Since EKS and AKS support 1.21, we have added the corresponding k8s version 1.21.
- The reason why it is 1.21.2 is that the latest version of the image of `kindest:node` is `1.21.2
- https://hub.docker.com/r/kindest/node/tags?page=1&name=1.21