### PR TITLE
Update schema-loading helm chart for Cosmos DB

### DIFF
--- a/charts/schema-loading/templates/batchjob-schema-loading.yaml
+++ b/charts/schema-loading/templates/batchjob-schema-loading.yaml
@@ -19,12 +19,12 @@ spec:
         image: "{{ .Values.schemaLoading.image.repository }}:{{ .Values.schemaLoading.image.version }}"
         imagePullPolicy: "{{ .Values.schemaLoading.image.pullPolicy }}"
         args:
-        - "-u"
-        - "$(DB_USERNAME)"
         - "-p"
         - "$(DB_PASSWORD)"
         {{- if eq .Values.schemaLoading.database "cassandra" }}
         - "--cassandra"
+        - "-u"
+        - "$(DB_USERNAME)"
         - "-h"
         - "{{ .Values.schemaLoading.contactPoints }}"
         - "-P"
@@ -43,10 +43,14 @@ spec:
         - "--dynamo"
         - "--region"
         - "{{ .Values.schemaLoading.contactPoints }}"
+        - "-u"
+        - "$(DB_USERNAME)"
         - "-r"
         - "{{ .Values.schemaLoading.dynamoBaseResourceUnit }}"
         {{- else if eq .Values.schemaLoading.database "jdbc"}}
         - "--jdbc"
+        - "-u"
+        - "$(DB_USERNAME)"
         - "-j"
         - "{{ .Values.schemaLoading.contactPoints }}"
         {{- end }}


### PR DESCRIPTION
Remove `-u` option from scalar schema-loading helm chart for Cosmos DB.

**Issue**
```
[main] WARN com.scalar.db.schemaloader.SchemaLoader - Storage-specific options (--cassandra, --cosmos, --dynamo, --jdbc) are deprecated and will be removed in the future. Please use the --config option along with your config file instead.
Unknown options: '-u', 'cassandra'
Usage: java -jar scalardb-schema-loader-<version>.jar --cosmos [-D]
       [--no-scaling] -f=<schemaFile> -h=<uri> -p=<key> [-r=<ru>]
Create/Delete Cosmos DB schemas
  -D, --delete-all       Delete tables
  -f, --schema-file=<schemaFile>
                         Path to the schema json file
  -h, --host=<uri>       Cosmos DB account URI
      --no-scaling       Disable auto-scaling for Cosmos DB
  -p, --password=<key>   Cosmos DB key
  -r, --ru=<ru>          Base resource unit
```