### PR TITLE
Fix graph title of Scalar DL's Grafana Dashboard

### DIFF
--- a/charts/scalardl-audit/files/grafana/scalardl_audit_grafana_dashboard.json
+++ b/charts/scalardl-audit/files/grafana/scalardl_audit_grafana_dashboard.json
@@ -103,7 +103,7 @@
           "refId": "A"
         }
       ],
-      "title": "Total Succeded",
+      "title": "Success Requests Per One Second",
       "type": "timeseries"
     },
     {
@@ -184,7 +184,7 @@
           "refId": "A"
         }
       ],
-      "title": "Total Failed",
+      "title": "Failure Requests Per One Second",
       "type": "timeseries"
     },
     {
@@ -282,7 +282,7 @@
           "refId": "C"
         }
       ],
-      "title": "Certificate Registration Request Count",
+      "title": "Certificate Registration Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -404,7 +404,7 @@
           "refId": "F"
         }
       ],
-      "title": "Certificate Registration Request",
+      "title": "Certificate Registration Request Execution Time (percentile)",
       "type": "timeseries"
     },
     {
@@ -501,7 +501,7 @@
           "refId": "C"
         }
       ],
-      "title": "Contract Execution Request Count",
+      "title": "Contract Execution Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -622,7 +622,7 @@
           "refId": "F"
         }
       ],
-      "title": "Contract Execution Request",
+      "title": "Contract Execution Request Execution Time (percentile)",
       "type": "timeseries"
     },
     {
@@ -719,7 +719,7 @@
           "refId": "C"
         }
       ],
-      "title": "Execution Validation Request Count",
+      "title": "Execution Validation Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -840,7 +840,7 @@
           "refId": "F"
         }
       ],
-      "title": "Execution Validation Request",
+      "title": "Execution Validation Request Execution Time (percentile)",
       "type": "timeseries"
     },
     {
@@ -937,7 +937,7 @@
           "refId": "C"
         }
       ],
-      "title": "Ledger Validation Request Count",
+      "title": "Ledger Validation Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -1058,7 +1058,7 @@
           "refId": "F"
         }
       ],
-      "title": "Ledger Validation Request",
+      "title": "Ledger Validation Request Execution Time (percentile)",
       "type": "timeseries"
     }
   ],

--- a/charts/scalardl/files/grafana/scalardl_grafana_dashboard.json
+++ b/charts/scalardl/files/grafana/scalardl_grafana_dashboard.json
@@ -108,7 +108,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Total Succeded",
+      "title": "Success Requests Per One Second",
       "type": "timeseries"
     },
     {
@@ -189,7 +189,7 @@
           "refId": "A"
         }
       ],
-      "title": "Total Failed",
+      "title": "Failure Requests Per One Second",
       "type": "timeseries"
     },
     {
@@ -286,7 +286,7 @@
           "refId": "C"
         }
       ],
-      "title": "Contract Registration Request Count",
+      "title": "Contract Registration Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -411,7 +411,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Contract Registration Request",
+      "title": "Contract Registration Request Execution Time (percentile)",
       "type": "timeseries"
     },
     {
@@ -508,7 +508,7 @@
           "refId": "C"
         }
       ],
-      "title": "Contract Execution Request Count",
+      "title": "Contract Execution Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -629,7 +629,7 @@
           "refId": "F"
         }
       ],
-      "title": "Contract Execution Request",
+      "title": "Contract Execution Request Execution Time (percentile)",
       "type": "timeseries"
     },
     {
@@ -731,7 +731,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Certificate Registration Request Count",
+      "title": "Certificate Registration Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -852,7 +852,7 @@
           "refId": "F"
         }
       ],
-      "title": "Certificate Registration Request",
+      "title": "Certificate Registration Request Execution Time (percentile)",
       "type": "timeseries"
     },
     {
@@ -950,7 +950,7 @@
           "refId": "C"
         }
       ],
-      "title": "Execution Abort Request Count",
+      "title": "Execution Abort Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -1071,7 +1071,7 @@
           "refId": "F"
         }
       ],
-      "title": "Execution Abort Request",
+      "title": "Execution Abort Request Execution Time (percentile)",
       "type": "timeseries"
     },
     {
@@ -1168,7 +1168,7 @@
           "refId": "C"
         }
       ],
-      "title": "Asset Proof Retrieval Request Count",
+      "title": "Asset Proof Retrieval Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -1289,7 +1289,7 @@
           "refId": "F"
         }
       ],
-      "title": "Asset Proof Retrieval Request",
+      "title": "Asset Proof Retrieval Request Execution Time (percentile)",
       "type": "timeseries"
     },
     {
@@ -1386,7 +1386,7 @@
           "refId": "C"
         }
       ],
-      "title": "Ledger Validation Request Count",
+      "title": "Ledger Validation Request Per One Second",
       "type": "timeseries"
     },
     {
@@ -1507,7 +1507,7 @@
           "refId": "F"
         }
       ],
-      "title": "Ledger Validation Request",
+      "title": "Ledger Validation Request Execution Time (percentile)",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
This PR update the Graph Title of Grafana Dashboard.  

There are two kind of changes.
Both fixes are related to https://github.com/scalar-labs/helm-charts/pull/81. (I fixed each graph title to consistency of Grafana Dashboard between Scalar DB and Scalar DL.)  

1. `XXX Request Count` -> `XXX Request Per One Second`
2. `XXX Request` -> `XXX Request Execution Time (percentile)`

One is update `Count` -> `Per One Second`, because the irate() function of prometheus returns metrics that request number of per one second.  
Please see the following PR commnet for details of irate() function.  
* Reference information
    * https://github.com/scalar-labs/helm-charts/pull/81#issuecomment-1066435328

Next one is `Request` -> `Request Execution Time (percentile)`, because the metrics show execution time as percentile.  

The fixed dashboards are the following.  

<details>
<summary>Fixed Graph Capture (Ledger)</summary>

![Grafana_Dashboard_Ledger](https://user-images.githubusercontent.com/47254383/162711044-2210ac70-2e0c-479e-a8b6-f43f8bf6d6bc.png)
</details>


<details>
<summary>Fixed Graph Capture (Auditor)</summary>

![Grafana_Dashboard_Auditor](https://user-images.githubusercontent.com/47254383/162711081-b4cf18dc-74f8-4b5e-aba0-2646c7110406.png)
</details>

Please take a look!
