### PR TITLE
Bump up schema loading to 3.2.1

### DIFF
--- a/charts/schema-loading/Chart.yaml
+++ b/charts/schema-loading/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: schema-loading
 description: A schema loading tool for Scalar DL.
 type: application
-version: 2.2.0
-appVersion: 3.2.0
+version: 2.2.1
+appVersion: 3.2.1
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -26,7 +26,7 @@ schemaLoading:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalardl-schema-loader
     # -- Docker tag
-    version: 3.2.0
+    version: 3.2.1
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- bump up schema loading to 3.2.1
- Create a branch (prepare-release-v*) from the tag where the `3.2.0` app version is released, and issue a PR against that branch.

## Prepare
```
helm search repo scalar-labs/schema-loading --versions
NAME                            CHART VERSION   APP VERSION     DESCRIPTION
scalar-labs/schema-loading      2.4.0           3.3.0           A schema loading tool for Scalar DL.
scalar-labs/schema-loading      2.3.0           3.3.0           A schema loading tool for Scalar DL.
scalar-labs/schema-loading      2.2.0           3.2.0           A schema loading tool for Scalar DL.
scalar-labs/schema-loading      2.1.0           3.1.0           A schema loading tool for Scalar DL.
scalar-labs/schema-loading      1.3.0           1.3.0           Implementation schema loading for scalar-ledger

$ git checkout -b prepare-release-v2.2.1 refs/tags/schema-loading-2.2.0
$ git push prepare-release-v2.2.1
$ git checkout -b bumpup-schema-loading-3-2-1
```