### PR TITLE
Use scalardl-schema-loader 3.2.1

### DIFF
--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -26,7 +26,7 @@ schemaLoading:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalardl-schema-loader
     # -- Docker tag
-    version: 3.3.0
+    version: 3.2.1
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This PR tries to release scalar-labs/schema-loading version 2.2.1.
Because version 2.2.0 uses `ghcr.io/scalar-labs/scalardl-schema-loader:3.2.0` which has a bug using a wrong version of scalardb-schema-loader.