### PR TITLE
Add scalardl v3.0.1 entry to index.yaml

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -870,6 +870,37 @@ entries:
     - https://github.com/scalar-labs/helm-charts/releases/download/scalardl-3.1.0/scalardl-3.1.0.tgz
     version: 3.1.0
   - apiVersion: v2
+    appVersion: 3.0.5
+    created: "2022-01-25T01:59:50.984147143Z"
+    dependencies:
+    - condition: envoy.enabled
+      name: envoy
+      repository: https://scalar-labs.github.io/helm-charts
+      version: ~1.0.0
+    description: Scalar DL is a tamper-evident and scalable distributed database.
+    digest: 0f3f67c70f902de75e48600821e2328afe07361799bb9c226848fbd797657178
+    home: https://scalar-labs.com/
+    icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
+    keywords:
+    - database
+    - distributed ledger
+    - scalar
+    - scalar dl
+    maintainers:
+    - email: yusuke.morimoto@scalar-labs.com
+      name: Yusuke Morimoto
+    - email: kun.tei@scalar-labs.com
+      name: Kun Tei
+    - email: hiroyuki.yamada@scalar-labs.com
+      name: Hiroyuki Yamada
+    name: scalardl
+    sources:
+    - https://github.com/scalar-labs/scalardl
+    type: application
+    urls:
+    - https://github.com/scalar-labs/helm-charts/releases/download/scalardl-3.0.1/scalardl-3.0.1.tgz
+    version: 3.0.1
+  - apiVersion: v2
     appVersion: 3.0.1
     created: "2021-09-30T15:36:26.217322+09:00"
     dependencies:


### PR DESCRIPTION
The entry of scalardl v3.0.1 removed by the following commit. (The following commit is related to scalardl-audit v1.0.1. At this time
we don't find the cause that this commit removes other chart's entry.)
b2a9e78995c8e2d4f99a58859b0a68d305acf84e

I the result of the above behavior, we cannot find chart "scalardl v3.0.1" in the helm search repo command.
So, we need to add entry of "scalardl v3.0.1" into the index.yaml.

Usually, the entry of index.yaml added by chart releaser automatically.
However, to fix the above issue, add entry of scalardl v3.0.1 manually in this commit.