### PR TITLE
Make namespace configurable in helm template

### DIFF
--- a/charts/envoy/templates/deployment.yaml
+++ b/charts/envoy/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "envoy.fullname" . }}-envoy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "envoy.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy/templates/service.yaml
+++ b/charts/envoy/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "envoy.fullname" . }}-envoy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "envoy.labels" . | nindent 4 }}
   annotations:

--- a/charts/envoy/templates/serviceaccount.yaml
+++ b/charts/envoy/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "envoy.fullname" . }}-envoy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "envoy.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/scalardb/templates/scalardb/configmap.yaml
+++ b/charts/scalardb/templates/scalardb/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "scalardb.fullname" . }}-config-file
+  namespace: {{ .Release.Namespace }}
 data:
   # Create a database.properties file which is config file of Scalar DB server.
   database.properties: |-

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "scalardb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardb.labels" . | nindent 4 }}
 spec:

--- a/charts/scalardb/templates/scalardb/service.yaml
+++ b/charts/scalardb/templates/scalardb/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "scalardb.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardb.labels" . | nindent 4 }}
   annotations:

--- a/charts/scalardb/templates/scalardb/serviceaccount.yaml
+++ b/charts/scalardb/templates/scalardb/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scalardb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardb.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "scalardl-audit.fullname" . }}-auditor
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
 spec:

--- a/charts/scalardl-audit/templates/auditor/secret.yaml
+++ b/charts/scalardl-audit/templates/auditor/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "scalardl-audit.fullname" . }}-auditor
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/scalardl-audit/templates/auditor/service.yaml
+++ b/charts/scalardl-audit/templates/auditor/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "scalardl-audit.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
   annotations:

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "scalardl.fullname" . }}-ledger
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardl-ledger.labels" . | nindent 4 }}
 spec:

--- a/charts/scalardl/templates/ledger/secret.yaml
+++ b/charts/scalardl/templates/ledger/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "scalardl.fullname" . }}-ledger
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardl-ledger.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/scalardl/templates/ledger/service.yaml
+++ b/charts/scalardl/templates/ledger/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "scalardl.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardl-ledger.labels" . | nindent 4 }}
   annotations:

--- a/charts/schema-loading/templates/batchjob-schema-loading.yaml
+++ b/charts/schema-loading/templates/batchjob-schema-loading.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "schema-loading.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "schema-loading.labels" . | nindent 4 }}
 spec:

--- a/charts/schema-loading/templates/secret.yaml
+++ b/charts/schema-loading/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "schema-loading.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "schema-loading.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
This PR allows `--namespace` flag to work when using `helm template` command to generate manifests.

Currently, `--namespace` flag works when installing a Helm chart with `helm install` command. However, when using `--namespace` flag with `helm template` command, namespace must be templated with `{{ .Release.Namespace }}` to specify namespace.

Users may use `helm template` command to generate a manifest file, and then apply that manifest file to the cluster using another tool.

You can verify that this change allows `--namespace` flag to work with `helm template` command by following the steps:

```
$ git checkout main
$ git show -q
commit 717daeeda7eea7a6e9e03404ce811b71e52ec346 (HEAD -> main, origin/main, origin/HEAD)
Author: kota2and3kan <kota2and3kan@users.noreply.github.com>
Date:   Tue Mar 29 02:58:06 2022 +0000

    Update index.yaml

    Signed-off-by: kota2and3kan <kota2and3kan@users.noreply.github.com>

$ helm template scalardl charts/scalardl --namespace scalardl >/tmp/main.yaml
$ git checkout namespace
$ git show -q
commit 7ea3cccabcf541c54bf3dea809d8350b04f74b60 (HEAD -> namespace)
Author: Kazuki Suda <kazuki.suda@gmail.com>
Date:   Tue Apr 5 11:54:31 2022 +0900

    Make namespace configurable in helm template
$ helm template scalardl charts/scalardl --namespace scalardl >/tmp/namespace.yaml
$ diff -u /tmp/main.yaml /tmp/namespace.yaml
--- /tmp/main.yaml      2022-04-05 12:03:40.150221213 +0900
+++ /tmp/namespace.yaml 2022-04-05 12:02:48.805547730 +0900
@@ -63,6 +63,7 @@
 kind: Secret
 metadata:
   name: scalardl-ledger
+  namespace: scalardl
   labels:
     helm.sh/chart: scalardl-4.1.1
     app.kubernetes.io/name: scalardl
@@ -174,6 +175,7 @@
 kind: Service
 metadata:
   name: scalardl-headless
+  namespace: scalardl
   labels:
     helm.sh/chart: scalardl-4.1.1
     app.kubernetes.io/name: scalardl
@@ -313,6 +315,7 @@
 kind: Deployment
 metadata:
   name: scalardl-ledger
+  namespace: scalardl
   labels:
     helm.sh/chart: scalardl-4.1.1
     app.kubernetes.io/name: scalardl
```