### PR TITLE
Add `values.schema.json` and verify values.schema.json

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -201,14 +201,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-      - name: Set up Helm plugins
-        run: |
-          helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
-
       - name: Verify values schema json
         run: ./scripts/verify-values-schema-json.sh

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -193,3 +193,22 @@ jobs:
 
       - name: Verify chart docs
         run: ./scripts/verify-chart-docs.sh
+
+  verify-values-schema-json:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Set up Helm plugins
+        run: |
+          helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+
+      - name: Verify values schema json
+        run: ./scripts/verify-values-schema-json.sh

--- a/charts/envoy/values.schema.json
+++ b/charts/envoy/values.schema.json
@@ -1,0 +1,206 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "envoyConfiguration": {
+            "type": "object",
+            "properties": {
+                "adminAccessLogPath": {
+                    "type": "string"
+                },
+                "serviceListeners": {
+                    "type": "string"
+                }
+            }
+        },
+        "grafanaDashboard": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "podAnnotations": {
+            "type": "object",
+            "properties": {
+                "seccomp.security.alpha.kubernetes.io/pod": {
+                    "type": "string"
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object"
+        },
+        "podSecurityPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "prometheusRule": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "serviceAccountAnnotations": {
+                    "type": "object"
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "add": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "envoy": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "protocol": {
+                                    "type": "string"
+                                },
+                                "targetPort": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "envoy-priv": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "protocol": {
+                                    "type": "string"
+                                },
+                                "targetPort": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "strategy": {
+            "type": "object",
+            "properties": {
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxSurge": {
+                            "type": "string"
+                        },
+                        "maxUnavailable": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array"
+        }
+    }
+}

