### PR TITLE
Bumpup scalardl schema loader minor version to 2.2.0

### DIFF
--- a/charts/schema-loading/Chart.yaml
+++ b/charts/schema-loading/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: schema-loading
 description: A schema loading tool for Scalar DL.
 type: application
-version: 2.1.0
-appVersion: 3.1.0
+version: 2.2.0
+appVersion: 3.2.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/schema-loading/README.md
+++ b/charts/schema-loading/README.md
@@ -1,7 +1,7 @@
 # schema-loading
 
 A schema loading tool for Scalar DL.
-Current chart version is `2.1.0`
+Current chart version is `2.2.0`
 
 ## Values
 
@@ -17,7 +17,7 @@ Current chart version is `2.1.0`
 | schemaLoading.existingSecret | string | `nil` | Name of existing secret to use for storing database username and password |
 | schemaLoading.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | schemaLoading.image.repository | string | `"ghcr.io/scalar-labs/scalardl-schema-loader"` | Docker image |
-| schemaLoading.image.version | string | `"3.1.0"` | Docker tag |
+| schemaLoading.image.version | string | `"3.2.0"` | Docker tag |
 | schemaLoading.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | schemaLoading.password | string | `"cassandra"` | The password of the database. For Cosmos DB, please specify a key here. |
 | schemaLoading.schemaType | string | `"ledger"` | Type of schema to apply (ledger or auditor). |

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -26,7 +26,7 @@ schemaLoading:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalardl-schema-loader
     # -- Docker tag
-    version: 3.1.0
+    version: 3.2.0
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Now that the minor version(3.2.0) of scalardl schema loader has been upgraded, update the patch version of the helm charts in scalardl shcema loader minor version(2.2.0)