### PR TITLE
Fix the `values.schema.json` type being `null` 

### DIFF
--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -46,7 +46,7 @@ Current chart version is `2.0.1`
 | fullnameOverride | string | `""` | String to fully override scalardb.fullname template |
 | nameOverride | string | `""` | String to partially override scalardb.fullname template (will maintain the release name) |
 | scalardb.affinity | object | `{}` | The affinity/anti-affinity feature, greatly expands the types of constraints you can express. |
-| scalardb.existingSecret | string | `nil` | Name of existing secret to use for storing database username and password. |
+| scalardb.existingSecret | string | `""` | Name of existing secret to use for storing database username and password. |
 | scalardb.grafanaDashboard.enabled | bool | `false` | Enable grafana dashboard. |
 | scalardb.grafanaDashboard.namespace | string | `"monitoring"` | Which namespace grafana dashboard is located. by default monitoring. |
 | scalardb.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |

--- a/charts/scalardb/values.schema.json
+++ b/charts/scalardb/values.schema.json
@@ -160,7 +160,7 @@
                     "type": "object"
                 },
                 "existingSecret": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "grafanaDashboard": {
                     "type": "object",

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -214,4 +214,4 @@ scalardb:
   affinity: {}
 
   # -- Name of existing secret to use for storing database username and password.
-  existingSecret: null
+  existingSecret: ""

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -14,7 +14,7 @@ Current chart version is `2.0.1`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | auditor.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
-| auditor.existingSecret | string | `nil` | Name of existing secret to use for storing database username and password |
+| auditor.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | auditor.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | auditor.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -9,7 +9,7 @@
                     "type": "object"
                 },
                 "existingSecret": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "grafanaDashboard": {
                     "type": "object",

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -253,4 +253,4 @@ auditor:
   affinity: {}
 
   # -- Name of existing secret to use for storing database username and password
-  existingSecret: null
+  existingSecret: ""

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -48,7 +48,7 @@ Current chart version is `4.0.1`
 | envoy.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | fullnameOverride | string | `""` | String to fully override scalardl.fullname template |
 | ledger.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
-| ledger.existingSecret | string | `nil` | Name of existing secret to use for storing database username and password |
+| ledger.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | ledger.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -171,7 +171,7 @@
                     "type": "object"
                 },
                 "existingSecret": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "grafanaDashboard": {
                     "type": "object",

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -244,4 +244,4 @@ ledger:
   affinity: {}
 
   # -- Name of existing secret to use for storing database username and password
-  existingSecret: null
+  existingSecret: ""

--- a/charts/schema-loading/README.md
+++ b/charts/schema-loading/README.md
@@ -14,7 +14,7 @@ Current chart version is `2.3.0`
 | schemaLoading.cosmosBaseResourceUnit | int | `400` | The resource unit value of the Cosmos DB schema. This is a Cosmos DB specific option. |
 | schemaLoading.database | string | `"cassandra"` | The database to which the schema is loaded. `cassandra` and `cosmos` are supported. |
 | schemaLoading.dynamoBaseResourceUnit | int | `10` | The resource unit value of the DynamoDB schema. This is a DynamoDB specific option. |
-| schemaLoading.existingSecret | string | `nil` | Name of existing secret to use for storing database username and password |
+| schemaLoading.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | schemaLoading.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | schemaLoading.image.repository | string | `"ghcr.io/scalar-labs/scalardl-schema-loader"` | Docker image |
 | schemaLoading.image.version | string | `"3.3.0"` | Docker tag |

--- a/charts/schema-loading/values.schema.json
+++ b/charts/schema-loading/values.schema.json
@@ -27,7 +27,7 @@
                     "type": "integer"
                 },
                 "existingSecret": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "image": {
                     "type": "object",

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -34,7 +34,7 @@ schemaLoading:
   imagePullSecrets: [name: reg-docker-secrets]
 
   # -- Name of existing secret to use for storing database username and password
-  existingSecret: null
+  existingSecret: ""
 
   # schemaLoading.schemaType -- Type of schema to apply (ledger or auditor).
   schemaType: ledger


### PR DESCRIPTION
## Summary
- The type of `values.schema.json` was set to `null` in some places, so this has been fixed.
- `values.yaml` should not be set to `null` as default value
- As for the conditional judgment of `helm`, if it is `null` or `empty character`, it will be `false`, so there is no need to change the logic of template.
- The version that applies `values.schema.json` has not been released yet, so it will not affect existing versions.