### PR TITLE
Change the github repository of helm-schema-gen

### DIFF
--- a/scripts/update-values-schema-json.sh
+++ b/scripts/update-values-schema-json.sh
@@ -2,7 +2,7 @@
 
 # Generate json schema for chart values.
 #
-# https://github.com/karuppiah7890/helm-schema-gen
+# https://github.com/scalar-labs/helm-schema-gen
 
 set -e -o pipefail [[ -n "$DEBUG" ]] && set -x
 

--- a/scripts/update-values-schema-json/Dockerfile
+++ b/scripts/update-values-schema-json/Dockerfile
@@ -9,9 +9,9 @@ RUN set -x && \
 SHELL ["/bin/bash", "-c"]
 
 # Install helm-schema-gen
-# https://github.com/karuppiah7890/helm-schema-gen
+# https://github.com/scalar-labs/helm-schema-gen
 RUN set -x && \
-    curl -L https://github.com/karuppiah7890/helm-schema-gen/releases/download/0.0.4/helm-schema-gen_0.0.4_Linux_x86_64.tar.gz | tar xvzf - -C /
+    curl -L https://github.com/scalar-labs/helm-schema-gen/releases/download/0.0.4/helm-schema-gen_0.0.4_Linux_x86_64.tar.gz | tar xvzf - -C /
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- The repository of helm-schema-gen is in maintenance mode, so fork the repository and change to use the fork destination.

## Reference
- https://github.com/scalar-labs/helm-schema-gen