### PR TITLE
Add kubeaudit workflow to CI

### DIFF
--- a/.github/kube-audit.yaml
+++ b/.github/kube-audit.yaml
@@ -1,0 +1,17 @@
+enabledAuditors:
+  apparmor: false
+  asat: true
+  capabilities: true
+  hostns: true
+  image: true
+  limits: true
+  mounts: true
+  netpols: true
+  nonroot: true
+  privesc: true
+  privileged: true
+  rootfs: false
+  seccomp: true
+auditors:
+  capabilities:
+    allowAddList: ['NET_BIND_SERVICE']

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -77,7 +77,7 @@ jobs:
           # TODO If more charts are supported by kubeaudit, they should be added.
           # Change to `ls charts` when all charts are supported.
           chart_dirs=(envoy)
-          for chart_dir in ${chart_dirs}; do
+          for chart_dir in ${chart_dirs[@]}; do
             echo "kubeaudit charts/${chart_dir} chart..."
             kubeaudit all -k .github/kube-audit.yaml -f <(helm template --generate-name "charts/${chart_dir}") -m error
           done

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -45,6 +45,43 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
 
+  kubeaudit-chart:
+    runs-on: ubuntu-latest
+    env:
+      KUBE_AUDIT_VERSION: 0.16.0
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Set up kubeaudit
+        uses: supplypike/setup-bin@v1
+        with:
+          uri: "https://github.com/Shopify/kubeaudit/releases/download/${{ env.KUBE_AUDIT_VERSION }}/kubeaudit_${{ env.KUBE_AUDIT_VERSION }}_linux_amd64.tar.gz"
+          name: "kubeaudit"
+          version: ${{ env.KUBE_AUDIT_VERSION }}
+
+      - name: Add Helm repos
+        run: |
+          helm repo add scalar https://scalar-labs.github.io/helm-charts
+
+      - name: Run kubeaudit
+        run: |
+          # TODO If more charts are supported by kubeaudit, they should be added.
+          # Change to `ls charts` when all charts are supported.
+          chart_dirs=(envoy)
+          for chart_dir in ${chart_dirs}; do
+            echo "kubeaudit charts/${chart_dir} chart..."
+            kubeaudit all -k .github/kube-audit.yaml -f <(helm template --generate-name "charts/${chart_dir}") -m error
+          done
+
   kubeval-chart:
     runs-on: ubuntu-latest
     needs: lint-chart
@@ -93,6 +130,7 @@ jobs:
     needs:
       - lint-chart
       - kubeval-chart
+      - kubeaudit-chart
     env:
       DOCKER_REGISTRY_PASSWORD: ${{ secrets.CR_PAT }}
       DOCKER_REGISTRY_USERNAME: scalar-git


### PR DESCRIPTION
## Summary
- Set `kubeaudit` to CI to do security audit for each helm chart
