### PR TITLE
Add --versions option of helm search repo command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Once Helm is set up properly, add the repo as follows:
 helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
 
-You can then run `helm search repo scalar-labs` to see the Scalar charts.
+You can then run `helm search repo scalar-labs` to see the Scalar charts.  
+Also, you can see the all versions by `helm search repo scalar-labs --versions` command.
 
 ### Pre-commit hook
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
 
 You can then run `helm search repo scalar-labs` to see the Scalar charts.  
-Also, you can see the all versions by `helm search repo scalar-labs --versions` command.
+Also, you can see all the versions by `helm search repo scalar-labs --versions` command.
 
 ### Pre-commit hook
 


### PR DESCRIPTION
If we want to see all versions of helm charts, we need to specify the `--versions` option in the `helm search repo` command. 
So, I added it in the README. Please take a look!