### PR TITLE
Check for bump up scalardl to v4.1.1

### DIFF
--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl
 description: Scalar DL is a tamper-evident and scalable distributed database.
 type: application
-version: 4.1.0
-appVersion: 3.3.1
+version: 4.1.1
+appVersion: 3.3.2
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,7 +1,7 @@
 # scalardl
 
 Scalar DL is a tamper-evident and scalable distributed database.
-Current chart version is `4.1.0`
+Current chart version is `4.1.1`
 
 ## Requirements
 
@@ -53,7 +53,7 @@ Current chart version is `4.1.0`
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
-| ledger.image.version | string | `"3.3.1"` | Docker tag |
+| ledger.image.version | string | `"3.3.2"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | ledger.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -144,7 +144,7 @@ ledger:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger
     # -- Docker tag
-    version: 3.3.1
+    version: 3.3.2
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
I changed version of scalardl for release new version.
```
$ git checkout -b check-release-v4.1.1 refs/tags/scalardl-4.1.0
```

Could you please confirm the changes?

If there is no problem, I will create prepare-release-v4.1.1 branch in the same way, for release new version. Also, I will release each minor version of scalardl, and release scalardl-audit in the same way.