--- a/charts/scalardb/values.schema.json
+++ b/charts/scalardb/values.schema.json
@@ -1,0 +1,308 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "envoy": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "envoyConfiguration": {
+                    "type": "object",
+                    "properties": {
+                        "adminAccessLogPath": {
+                            "type": "string"
+                        },
+                        "serviceListeners": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "grafanaDashboard": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "envoy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "strategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxSurge": {
+                                    "type": "string"
+                                },
+                                "maxUnavailable": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "scalardb": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "existingSecret": {
+                    "type": "null"
+                },
+                "grafanaDashboard": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "scalardb": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "storageConfiguration": {
+                    "type": "object",
+                    "properties": {
+                        "contactPoints": {
+                            "type": "string"
+                        },
+                        "contactPort": {
+                            "type": "integer"
+                        },
+                        "dbLogLevel": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "storage": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "strategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxSurge": {
+                                    "type": "string"
+                                },
+                                "maxUnavailable": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        }
+    }
+}

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -1,0 +1,388 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "auditor": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "existingSecret": {
+                    "type": "null"
+                },
+                "grafanaDashboard": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "scalarAuditorConfiguration": {
+                    "type": "object",
+                    "properties": {
+                        "auditorCertHolderId": {
+                            "type": "string"
+                        },
+                        "auditorCertSecretKey": {
+                            "type": "string"
+                        },
+                        "auditorCertVersion": {
+                            "type": "integer"
+                        },
+                        "auditorLedgerHost": {
+                            "type": "string"
+                        },
+                        "auditorLogLevel": {
+                            "type": "string"
+                        },
+                        "auditorPrivateKeySecretKey": {
+                            "type": "string"
+                        },
+                        "auditorServerAdminPort": {
+                            "type": "integer"
+                        },
+                        "auditorServerPort": {
+                            "type": "integer"
+                        },
+                        "auditorServerPrivilegedPort": {
+                            "type": "integer"
+                        },
+                        "dbContactPoints": {
+                            "type": "string"
+                        },
+                        "dbContactPort": {
+                            "type": "integer"
+                        },
+                        "dbPassword": {
+                            "type": "string"
+                        },
+                        "dbStorage": {
+                            "type": "string"
+                        },
+                        "dbUsername": {
+                            "type": "string"
+                        },
+                        "secretName": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "scalardl-auditor": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "scalardl-auditor-admin": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "scalardl-auditor-priv": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "strategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxSurge": {
+                                    "type": "string"
+                                },
+                                "maxUnavailable": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "envoy": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "envoyConfiguration": {
+                    "type": "object",
+                    "properties": {
+                        "adminAccessLogPath": {
+                            "type": "string"
+                        },
+                        "serviceListeners": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "grafanaDashboard": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "envoy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "envoy-priv": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "strategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxSurge": {
+                                    "type": "string"
+                                },
+                                "maxUnavailable": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "nameOverride": {
+            "type": "string"
+        }
+    }
+}

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -1,0 +1,373 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "envoy": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "envoyConfiguration": {
+                    "type": "object",
+                    "properties": {
+                        "adminAccessLogPath": {
+                            "type": "string"
+                        },
+                        "serviceListeners": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "grafanaDashboard": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "envoy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "envoy-priv": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "strategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxSurge": {
+                                    "type": "string"
+                                },
+                                "maxUnavailable": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "ledger": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "existingSecret": {
+                    "type": "null"
+                },
+                "grafanaDashboard": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "scalarLedgerConfiguration": {
+                    "type": "object",
+                    "properties": {
+                        "dbContactPoints": {
+                            "type": "string"
+                        },
+                        "dbContactPort": {
+                            "type": "integer"
+                        },
+                        "dbPassword": {
+                            "type": "string"
+                        },
+                        "dbStorage": {
+                            "type": "string"
+                        },
+                        "dbUsername": {
+                            "type": "string"
+                        },
+                        "ledgerAuditorEnabled": {
+                            "type": "boolean"
+                        },
+                        "ledgerLogLevel": {
+                            "type": "string"
+                        },
+                        "ledgerPrivateKeySecretKey": {
+                            "type": "string"
+                        },
+                        "ledgerProofEnabled": {
+                            "type": "boolean"
+                        },
+                        "secretName": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "scalardl": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "scalardl-admin": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "scalardl-priv": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "targetPort": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "strategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxSurge": {
+                                    "type": "string"
+                                },
+                                "maxUnavailable": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        }
+    }
+}

--- a/charts/schema-loading/values.schema.json
+++ b/charts/schema-loading/values.schema.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "schemaLoading": {
+            "type": "object",
+            "properties": {
+                "cassandraReplicationFactor": {
+                    "type": "integer"
+                },
+                "cassandraReplicationStrategy": {
+                    "type": "string"
+                },
+                "contactPoints": {
+                    "type": "string"
+                },
+                "contactPort": {
+                    "type": "integer"
+                },
+                "cosmosBaseResourceUnit": {
+                    "type": "integer"
+                },
+                "database": {
+                    "type": "string"
+                },
+                "dynamoBaseResourceUnit": {
+                    "type": "integer"
+                },
+                "existingSecret": {
+                    "type": "null"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "password": {
+                    "type": "string"
+                },
+                "schemaType": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/scripts/update-values-schema-json.sh
+++ b/scripts/update-values-schema-json.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Generate json schema for chart values.
+#
+# https://github.com/karuppiah7890/helm-schema-gen
+
+set -e -o pipefail [[ -n "$DEBUG" ]] && set -x
+
+chart_dirs=$(ls charts)
+for chart_dir in ${chart_dirs}; do
+  echo "schema-gen charts/${chart_dir} chart..."
+  helm schema-gen "charts/${chart_dir}/values.yaml" >| "charts/${chart_dir}/values.schema.json"
+done

--- a/scripts/update-values-schema-json.sh
+++ b/scripts/update-values-schema-json.sh
@@ -6,8 +6,9 @@
 
 set -e -o pipefail [[ -n "$DEBUG" ]] && set -x
 
-chart_dirs=$(ls charts)
-for chart_dir in ${chart_dirs}; do
-  echo "schema-gen charts/${chart_dir} chart..."
-  helm schema-gen "charts/${chart_dir}/values.yaml" >| "charts/${chart_dir}/values.schema.json"
-done
+SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
+
+DOCKER_BUILDKIT=1 docker build \
+  -f "${SCRIPT_ROOT}/update-values-schema-json/Dockerfile" \
+  --output "${SCRIPT_ROOT}/../" \
+  "${SCRIPT_ROOT}/../"

--- a/scripts/update-values-schema-json/Dockerfile
+++ b/scripts/update-values-schema-json/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04 AS build
+
+WORKDIR /src
+
+RUN set -x && \
+    apt update && \
+    apt -y install curl bash
+
+SHELL ["/bin/bash", "-c"]
+
+# Install helm-schema-gen
+# https://github.com/karuppiah7890/helm-schema-gen
+RUN set -x && \
+    curl -L https://github.com/karuppiah7890/helm-schema-gen/releases/download/0.0.4/helm-schema-gen_0.0.4_Linux_x86_64.tar.gz | tar xvzf - -C /
+
+COPY . .
+
+RUN set -x && \
+    ls -d charts/* | xargs -I{} sh -c "/helm-schema-gen {}/values.yaml >{}/values.schema.json"
+
+FROM scratch AS output
+COPY --from=build /src/charts charts

--- a/scripts/verify-chart-docs.sh
+++ b/scripts/verify-chart-docs.sh
@@ -3,21 +3,6 @@
 set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
 
 SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
-
 docs="${SCRIPT_ROOT}/../charts/**/README.md"
-"${SCRIPT_ROOT}/update-chart-docs.sh"
 
-set +e
-git diff --no-patch --exit-code "$docs"
-exit_code="$?"
-set -e
-
-# Discard changes
-git checkout -- "$docs"
-
-if [[ "$exit_code" != 0 ]]; then
-  echo
-  echo "Run ./scripts/update-chart-docs.sh"
-  exit 1
-fi
-# vim: ai ts=2 sw=2 et sts=2 ft=sh
+exec "${SCRIPT_ROOT}/verify-files.sh" "${docs}" "${SCRIPT_ROOT}/update-chart-docs.sh"

--- a/scripts/verify-files.sh
+++ b/scripts/verify-files.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+files_path=$1
+exec_script_path=$2
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $(basename "$0") <files_path> <exec_script_path>" >&2
+  exit 1
+fi
+
+"${exec_script_path}"
+
+set +e
+git diff --no-patch --exit-code "$files_path"
+exit_code="$?"
+set -e
+
+# Discard changes
+git checkout -- "$files_path"
+
+if [[ "$exit_code" != 0 ]]; then
+  echo
+  echo "Run ${exec_script_path}"
+  exit 1
+fi

--- a/scripts/verify-values-schema-json.sh
+++ b/scripts/verify-values-schema-json.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
+schemas="${SCRIPT_ROOT}/../charts/**/values.schema.json"
+
+exec "${SCRIPT_ROOT}/verify-files.sh" "${schemas}" "${SCRIPT_ROOT}/update-values-schema-json.sh"


### PR DESCRIPTION
## Summary
* Add values.schema.json to each helm charts.
* `values.schema.json` can be used to provide more robust Helm input validation, with the additional benefit of enforcing value restrictions from a single schema file.

## Usage
```
$ helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
$ helm schema-gen charts/${chart_name}/values.yaml > values.schema.json
```