### PR TITLE
Fixed the items pointed out in the security audit in scalardb charts

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           # TODO If more charts are supported by kubeaudit, they should be added.
           # Change to `ls charts` when all charts are supported.
-          chart_dirs=(envoy)
+          chart_dirs=(envoy scalardb)
           for chart_dir in ${chart_dirs[@]}; do
             echo "kubeaudit charts/${chart_dir} chart..."
             kubeaudit all -k .github/kube-audit.yaml -f <(helm template --generate-name "charts/${chart_dir}") -m error

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -54,12 +54,19 @@ Current chart version is `2.0.1`
 | scalardb.image.tag | string | `"3.4.1"` | Docker tag of the image. |
 | scalardb.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalardb.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
+| scalardb.podAnnotations | object | `{"seccomp.security.alpha.kubernetes.io/pod":"runtime/default"}` | Pod annotations for the scalardb deployment |
 | scalardb.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings. |
+| scalardb.podSecurityPolicy.enabled | bool | `true` | Enable pod security policy |
 | scalardb.prometheusRule.enabled | bool | `false` | Enable rules for prometheus. |
 | scalardb.prometheusRule.namespace | string | `"monitoring"` | Which namespace prometheus is located. by default monitoring. |
+| scalardb.rbac.create | bool | `true` | If true, create and use RBAC resources |
+| scalardb.rbac.serviceAccountAnnotations | object | `{}` | Annotations for the Service Account |
 | scalardb.replicaCount | int | `3` | Default values for number of replicas. |
 | scalardb.resources | object | `{}` | Resources allowed to the pod. |
-| scalardb.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod. |
+| scalardb.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod. |
+| scalardb.securityContext.allowPrivilegeEscalation | bool | `false` | AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process |
+| scalardb.securityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default |
+| scalardb.securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege) |
 | scalardb.service.ports.scalardb.port | int | `50051` | Scalar DB server port. |
 | scalardb.service.ports.scalardb.protocol | string | `"TCP"` | Scalar DB server protocol. |
 | scalardb.service.ports.scalardb.targetPort | int | `50051` | Scalar DB server target port. |

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -16,10 +16,18 @@ spec:
   {{- end }}
   template:
     metadata:
+    {{- if .Values.scalardb.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.scalardb.podAnnotations | nindent 8 }}
+    {{- end }}
       labels:
         {{- include "scalardb.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.scalardb.rbac.create }}
+      serviceAccountName: {{ include "scalardb.fullname" . }}
+      {{- end }}
       restartPolicy: Always
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 60
       {{- with .Values.scalardb.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/scalardb/templates/scalardb/podsecuritypolicy.yaml
+++ b/charts/scalardb/templates/scalardb/podsecuritypolicy.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.scalardb.podSecurityPolicy.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "scalardb.fullname" . }}-psp
+  labels:
+    {{- include "scalardb.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - configMap
+    - emptyDir
+    - projected
+    - downwardAPI
+    - secret
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/scalardb/templates/scalardb/psp-clusterrole.yaml
+++ b/charts/scalardb/templates/scalardb/psp-clusterrole.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.scalardb.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "scalardb.fullname" . }}-psp
+  labels:
+    {{- include "scalardb.labels" . | nindent 4 }}
+rules:
+- apiGroups: [{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}'policy'{{ else }}'extensions'{{ end }}]
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "scalardb.fullname" . }}-psp
+{{- end }}

--- a/charts/scalardb/templates/scalardb/serviceaccount.yaml
+++ b/charts/scalardb/templates/scalardb/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.scalardb.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "scalardb.fullname" . }}
+  labels:
+    {{- include "scalardb.labels" . | nindent 4 }}
+{{- end }}
+{{- if .Values.scalardb.rbac.serviceAccountAnnotations }}
+  annotations:
+{{ toYaml .Values.scalardb.rbac.serviceAccountAnnotations | nindent 4 }}
+{{- end }}

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -155,6 +155,16 @@ scalardb:
         # -- Scalar DB server protocol.
         protocol: TCP
 
+  rbac:
+    # -- If true, create and use RBAC resources
+    create: true
+    # -- Annotations for the Service Account
+    serviceAccountAnnotations: {}
+
+  podSecurityPolicy:
+    # -- Enable pod security policy
+    enabled: true
+
   serviceMonitor:
     # -- Enable metrics collect with prometheus.
     enabled: false
@@ -182,13 +192,20 @@ scalardb:
 
   # -- Setting security context at the pod applies those settings to all containers in the pod.
   securityContext:
-    {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+    # -- Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - NET_BIND_SERVICE
+    # -- Containers should be run as a non-root user with the minimum required permissions (principle of least privilege)
+    runAsNonRoot: true
+    # -- AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process
+    allowPrivilegeEscalation: false
+
+  # -- Pod annotations for the scalardb deployment
+  podAnnotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
 
   # -- Resources allowed to the pod.
   resources:


### PR DESCRIPTION
## Summary
- We used [kubeaudit](https://github.com/Shopify/kubeaudit) to conducted a security audit in scalardb charts.
- I fixed the items pointed out in the security audit.
- I created pod security policy to scalardb charts
- The reason for creating the `pod security policy` is to avoid violating the settings that comply with the security audit log.

## Security audit summary
``` sh
$ kubeaudit all -k .github/kube-audit.yaml -f <(helm template --generate-name "charts/scalardb") -m error

-- [error] AutomountServiceAccountTokenTrueAndDefaultSA
   Message: Default service account with token mounted. automountServiceAccountToken should be set to 'false' on either the ServiceAccount or on the PodSpec or a non-default service account should be used.

-- [error] CapabilityOrSecurityContextMissing
   Message: Security Context not set. The Security Context should be specified and all Capabilities should be dropped by setting the Drop list to ALL.
   Metadata:
      Container: scalardb

-- [error] RunAsNonRootPSCNilCSCNil
   Message: runAsNonRoot should be set to true or runAsUser should be set to a value > 0 either in the container SecurityContext or PodSecurityContext.
   Metadata:
      Container: scalardb

-- [error] AllowPrivilegeEscalationNil
   Message: allowPrivilegeEscalation not set which allows privilege escalation. It should be set to 'false'.
   Metadata:
      Container: scalardb

-- [error] SeccompAnnotationMissing
   Message: Seccomp annotation is missing. The annotation seccomp.security.alpha.kubernetes.io/pod: runtime/default should be added.
   Metadata:
      MissingAnnotation: seccomp.security.alpha.kubernetes.io/pod
```

## Reference
- https://github.com/scalar-labs/helm-charts/pull/49