### PR TITLE
Add Getting Started Guide with Helm Chart (Scalar DL)

### DIFF
--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -1,6 +1,6 @@
 # Getting Started with Helm Charts (Scalar DL Auditor)
 
-This document explains how to get started with Scalar DL Ledger and Auditor by using the Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
+This document explains how to get started with Scalar DL Ledger and Auditor using the Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
 
 ## Requirement
 
@@ -51,7 +51,7 @@ Also, after this step, we call `Scalar DL Ledger` as `Ledger` and `Scalar DL Aud
 
 ## Step 2. Start Cassandra container for Auditor
 
-In this guide, we use Apache Cassandra as backend storage of the Auditor, it will be started on the same network of Auditor (Pod on minikube) to enable proper communication.
+In this guide, we use Apache Cassandra as backend storage of the Auditor, it will be started on the same network of Auditor (pod on minikube) to enable proper communication.
 
 1. Start Cassandra container for Auditor on the Docker Network `minikube`.
    ```console
@@ -60,10 +60,10 @@ In this guide, we use Apache Cassandra as backend storage of the Auditor, it wil
    * Note: 
        * The Docker Network `minikube` was created by the `minikube start --driver=docker` command that we ran in Step 1.
        * You need to specify the Cassandra version (tag) that the Scalar DB that is used in Scalar DL supports.
-           * You can see the version of Scalar DB that is used in each Scalar DL in the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
-           * Also, you can see the Cassandra version that is supported by Scalar DB in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
+           * You can see the Scalar DB version of Scalar DL from the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
+           * Also, you can see the Scalar DB-supported Cassandra versions (tag) in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
-1. Check the Cassandra containers are running.
+1. Check the status of the Cassandra container.
    ```console
    $ docker ps -f name=cassandra-auditor
    CONTAINER ID   IMAGE            COMMAND                  CREATED          STATUS          PORTS                                         NAMES
@@ -85,7 +85,7 @@ In this section, we will create key/certificate files for Auditor.
     * In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
     * We assume that you already made a working directory and create key/certificate files for Ledger and Client in the [Getting Started with Helm Charts (Scalar DL Ledger)](./getting-started-scalardl-ledger.md).
 
-1. Change working dir to `certs/`.
+1. Change working directory to `certs/`.
    ```console
    $ cd ~/scalardl-test/certs/
    ```
@@ -140,7 +140,7 @@ In this section, we will create key/certificate files for Auditor.
 In this section, we will deploy Scalar DL Schema Loader on minikube by using Helm Charts.  
 The Scalar DL Schema Loader will create the DB schema in the Cassandra for Auditor.  
 
-1. Change working dir from `certs/`.
+1. Change working directory from `certs/`.
    ```console
    $ cd ~/scalardl-test/
    ```
@@ -162,12 +162,12 @@ The Scalar DL Schema Loader will create the DB schema in the Cassandra for Audit
    $ helm install schema-loader-auditor scalar-labs/schema-loading  -f ./schema-loader-auditor-custom-values.yaml
    ```
 
-1. Check the Scalar DL Schema Loader Pod is deployed and completed.
+1. Check the Scalar DL Schema Loader pod is deployed and completed.
    ```console
    $ kubectl get pod | grep schema-loader-auditor
    schema-loader-auditor-schema-loading-9v5m7   0/1     Completed   0          10m
    ```
-   If the Scalar DL Schema Loader Pod (schema-loader-auditor-schema-loading-xxxxx) is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
+   If the Scalar DL Schema Loader pod (schema-loader-auditor-schema-loading-xxxxx) is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
 
 ## Step 5. Deploy Auditor on minikube by Helm Charts
 
@@ -215,7 +215,7 @@ In this section, we will deploy Auditor on minikube by using Helm Charts.
    $ helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
-1. Check the Auditor Pods are deployed.
+1. Check the Auditor pods are deployed.
    ```console
    $ kubectl get pod
    NAME                                         READY   STATUS      RESTARTS   AGE
@@ -234,7 +234,7 @@ In this section, we will deploy Auditor on minikube by using Helm Charts.
    schema-loader-auditor-schema-loading-9v5m7   0/1     Completed   0          15m
    schema-loader-ledger-schema-loading-dgksb    0/1     Completed   0          19m
    ```
-   If the Auditor Pods are deployed properly, you can see the STATUS are `Running`.  
+   If the Auditor pods are deployed properly, you can see the STATUS are `Running`.  
 
 1. Check the Auditor Services are deployed.
    ```console
@@ -304,7 +304,7 @@ This guide explains the minimum steps. If you want to know more details about Sc
    # git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
-1. Change dir to `scalardl-java-client-sdk/`.
+1. Change directory to `scalardl-java-client-sdk/`.
    ```console
    # cd scalardl-java-client-sdk/ 
    # pwd
@@ -532,7 +532,7 @@ After completing the Scalar DL Auditor tests on minikube, remove all resources.
    $ docker rm $(docker kill scalardl-client cassandra-ledger cassandra-auditor)
    ```
 
-1. Remove working dir and sample files (configuration file, key, and certificate).
+1. Remove working directory and sample files (configuration file, key, and certificate).
    ```console
    $ cd ~
    $ rm -rf ~/scalardl-test/

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -5,7 +5,7 @@ This document explains how to get started with Scalar DL Ledger and Auditor by u
 ## Requirement
 
 * You need the privileges to pull the Scalar DL containers (`scalar-ledger`, `scalar-auditor`, and `scalardl-schema-loader`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).
-* You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token), to pull the above containers.
+* You must create a Github Personal Access Token (PAT) with `read:packages` scope using the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above containers.
 
 ## Note
 To make Byzantine fault detection with auditing work properly, Ledger and Auditor should be deployed and managed in different administrative domains. However, in this guide, we will deploy Ledger and Auditor in the same Kubernetes (minikube) to make the test easier.  
@@ -113,7 +113,7 @@ In this section, we will create key/certificate files for Auditor.
    EOF
    ```
 
-1. Create key/certificate files of the Auditor.
+1. Create key/certificate files for the Auditor.
    ```console
    $ cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
    ```

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -12,7 +12,7 @@ To make Byzantine fault detection with auditing work properly, Ledger and Audito
 
 ## Tools
 
-In this guide, we will use the following tools for testing.  
+We will use the following tools for testing.  
 
 1. Docker
 1. minikube
@@ -22,7 +22,7 @@ In this guide, we will use the following tools for testing.
 
 ## Environment
 
-In this guide, we will create the following environment in your local by using Docker and minikube.  
+We will create the following environment in your local by using Docker and minikube.  
 
 ```
 On the Docker Network (named minikube)
@@ -51,9 +51,9 @@ Also, after this step, we call `Scalar DL Ledger` as `Ledger` and `Scalar DL Aud
 
 ## Step 2. Start Cassandra container for Auditor
 
-In this guide, we use Apache Cassandra as backend storage of the Auditor, it will be started on the same network of Auditor (pod on minikube) to enable proper communication.
+We use Apache Cassandra as the backend storage of the Auditor. We start a Cassandra container on the same network of Kubernetes (Auditor Pod on minikube) to make them communicate properly.
 
-1. Start Cassandra container for Auditor on the Docker Network `minikube`.
+1. Start a Cassandra container for Auditor on the Docker Network `minikube`.
    ```console
    $ docker run --name cassandra-auditor --network minikube -d cassandra:3.11
    ```
@@ -63,7 +63,7 @@ In this guide, we use Apache Cassandra as backend storage of the Auditor, it wil
            * You can see the Scalar DB version of Scalar DL from the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
            * Also, you can see the Scalar DB-supported Cassandra versions (tag) in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
-1. Check the status of the Cassandra container.
+1. Check if the Cassandra container is running.
    ```console
    $ docker ps -f name=cassandra-auditor
    CONTAINER ID   IMAGE            COMMAND                  CREATED          STATUS          PORTS                                         NAMES
@@ -75,11 +75,9 @@ In this guide, we use Apache Cassandra as backend storage of the Auditor, it wil
    $ docker exec -t cassandra-auditor cqlsh -e "show version"
    [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
    ```
-   It may take some time to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
+   It may take a while to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
 
 ## Step 3. Create key/certificate files for Auditor
-
-In this section, we will create key/certificate files for Auditor.  
 
 * Note: 
     * In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
@@ -137,7 +135,7 @@ In this section, we will create key/certificate files for Auditor.
 
 ## Step 4. Create DB schema for Auditor by Helm Charts
 
-In this section, we will deploy Scalar DL Schema Loader on minikube by using Helm Charts.  
+We will deploy a Scalar DL Schema Loader on minikube by using Helm Charts.  
 The Scalar DL Schema Loader will create the DB schema in the Cassandra for Auditor.  
 
 1. Change working directory from `certs/`.
@@ -157,21 +155,19 @@ The Scalar DL Schema Loader will create the DB schema in the Cassandra for Audit
    EOF
    ```
 
-1. Deploy Scalar DL Schema Loader for Auditor.
+1. Deploy the Scalar DL Schema Loader for Auditor.
    ```console
    $ helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
-1. Check the Scalar DL Schema Loader pod is deployed and completed.
+1. Check if the Scalar DL Schema Loader pod is deployed and completed.
    ```console
    $ kubectl get pod | grep schema-loader-auditor
    schema-loader-auditor-schema-loading-9v5m7   0/1     Completed   0          10m
    ```
    If the Scalar DL Schema Loader pod (schema-loader-auditor-schema-loading-xxxxx) is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
 
-## Step 5. Deploy Auditor on minikube by Helm Charts
-
-In this section, we will deploy Auditor on minikube by using Helm Charts.  
+## Step 5. Deploy Auditor on the Kubernetes (minikube) using Helm Charts
 
 1. Create a custom value file for Auditor (scalardl-auditor-custom-values.yaml).
    ```console
@@ -210,12 +206,12 @@ In this section, we will deploy Auditor on minikube by using Helm Charts.
    $ kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
    ```
 
-1. Deploy Auditor.
+1. Deploy the Auditor.
    ```console
    $ helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
-1. Check the Auditor pods are deployed.
+1. Check if the Auditor pods are deployed.
    ```console
    $ kubectl get pod
    NAME                                         READY   STATUS      RESTARTS   AGE
@@ -236,7 +232,7 @@ In this section, we will deploy Auditor on minikube by using Helm Charts.
    ```
    If the Auditor pods are deployed properly, you can see the STATUS are `Running`.  
 
-1. Check the Auditor Services are deployed.
+1. Check if the Auditor Services are deployed.
    ```console
    $ kubectl get svc
    NAME                             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
@@ -266,27 +262,25 @@ In this section, we will deploy Auditor on minikube by using Helm Charts.
 
 ## Step 6. Start Client container
 
-In this section, we will create a Client container to run a sample contract of Scalar DL.  
-We will use certificate files in the Client container. So, mount ~/scalardl-test/certs to the Client container.  
+We will use certificate files in the Client container. So, we mount ~/scalardl-test/certs directory to the Client container.  
 
-1. Start the Client container on the Docker Network `minikube`.
+1. Start a Client container on the `minikube` network.
    ```console
    $ docker run -d --name scalardl-client --hostname scalardl-client -v ~/scalardl-test/certs:/certs --network minikube --entrypoint sleep ubuntu:20.04 inf
    ```
 
-1. Check the Client container is running.
+1. Check if the Client container is running.
    ```console
    $ docker ps -f name=scalardl-client
    ```
 
 ## Step 7. Run Scalar DL sample contracts in the Client container
 
-In this section, we will prepare and run the Scalar DL sample contract.  
 * Note: 
    * When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application.  
    * The Ledger needs to register its certificate to Auditor, and the Auditor needs to register its certificate to Ledger.
 
-This guide explains the minimum steps. If you want to know more details about Scalar DL and the contract, please refer to the [Getting Started with Scalar DL Auditor](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started-auditor.md).
+The following explains the minimum steps. If you want to know more details about Scalar DL and the contract, please refer to the [Getting Started with Scalar DL Auditor](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started-auditor.md).
 
 1. Run bash in the Client container.
    ```console
@@ -299,7 +293,7 @@ This guide explains the minimum steps. If you want to know more details about Sc
    # apt update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt install -y git openjdk-8-jdk curl unzip
    ```
 
-1. Clone Scalar DL Java Client SDK's git repository.
+1. Clone Scalar DL Java Client SDK git repository.
    ```console
    # git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
@@ -414,38 +408,38 @@ This guide explains the minimum steps. If you want to know more details about Sc
    EOF
    ```
 
-1. Register certificate file of Ledger.
+1. Register the certificate file of Ledger.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
-1. Register certificate file of Auditor.
+1. Register the certificate file of Auditor.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
-1. Register certificate file of client.
+1. Register the certificate file of client.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./client.properties
    ```
 
-1. Register sample contract `StateUpdater`.
+1. Register the sample contract `StateUpdater`.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
-1. Register sample contract `StateReader`.
+1. Register the sample contract `StateReader`.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
-1. Execute contract `StateUpdater`.
+1. Execute the contract `StateUpdater`.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
-1. Execute contract `StateReader`.
+1. Execute the contract `StateReader`.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    {
@@ -483,7 +477,7 @@ This guide explains the minimum steps. If you want to know more details about Sc
          ```
            * In this way, the Scalar DL can detect data tampering.
 
-1. Execute validation request of the asset.
+1. Execute a validation request of the asset.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    {

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -1,0 +1,545 @@
+# Getting Started with Helm Charts (Scalar DL Auditor)
+
+This document explains how to get started with Scalar DL Ledger and Auditor by using the Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
+
+## Requirement
+
+* You need the privileges to pull the Scalar DL containers (`scalar-ledger`, `scalar-auditor`, and `scalardl-schema-loader`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).
+* You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token), to pull the above containers.
+
+## Note
+To make Byzantine fault detection with auditing work properly, Ledger and Auditor should be deployed and managed in different administrative domains. However, in this guide, we will deploy Ledger and Auditor in the same Kubernetes (minikube) to make the test easier.  
+
+## Tools
+
+In this guide, we will use the following tools for testing.  
+
+1. Docker
+1. minikube
+1. kubectl
+1. Helm
+1. cfssl / cfssljson
+
+## Environment
+
+In this guide, we will create the following environment in your local by using Docker and minikube.  
+
+```
+On the Docker Network (named minikube)
+
+                   +---------------------------------------------+    +-----------+    +-----------+
+  +-----------+    | +------------------+  +-------------------+ |    |           |    |           |
+  |           |    | | Scalar DL Ledger |  | Scalar DL Auditor | |    | Cassandra |    | Cassandra |
+  |  Client   |    | +------------------+  +-------------------+ |    | Container |    | Container |
+  | Container |    |                                             |    | (Ledger)  |    | (Auditor) |
+  |           |    |            Kubernetes (minikube)            |    |           |    |           |
+  +-----+-----+    +----------------------+----------------------+    +-----+-----+    +-----+-----+
+        |                                 |                                 |                |
+*-------+---------------------------------+---------------------------------+----------------+-------*
+             ------->                                           ------->
+               gRPC                                          Cassandra Driver
+```
+
+## Step 1. Create the Scalar DL Ledger environment
+
+First, you need to create a Scalar DL Ledger environment with Auditor configuration.  
+Please refer to the `Step 1` ~ `Step 7` of [Getting Started with Helm Charts (Scalar DL Ledger)](./getting-started-scalardl-ledger.md) to create a Ledger environment.  
+To enable Auditor configuration in the Scalar DL Ledger, set `true` to `ledger.scalarLedgerConfiguration.ledgerAuditorEnabled` in `Step 7` of the above guide.  
+
+After this step, we will create (add) a Scalar DL Auditor environment into the above Scalar DL Ledger environment.  
+Also, after this step, we call `Scalar DL Ledger` as `Ledger` and `Scalar DL Auditor` as `Auditor`.  
+
+## Step 2. Start Cassandra container for Auditor
+
+In this guide, we use Apache Cassandra as backend storage of the Auditor, it will be started on the same network of Auditor (Pod on minikube) to enable proper communication.
+
+1. Start Cassandra container for Auditor on the Docker Network `minikube`.
+   ```console
+   $ docker run --name cassandra-auditor --network minikube -d cassandra:3.11
+   ```
+   * Note: 
+       * The Docker Network `minikube` was created by the `minikube start --driver=docker` command that we ran in Step 1.
+       * You need to specify the Cassandra version (tag) that the Scalar DB that is used in Scalar DL supports.
+           * You can see the version of Scalar DB that is used in each Scalar DL in the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
+           * Also, you can see the Cassandra version that is supported by Scalar DB in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
+
+1. Check the Cassandra containers are running.
+   ```console
+   $ docker ps -f name=cassandra-auditor
+   CONTAINER ID   IMAGE            COMMAND                  CREATED          STATUS          PORTS                                         NAMES
+   2a1d2770bf72   cassandra:3.11   "docker-entrypoint.s…"   6 seconds ago    Up 4 seconds    7000-7001/tcp, 7199/tcp, 9042/tcp, 9160/tcp   cassandra-auditor
+   ```
+
+1. Check the status of Cassandra.
+   ```console
+   $ docker exec -t cassandra-auditor cqlsh -e "show version"
+   [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
+   ```
+   It may take some time to start Cassandra in the container. So, if this command return error, wait a moment and then re-run it.
+
+## Step 3. Create key/certificate files for Auditor
+
+In this section, we will create key/certificate files for Auditor.  
+
+* Note: 
+    * In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
+    * We assume that you already made a working directory and create key/certificate files for Ledger and Client in the [Getting Started with Helm Charts (Scalar DL Ledger)](./getting-started-scalardl-ledger.md).
+
+1. Change working dir to `certs/`.
+   ```console
+   $ cd ~/scalardl-test/certs/
+   ```
+
+1. Create a JSON file that includes Auditor information.
+   ```console
+   $ cat << EOF > ~/scalardl-test/certs/auditor.json
+   {
+       "CN": "auditor",
+       "hosts": ["example.com","*.example.com"],
+       "key": {
+           "algo": "ecdsa",
+           "size": 256
+       },
+       "names": [
+           {
+               "O": "auditor",
+               "OU": "test team",
+               "L": "Shinjuku",
+               "ST": "Tokyo",
+               "C": "JP"
+           }
+       ]
+   }
+   EOF
+   ```
+
+1. Create key/certificate files of the Auditor.
+   ```console
+   $ cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
+   ```
+
+1. Confirm key/certificate files are created.
+   ```console
+   $ ls -1
+   auditor-key.pem
+   auditor.csr
+   auditor.json
+   auditor.pem
+   client-key.pem
+   client.csr
+   client.json
+   client.pem
+   ledger-key.pem
+   ledger.csr
+   ledger.json
+   ledger.pem
+   ```
+
+## Step 4. Create DB schema for Auditor by Helm Charts
+
+In this section, we will deploy Scalar DL Schema Loader on minikube by using Helm Charts.  
+The Scalar DL Schema Loader will create the DB schema in the Cassandra for Auditor.  
+
+1. Change working dir from `certs/`.
+   ```console
+   $ cd ~/scalardl-test/
+   ```
+
+1. Create a custom value file for Scalar DL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
+   ```console
+   $ cat << EOF > schema-loader-auditor-custom-values.yaml
+   schemaLoading:
+     database: "cassandra"
+     contactPoints: "cassandra-auditor"
+     username: "cassandra"
+     password: "cassandra"
+     schemaType: "auditor"
+   EOF
+   ```
+
+1. Deploy Scalar DL Schema Loader for Auditor.
+   ```console
+   $ helm install schema-loader-auditor scalar-labs/schema-loading  -f ./schema-loader-auditor-custom-values.yaml
+   ```
+
+1. Check the Scalar DL Schema Loader Pod is deployed and completed.
+   ```console
+   $ kubectl get pod | grep schema-loader-auditor
+   schema-loader-auditor-schema-loading-9v5m7   0/1     Completed   0          10m
+   ```
+   If the Scalar DL Schema Loader Pod (schema-loader-auditor-schema-loading-xxxxx) is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
+
+## Step 5. Deploy Auditor on minikube by Helm Charts
+
+In this section, we will deploy Auditor on minikube by using Helm Charts.  
+
+1. Create a custom value file for Auditor (scalardl-auditor-custom-values.yaml).
+   ```console
+   $ cat << EOF > scalardl-auditor-custom-values.yaml
+   envoy:
+     service:
+       type: "NodePort"
+   
+   auditor:
+     scalarAuditorConfiguration:
+       dbStorage: "cassandra"
+       dbContactPoints: "cassandra-auditor"
+       dbUsername: "cassandra"
+       dbPassword: "cassandra"
+       auditorLedgerHost: "scalardl-ledger-envoy"
+   EOF
+   ```
+   * Note:
+       * If you want to access Auditor from 127.0.0.1 (your localhost), set `LoadBalancer` to `envoy.service.type` like the following.
+         ```yaml
+         envoy:
+           service:
+             type: "LoadBalancer"
+         
+         auditor:
+           scalarAuditorConfiguration:
+             dbStorage: "cassandra"
+             dbContactPoints: "cassandra-auditor"
+             dbUsername: "cassandra"
+             dbPassword: "cassandra"
+             auditorLedgerHost: "scalardl-ledger-envoy"
+         ```
+
+1. Create secret resource `auditor-keys`.
+   ```console
+   $ kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
+   ```
+
+1. Deploy Auditor.
+   ```console
+   $ helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
+   ```
+
+1. Check the Auditor Pods are deployed.
+   ```console
+   $ kubectl get pod
+   NAME                                         READY   STATUS      RESTARTS   AGE
+   scalardl-auditor-auditor-99b94bb75-7fjmb     1/1     Running     0          3m1s
+   scalardl-auditor-auditor-99b94bb75-jbp7c     1/1     Running     0          3m1s
+   scalardl-auditor-auditor-99b94bb75-trq66     1/1     Running     0          3m1s
+   scalardl-auditor-envoy-55bfcbb76b-4bkdp      1/1     Running     0          3m1s
+   scalardl-auditor-envoy-55bfcbb76b-552hd      1/1     Running     0          3m1s
+   scalardl-auditor-envoy-55bfcbb76b-cqx98      1/1     Running     0          3m1s
+   scalardl-ledger-envoy-84dcc85b6d-jzkjr       1/1     Running     0          18m
+   scalardl-ledger-envoy-84dcc85b6d-l4r66       1/1     Running     0          18m
+   scalardl-ledger-envoy-84dcc85b6d-nz25m       1/1     Running     0          18m
+   scalardl-ledger-ledger-6dbc56c7b5-nsmxv      1/1     Running     0          18m
+   scalardl-ledger-ledger-6dbc56c7b5-rxnjz      1/1     Running     0          18m
+   scalardl-ledger-ledger-6dbc56c7b5-szqc2      1/1     Running     0          18m
+   schema-loader-auditor-schema-loading-9v5m7   0/1     Completed   0          15m
+   schema-loader-ledger-schema-loading-dgksb    0/1     Completed   0          19m
+   ```
+   If the Auditor Pods are deployed properly, you can see the STATUS are `Running`.  
+
+1. Check the Auditor Services are deployed.
+   ```console
+   $ kubectl get svc
+   NAME                             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
+   kubernetes                       ClusterIP   10.96.0.1       <none>        443/TCP                           25m
+   scalardl-auditor-envoy           NodePort    10.101.34.229   <none>        40051:30140/TCP,40052:30599/TCP   3m32s
+   scalardl-auditor-envoy-metrics   ClusterIP   10.97.47.11     <none>        9001/TCP                          3m32s
+   scalardl-auditor-headless        ClusterIP   None            <none>        50051/TCP,50053/TCP,50052/TCP     3m32s
+   scalardl-auditor-metrics         ClusterIP   10.103.88.93    <none>        8080/TCP                          3m32s
+   scalardl-ledger-envoy            NodePort    10.97.160.80    <none>        50051:32468/TCP,50052:30626/TCP   19m
+   scalardl-ledger-envoy-metrics    ClusterIP   10.97.83.78     <none>        9001/TCP                          19m
+   scalardl-ledger-headless         ClusterIP   None            <none>        50051/TCP,50053/TCP,50052/TCP     19m
+   scalardl-ledger-metrics          ClusterIP   10.111.170.92   <none>        8080/TCP                          19m
+   ```
+   If the Auditor Services are deployed properly, you can see a private IP address in the CLUSTER-IP column. (Note: `scalardl-auditor-headless` has no CLUSTER-IP.)  
+
+1. (Optional) If you set `LoadBalancer` to `envoy.service.type` in the `scalardl-auditor-custom-values.yaml`, you can access Auditor from 127.0.0.1.  
+   To expose the `scalardl-auditor-envoy` service as your local `127.0.0.1:40051` and `127.0.0.1:40052`, open another terminal, and run the `minikube tunnel` command.
+   ```console
+   $ minikube tunnel
+   ```
+   After running the `minikube tunnel` command, you can see the  EXTERNAL-IP of the `scalardl-auditor-envoy` as  `127.0.0.1`.
+   ```console
+   $ kubectl get svc scalardl-auditor-envoy
+   NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
+   scalardl-auditor-envoy   LoadBalancer   10.101.34.229   127.0.0.1     40051:30140/TCP,40052:30599/TCP   5m28s
+   ```
+
+## Step 6. Start Client container
+
+In this section, we will create a Client container to run a sample contract of Scalar DL.  
+We will use certificate files in the Client container. So, mount ~/scalardl-test/certs to the Client container.  
+
+1. Start the Client container on the Docker Network `minikube`.
+   ```console
+   $ docker run -d --name scalardl-client --hostname scalardl-client -v ~/scalardl-test/certs:/certs --network minikube --entrypoint sleep ubuntu:20.04 inf
+   ```
+
+1. Check the Client container is running.
+   ```console
+   $ docker ps -f name=scalardl-client
+   ```
+
+## Step 7. Run Scalar DL sample contract in the Client container
+
+In this section, we will prepare and run the Scalar DL sample contract.  
+* Note: 
+   * When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application.  
+   * The Ledger needs to register its certificate to Auditor, and the Auditor needs to register its certificate to Ledger.
+
+This guide explains the minimum steps. If you want to know more details about Scalar DL and the contract, please refer to the [Getting Started with Scalar DL Auditor](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started-auditor.md).
+
+1. Run bash in the Client container.
+   ```console
+   $ docker exec -it scalardl-client bash
+   ```
+   After this step, run each command in the Client container.  
+
+1. Install Git, OpenJDK 8, curl, and unzip in the Client container.
+   ```console
+   # apt update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt install -y git openjdk-8-jdk curl unzip
+   ```
+
+1. Clone Scalar DL Java Client SDK's git repository.
+   ```console
+   # git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
+   ```
+
+1. Change dir to `scalardl-java-client-sdk/`.
+   ```console
+   # cd scalardl-java-client-sdk/ 
+   # pwd
+   /scalardl-java-client-sdk
+   ```
+
+1. Change branch to arbitrary version.
+   ```
+   # git checkout -b v3.4.0 refs/tags/v3.4.0
+   # git branch
+     master
+   * v3.4.0
+   ```
+   If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of Scalar DL (Ledger and Auditor) and Scalar DL Java Client SDK.
+
+1. Build sample contract.
+   ```console
+   # ./gradlew assemble
+   ```
+
+1. Download CLI tools of Scalar DL from [Scalar DL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+   ```console
+   # curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.4.0/scalardl-java-client-sdk-3.4.0.zip
+   ```
+   You need to use the same version of CLI tools and Scalar DL (Ledger and Auditor).
+
+1. Unzip the scalardl-java-client-sdk-3.4.0.zip file.
+   ```console
+   # unzip ./scalardl-java-client-sdk-3.4.0.zip
+   ```
+
+1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
+   ```console
+   # cat << EOF > ledger.as.client.properties
+   # Ledger
+   scalar.dl.client.server.host=minikube
+   scalar.dl.client.server.port=32468
+   scalar.dl.client.server.privileged_port=30626
+   
+   # Auditor
+   scalar.dl.client.auditor.enabled=true
+   scalar.dl.client.auditor.host=minikube
+   scalar.dl.client.auditor.port=30140
+   scalar.dl.client.auditor.privileged_port=30599
+   
+   # Certificate
+   scalar.dl.client.cert_holder_id=ledger
+   scalar.dl.client.cert_path=../certs/ledger.pem
+   scalar.dl.client.private_key_path=../certs/ledger-key.pem
+   EOF
+   ```
+   * Note:
+       * You need to specify the port number (NodePort) of `scalardl-ledger-envoy` (Kubernetes Service Resource) as a value of `scalar.dl.client.server.port` and `scalar.dl.client.server.privileged_port` in each `*.properties`. You can confirm the port number of `scalardl-ledger-envoy` with the `kubectl get svc scalardl-ledger-envoy` command.
+         ```console
+         $ kubectl get svc scalardl-ledger-envoy
+         NAME                    TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)                           AGE
+         scalardl-ledger-envoy   NodePort   10.97.160.80   <none>        50051:32468/TCP,50052:30626/TCP   30m
+         ```
+         In this case, you need to specify `32468` to `scalar.dl.client.server.port` and `30626` to `scalar.dl.client.server.privileged_port` in the `*.properties` file.
+       * Also, you need to specify the port number (NodePort) of `scalardl-auditor-envoy` (Kubernetes Service Resource) as a value of `scalar.dl.client.auditor.port` and `scalar.dl.client.auditor.privileged_port` in each `*.properties`. You can confirm the port number of `scalardl-auditor-envoy` with the `kubectl get svc scalardl-auditor-envoy` command.
+         ```console
+         $ kubectl get svc scalardl-auditor-envoy
+         NAME                     TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
+         scalardl-auditor-envoy   NodePort   10.101.34.229   <none>        40051:30140/TCP,40052:30599/TCP   15m
+         ```
+         In this case, you need to specify `30140` to `scalar.dl.client.auditor.port` and `30599` to `scalar.dl.client.auditor.privileged_port` in the `*.properties` file.
+
+1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
+   ```console
+   # cat << EOF > auditor.as.client.properties
+   # Ledger
+   scalar.dl.client.server.host=minikube
+   scalar.dl.client.server.port=32468
+   scalar.dl.client.server.privileged_port=30626
+   
+   # Auditor
+   scalar.dl.client.auditor.enabled=true
+   scalar.dl.client.auditor.host=minikube
+   scalar.dl.client.auditor.port=30140
+   scalar.dl.client.auditor.privileged_port=30599
+   
+   # Certificate
+   scalar.dl.client.cert_holder_id=auditor
+   scalar.dl.client.cert_path=../certs/auditor.pem
+   scalar.dl.client.private_key_path=../certs/auditor-key.pem
+   EOF
+   ```
+
+1. Create a configuration file (client.properties) to access Scalar DL (Ledger and Auditor) on minikube.
+   ```console
+   # cat << EOF > client.properties
+   # Ledger
+   scalar.dl.client.server.host=minikube
+   scalar.dl.client.server.port=32468
+   scalar.dl.client.server.privileged_port=30626
+   
+   # Auditor
+   scalar.dl.client.auditor.enabled=true
+   scalar.dl.client.auditor.host=minikube
+   scalar.dl.client.auditor.port=30140
+   scalar.dl.client.auditor.privileged_port=30599
+   
+   # Certificate
+   scalar.dl.client.cert_holder_id=client
+   scalar.dl.client.cert_path=../certs/client.pem
+   scalar.dl.client.private_key_path=../certs/client-key.pem
+   EOF
+   ```
+
+1. Register certificate file of Ledger.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./ledger.as.client.properties
+   ```
+
+1. Register certificate file of Auditor.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./auditor.as.client.properties
+   ```
+
+1. Register certificate file of client.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./client.properties
+   ```
+
+1. Register sample contract `StateUpdater`.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
+   ```
+
+1. Register sample contract `StateReader`.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
+   ```
+
+1. Execute contract `StateUpdater`.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
+   ```
+   This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
+
+1. Execute contract `StateReader`.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
+   {
+       "status_code": "OK",
+       "output": {
+           "age": 0,
+           "input": {
+           },
+           "output": {
+               "state": 3
+           },
+           "contract_id": "client/1/StateUpdater",
+           "argument": {
+               "asset_id": "test_asset",
+               "state": 3,
+               "nonce": "ef041eb4-f9c3-455a-9dab-0f081a01d13b"
+           },
+           "signature": "MEUCIEzeQzX3poEfM6dlgmaLIMlMI0efnsYTfY25nru1DSeXAiEAiszgxFIO3Gv4yxBI6Sy/zph1pnnwQJRuGifio09fQOg=",
+           "hash": "zqm/vXPC8o5mL5YUaAPOrIYK/qBd3kXVjHXUH7rdjnE=",
+           "prev_hash": ""
+       },
+       "error_message": null
+   }
+   ```
+   * Reference information
+       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
+       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.
+         ```console
+         # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
+         {
+             "status_code": "INCONSISTENT_STATES",
+             "output": null,
+             "error_message": "The results from Ledger and Auditor don't match"
+         }
+         ```
+           * In this way, the Scalar DL can detect data tampering.
+
+1. Execute validation request of the asset.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
+   {
+       "status_code": "OK",
+       "Ledger": {
+           "id": "test_asset",
+           "age": 0,
+           "nonce": "ef041eb4-f9c3-455a-9dab-0f081a01d13b",
+           "hash": "zqm/vXPC8o5mL5YUaAPOrIYK/qBd3kXVjHXUH7rdjnE=",
+           "signature": "MEQCIB0lHtURoLYSz0vSpV4BhYmYBqzeSrYekN/GdP+quBLtAiBeQWMeLDEdxzeIoAkD/Cbi3zbIDud8CjK6gN/IpQKW0Q=="
+       },
+       "Auditor": {
+           "id": "test_asset",
+           "age": 0,
+           "nonce": "ef041eb4-f9c3-455a-9dab-0f081a01d13b",
+           "hash": "zqm/vXPC8o5mL5YUaAPOrIYK/qBd3kXVjHXUH7rdjnE=",
+           "signature": "MEQCIBP312FoK5pX/eSzNiJ+zCJA5PVjlbFVmMYujEESy978AiATC19Fo6Y/YGWIFgDKdfIZhLAcUcHeyNloU1YQqJBy3Q=="
+       },
+       "error_message": null
+   }
+   ```
+   * Reference information
+       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
+       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.
+         ```console
+         # ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
+         {
+             "status_code": "INVALID_OUTPUT",
+             "output": null,
+             "error_message": "Validation failed."
+         }
+         ```
+           * In this way, the Scalar DL can detect data tampering.
+
+## Step 8. Delete all resources
+
+After completing the Scalar DL Auditor tests on minikube, remove all resources.
+
+1. Uninstall Scalar DL Schema Loader, Ledger, and Auditor from minikube.
+   ```console
+   $ helm uninstall schema-loader-ledger schema-loader-auditor scalardl-ledger scalardl-auditor
+   ```
+
+1. Stop and remove containers (Cassandra and Client).
+   ```
+   $ docker rm $(docker kill scalardl-client cassandra-ledger cassandra-auditor)
+   ```
+
+1. Remove working dir and sample files (configuration file, key, and certificate).
+   ```console
+   $ cd ~
+   $ rm -rf ~/scalardl-test/
+   ```
+
+1. Delete minikube.
+   ```console
+   $ minikube delete --all
+   ```
+

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -5,7 +5,7 @@ This document explains how to get started with Scalar DL Ledger and Auditor usin
 ## Requirement
 
 * You need the privileges to pull the Scalar DL containers (`scalar-ledger`, `scalar-auditor`, and `scalardl-schema-loader`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).
-* You must create a Github Personal Access Token (PAT) with `read:packages` scope using the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above containers.
+* You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above containers.
 
 ## Note
 To make Byzantine fault detection with auditing work properly, Ledger and Auditor should be deployed and managed in different administrative domains. However, in this guide, we will deploy Ledger and Auditor in the same Kubernetes (minikube) to make the test easier.  
@@ -59,7 +59,7 @@ In this guide, we use Apache Cassandra as backend storage of the Auditor, it wil
    ```
    * Note: 
        * The Docker Network `minikube` was created by the `minikube start --driver=docker` command that we ran in Step 1.
-       * You need to specify the Cassandra version (tag) that the Scalar DB that is used in Scalar DL supports.
+       * Scalar DL uses Scalar DB in its internal. You need to specify the Scalar DB-supported Cassandra version (tag).
            * You can see the Scalar DB version of Scalar DL from the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
            * Also, you can see the Scalar DB-supported Cassandra versions (tag) in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
@@ -75,7 +75,7 @@ In this guide, we use Apache Cassandra as backend storage of the Auditor, it wil
    $ docker exec -t cassandra-auditor cqlsh -e "show version"
    [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
    ```
-   It may take some time to start Cassandra in the container. So, if this command return error, wait a moment and then re-run it.
+   It may take some time to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
 
 ## Step 3. Create key/certificate files for Auditor
 
@@ -159,7 +159,7 @@ The Scalar DL Schema Loader will create the DB schema in the Cassandra for Audit
 
 1. Deploy Scalar DL Schema Loader for Auditor.
    ```console
-   $ helm install schema-loader-auditor scalar-labs/schema-loading  -f ./schema-loader-auditor-custom-values.yaml
+   $ helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
 1. Check the Scalar DL Schema Loader pod is deployed and completed.
@@ -250,7 +250,7 @@ In this section, we will deploy Auditor on minikube by using Helm Charts.
    scalardl-ledger-headless         ClusterIP   None            <none>        50051/TCP,50053/TCP,50052/TCP     19m
    scalardl-ledger-metrics          ClusterIP   10.111.170.92   <none>        8080/TCP                          19m
    ```
-   If the Auditor Services are deployed properly, you can see a private IP address in the CLUSTER-IP column. (Note: `scalardl-auditor-headless` has no CLUSTER-IP.)  
+   If the Auditor Services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-auditor-headless` has no CLUSTER-IP.)  
 
 1. (Optional) If you set `LoadBalancer` to `envoy.service.type` in the `scalardl-auditor-custom-values.yaml`, you can access Auditor from 127.0.0.1.  
    To expose the `scalardl-auditor-envoy` service as your local `127.0.0.1:40051` and `127.0.0.1:40052`, open another terminal, and run the `minikube tunnel` command.
@@ -279,7 +279,7 @@ We will use certificate files in the Client container. So, mount ~/scalardl-test
    $ docker ps -f name=scalardl-client
    ```
 
-## Step 7. Run Scalar DL sample contract in the Client container
+## Step 7. Run Scalar DL sample contracts in the Client container
 
 In this section, we will prepare and run the Scalar DL sample contract.  
 * Note: 
@@ -320,7 +320,7 @@ This guide explains the minimum steps. If you want to know more details about Sc
    ```
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of Scalar DL (Ledger and Auditor) and Scalar DL Java Client SDK.
 
-1. Build sample contract.
+1. Build the sample contract.
    ```console
    # ./gradlew assemble
    ```

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -56,12 +56,15 @@ First, you need to install the following tools used in this guide.
 
 1. Start minikube with docker driver.
    ```console
-   $ minikube start --driver=docker
+   minikube start --driver=docker
    ```
 
 1. Check the status of the minikube and pods.
    ```console
-   $ kubectl get pod -A
+   kubectl get pod -A
+   ```
+   [Command execution result]
+   ```console
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
    kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
    kube-system   etcd-minikube                      1/1     Running   1 (20h ago)   21h
@@ -79,7 +82,7 @@ We use Apache Cassandra as the backend storage of Scalar DL Ledger. We start a C
 
 1. Start a Cassandra container on the Docker Network `minikube`.
    ```console
-   $ docker run --name cassandra-ledger --network minikube -d cassandra:3.11
+   docker run --name cassandra-ledger --network minikube -d cassandra:3.11
    ```
    * Note: 
        * The Docker Network `minikube` was created by the `minikube start --driver=docker` command that we ran in Step 2.
@@ -89,14 +92,20 @@ We use Apache Cassandra as the backend storage of Scalar DL Ledger. We start a C
 
 1. Check if the Cassandra container is running.
    ```console
-   $ docker ps -f name=cassandra-ledger
+   docker ps -f name=cassandra-ledger
+   ```
+   [Command execution result]
+   ```console
    CONTAINER ID   IMAGE            COMMAND                  CREATED         STATUS         PORTS                                         NAMES
    6dceab0007c8   cassandra:3.11   "docker-entrypoint.s…"   2 minutes ago   Up 2 minutes   7000-7001/tcp, 7199/tcp, 9042/tcp, 9160/tcp   cassandra-ledger
    ```
 
 1. Check the status of Cassandra.
    ```console
-   $ docker exec -t cassandra-ledger cqlsh -e "show version"
+   docker exec -t cassandra-ledger cqlsh -e "show version"
+   ```
+   [Command execution result]
+   ```console
    [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
    ```
    It may take a while to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
@@ -107,7 +116,7 @@ We will create some configuration files and key/certificate files locally. So, c
 
 1. Create working directory.
    ```console
-   $ mkdir ~/scalardl-test
+   mkdir ~/scalardl-test
    ```
 
 ## Step 5. Create key/certificate files
@@ -117,13 +126,15 @@ We will create some configuration files and key/certificate files locally. So, c
 
 1. Create `certs/` directory.
    ```console
-   $ mkdir ~/scalardl-test/certs/
-   $ cd ~/scalardl-test/certs/
+   mkdir ~/scalardl-test/certs/
+   ```
+   ```console
+   cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
    ```console
-   $ cat << EOF > ~/scalardl-test/certs/ledger.json
+   cat << EOF > ~/scalardl-test/certs/ledger.json
    {
        "CN": "ledger",
        "hosts": ["example.com","*.example.com"],
@@ -146,7 +157,7 @@ We will create some configuration files and key/certificate files locally. So, c
 
 1. Create a JSON file that includes Client information.
    ```console
-   $ cat << EOF > ~/scalardl-test/certs/client.json
+   cat << EOF > ~/scalardl-test/certs/client.json
    {
        "CN": "client",
        "hosts": ["example.com","*.example.com"],
@@ -169,17 +180,20 @@ We will create some configuration files and key/certificate files locally. So, c
 
 1. Create key/certificate files for the Ledger.
    ```console
-   $ cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
+   cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Client.
    ```console
-   $ cfssl selfsign "" ./client.json | cfssljson -bare client
+   cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
    ```console
-   $ ls -1
+   ls -1
+   ```
+   [Command execution result]
+   ```console
    client-key.pem
    client.csr
    client.json
@@ -198,22 +212,22 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
 
 1. Change working directory from `certs/`.
    ```console
-   $ cd ~/scalardl-test/
+   cd ~/scalardl-test/
    ```
 
 1. Add the Scalar Helm Repository.
    ```console
-   $ helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
+   helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create secret resource `reg-docker-secrets` to pull the Scalar DL container images from GitHub Packages.
    ```console
-   $ kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
+   kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
    ```
 
 1. Create a custom value file for Scalar DL Schema Loader (schema-loader-ledger-custom-values.yaml).
    ```console
-   $ cat << EOF > schema-loader-ledger-custom-values.yaml
+   cat << EOF > schema-loader-ledger-custom-values.yaml
    schemaLoading:
      database: "cassandra"
      contactPoints: "cassandra-ledger"
@@ -225,12 +239,15 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
 
 1. Deploy the Scalar DL Schema Loader.
    ```console
-   $ helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
+   helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check if the Scalar DL Schema Loader pod is deployed and completed.
    ```console
-   $ kubectl get pod
+   kubectl get pod
+   ```
+   [Command execution result]
+   ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    schema-loader-ledger-schema-loading-cscr4   0/1     Completed   0          19s
    ```
@@ -240,7 +257,7 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
 
 1. Create a custom value file for Scalar DL Ledger (scalardl-ledger-custom-values.yaml).
    ```console
-   $ cat << EOF > scalardl-ledger-custom-values.yaml
+   cat << EOF > scalardl-ledger-custom-values.yaml
    envoy:
      service:
        type: "NodePort"
@@ -256,7 +273,8 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
    ```
    * Note:
        * If you want to access Scalar DL Ledger from 127.0.0.1 (your localhost), set `LoadBalancer` to `envoy.service.type` like the following.
-         ```yaml
+         ```console
+         cat << EOF > scalardl-ledger-custom-values.yaml
          envoy:
            service:
              type: "LoadBalancer"
@@ -268,9 +286,11 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
              dbUsername: "cassandra"
              dbPassword: "cassandra"
              ledgerProofEnabled: true
+         EOF
          ```
        * If you want to use Scalar DL Auditor, set `true` to `ledger.scalarLedgerConfiguration.ledgerAuditorEnabled`.
-         ```yaml
+         ```console
+         cat << EOF > scalardl-ledger-custom-values.yaml
          envoy:
            service:
              type: "NodePort"
@@ -283,21 +303,25 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
              dbPassword: "cassandra"
              ledgerProofEnabled: true
              ledgerAuditorEnabled: true
+         EOF
          ```
 
 1. Create secret resource `ledger-keys`.
    ```console
-   $ kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
+   kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Deploy the Scalar DL Ledger.
    ```console
-   $ helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
+   helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Check if the Scalar DL Ledger pods are deployed.
    ```console
-   $ kubectl get pod
+   kubectl get pod
+   ```
+   [Command execution result]
+   ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    scalardl-ledger-envoy-84dcc85b6d-bs2xl      1/1     Running     0          5m55s
    scalardl-ledger-envoy-84dcc85b6d-btc8c      1/1     Running     0          5m55s
@@ -311,7 +335,10 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
 
 1. Check if the Scalar DL Ledger Services are deployed.
    ```console
-   $ kubectl get svc
+   kubectl get svc
+   ```
+   [Command execution result]
+   ```console
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
    kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                           21h
    scalardl-ledger-envoy           NodePort    10.98.162.209    <none>        50051:31452/TCP,50052:31118/TCP   6m23s
@@ -324,11 +351,14 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
 1. (Optional) If you set `LoadBalancer` to `envoy.service.type` in the `scalardl-ledger-custom-values.yaml`, you can access Scalar DL Ledger from 127.0.0.1.  
    To expose the `scalardl-ledger-envoy` service as your local `127.0.0.1:50051` and `127.0.0.1:50052`, open another terminal, and run the `minikube tunnel` command.
    ```console
-   $ minikube tunnel
+   minikube tunnel
    ```
    After running the `minikube tunnel` command, you can see the  EXTERNAL-IP of the `scalardl-ledger-envoy` as  `127.0.0.1`.
    ```console
-   $ kubectl get svc scalardl-ledger-envoy
+   kubectl get svc scalardl-ledger-envoy
+   ```
+   [Command execution result]
+   ```console
    NAME                    TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
    scalardl-ledger-envoy   LoadBalancer   10.98.162.209   127.0.0.1     50051:31452/TCP,50052:31118/TCP   9m7s
    ```
@@ -339,12 +369,12 @@ We will use certificate files in the Client container. So, we mount ~/scalardl-t
 
 1. Start a Client container on the `minikube` network.
    ```console
-   $ docker run -d --name scalardl-client --hostname scalardl-client -v ~/scalardl-test/certs:/certs --network minikube --entrypoint sleep ubuntu:20.04 inf
+   docker run -d --name scalardl-client --hostname scalardl-client -v ~/scalardl-test/certs:/certs --network minikube --entrypoint sleep ubuntu:20.04 inf
    ```
 
 1. Check if the Client container is running.
    ```console
-   $ docker ps -f name=scalardl-client
+   docker ps -f name=scalardl-client
    ```
 
 ## Step 9. Run Scalar DL sample contracts in the Client container
@@ -353,31 +383,42 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Run bash in the Client container.
    ```console
-   $ docker exec -it scalardl-client bash
+   docker exec -it scalardl-client bash
    ```
    After this step, run each command in the Client container.  
 
 1. Install Git, OpenJDK 8, curl, and unzip in the Client container.
    ```console
-   # apt update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt install -y git openjdk-8-jdk curl unzip
+   apt update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt install -y git openjdk-8-jdk curl unzip
    ```
 
 1. Clone Scalar DL Java Client SDK git repository.
    ```console
-   # git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
+   git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change directory to `scalardl-java-client-sdk/`.
    ```console
-   # cd scalardl-java-client-sdk/ 
-   # pwd
+   cd scalardl-java-client-sdk/ 
+   ```
+   ```console
+   pwd
+   ```
+   [Command execution result]
+   ```console
+
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+   ```console
+   git checkout -b v3.4.0 refs/tags/v3.4.0
    ```
-   # git checkout -b v3.4.0 refs/tags/v3.4.0
-   # git branch
+   ```console
+   git branch
+   ```
+   [Command execution result]
+   ```console
      master
    * v3.4.0
    ```
@@ -385,23 +426,23 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Build the sample contract.
    ```console
-   # ./gradlew assemble
+   ./gradlew assemble
    ```
 
 1. Download CLI tools of Scalar DL from [Scalar DL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
    ```console
-   # curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.4.0/scalardl-java-client-sdk-3.4.0.zip
+   curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.4.0/scalardl-java-client-sdk-3.4.0.zip
    ```
    You need to use the same version of CLI tools and Scalar DL Ledger.
 
 1. Unzip the scalardl-java-client-sdk-3.4.0.zip file.
    ```console
-   # unzip ./scalardl-java-client-sdk-3.4.0.zip
+   unzip ./scalardl-java-client-sdk-3.4.0.zip
    ```
 
 1. Create a configuration file (client.properties) to access Scalar DL Ledger on minikube.
    ```console
-   # cat << EOF > client.properties
+   cat << EOF > client.properties
    scalar.dl.client.server.host=minikube
    scalar.dl.client.server.port=31452
    scalar.dl.client.server.privileged_port=31118
@@ -413,7 +454,10 @@ The following explains the minimum steps. If you want to know more details about
    * Note:
        * You need to specify the port number (NodePort) of `scalardl-ledger-envoy` (Kubernetes Service Resource) as a value of `scalar.dl.client.server.port` and `scalar.dl.client.server.privileged_port` in the `client.properties`. You can confirm the port number of `scalardl-ledger-envoy` with the `kubectl get svc scalardl-ledger-envoy` command.
          ```console
-         $ kubectl get svc scalardl-ledger-envoy
+         kubectl get svc scalardl-ledger-envoy
+         ```
+         [Command execution result]
+         ```console
          NAME                    TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
          scalardl-ledger-envoy   NodePort   10.98.162.209   <none>        50051:31452/TCP,50052:31118/TCP   21m
          ```
@@ -421,28 +465,31 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Register the certificate file of client.
    ```console
-   # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./client.properties
+   ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
    ```console
-   # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
+   ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
    ```console
-   # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
+   ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Execute the contract `StateUpdater`.
    ```console
-   # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
+   ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
    ```console
-   # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
+   ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
+   ```
+   [Command execution result]
+   ```console
    {
        "status_code": "OK",
        "output": {
@@ -468,7 +515,10 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Execute a validation request of the asset.
    ```console
-   # ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
+   ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
+   ```
+   [Command execution result]
+   ```console
    {
        "status_code": "OK",
        "Ledger": {
@@ -486,7 +536,10 @@ The following explains the minimum steps. If you want to know more details about
        * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
        * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.
          ```console
-         # ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
+         ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
+         ```
+         [Command execution result]
+         ```console
          {
              "status_code": "INVALID_OUTPUT",
              "Ledger": {
@@ -508,22 +561,24 @@ After completing the Scalar DL Ledger tests on minikube, remove all resources.
 
 1. Uninstall Scalar DL Schema Loader and Ledger from minikube.
    ```console
-   $ helm uninstall schema-loader-ledger scalardl-ledger
+   helm uninstall schema-loader-ledger scalardl-ledger
    ```
 
 1. Stop and remove containers (Cassandra and Client).
    ```
-   $ docker rm $(docker kill scalardl-client cassandra-ledger)
+   docker rm $(docker kill scalardl-client cassandra-ledger)
    ```
 
 1. Remove working directory and sample files (configuration file, key, and certificate).
    ```console
-   $ cd ~
-   $ rm -rf ~/scalardl-test/
+   cd ~
+   ```
+   ```console
+   rm -rf ~/scalardl-test/
    ```
 
 1. Delete minikube.
    ```console
-   $ minikube delete --all
+   minikube delete --all
    ```
 

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -77,7 +77,7 @@ We need to start the Cassandra container as backend storage of the Scalar DL Led
 
 ## Step 3. Start Cassandra container
 
-In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledger, it will be started on the same network of Scalar DL Ledger (Pod on minikube) to enable proper communication.
+In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledger, it will be started on the same network of Scalar DL Ledger (pod on minikube) to enable proper communication.
 
 1. Start Cassandra container on the Docker Network `minikube`.
    ```console
@@ -107,7 +107,7 @@ In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledge
 
 In this guide, we will create some configuration files and key/certificate files locally. So, create a working directory for it.
 
-1. Create working dir.
+1. Create working directory.
    ```console
    $ mkdir ~/scalardl-test
    ```
@@ -301,7 +301,7 @@ In this section, we will deploy Scalar DL Ledger on minikube by using Helm Chart
    $ helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
-1. Check the Scalar DL Ledger Pods are deployed.
+1. Check the Scalar DL Ledger pods are deployed.
    ```console
    $ kubectl get pod
    NAME                                        READY   STATUS      RESTARTS   AGE
@@ -313,7 +313,7 @@ In this section, we will deploy Scalar DL Ledger on minikube by using Helm Chart
    scalardl-ledger-ledger-57dcb56f58-mtrfc     1/1     Running     0          5m55s
    schema-loader-ledger-schema-loading-cscr4   0/1     Completed   0          8m16s
    ```
-   If the Scalar DL Ledger Pods are deployed properly, you can see the STATUS are `Running`.  
+   If the Scalar DL Ledger pods are deployed properly, you can see the STATUS are `Running`.  
 
 1. Check the Scalar DL Ledger Services are deployed.
    ```console
@@ -525,7 +525,7 @@ After completing the Scalar DL Ledger tests on minikube, remove all resources.
    $ docker rm $(docker kill scalardl-client cassandra-ledger)
    ```
 
-1. Remove working dir and sample files (configuration file, key, and certificate).
+1. Remove working directory and sample files (configuration file, key, and certificate).
    ```console
    $ cd ~
    $ rm -rf ~/scalardl-test/

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -5,7 +5,7 @@ This document explains how to get started with Scalar DL Ledger using the Helm C
 ## Requirement
 
 * You need the privileges to pull the Scalar DL containers (`scalar-ledger` and `scalardl-schema-loader`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).  
-* You must create a Github Personal Access Token (PAT) with `read:packages` scope using the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above containers.
+* You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above containers.
 
 ## Tools
 
@@ -85,7 +85,7 @@ In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledge
    ```
    * Note: 
        * The Docker Network `minikube` was created by the `minikube start --driver=docker` command that we ran in Step 2.
-       * You need to specify the Cassandra version (tag) that the Scalar DB that is used in Scalar DL supports.
+       * Scalar DL uses Scalar DB in its internal. You need to specify the Scalar DB-supported Cassandra version (tag).
            * You can see the Scalar DB version of Scalar DL from the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
            * Also, you can see the Scalar DB-supported Cassandra versions (tag) in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
@@ -101,7 +101,7 @@ In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledge
    $ docker exec -t cassandra-ledger cqlsh -e "show version"
    [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
    ```
-   It may take some time to start Cassandra in the container. So, if this command return error, wait a moment and then re-run it.
+   It may take some time to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
 
 ## Step 4. Create working directory
 
@@ -229,7 +229,7 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
 
 1. Deploy Scalar DL Schema Loader.
    ```console
-   $ helm install schema-loader-ledger scalar-labs/schema-loading  -f ./schema-loader-ledger-custom-values.yaml
+   $ helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check the Scalar DL Schema Loader pod is deployed and completed.
@@ -325,7 +325,7 @@ In this section, we will deploy Scalar DL Ledger on minikube by using Helm Chart
    scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP     6m23s
    scalardl-ledger-metrics         ClusterIP   10.110.55.239    <none>        8080/TCP                          6m23s
    ```
-   If the Scalar DL Ledger Services are deployed properly, you can see a private IP address in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
+   If the Scalar DL Ledger Services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
 
 1. (Optional) If you set `LoadBalancer` to `envoy.service.type` in the `scalardl-ledger-custom-values.yaml`, you can access Scalar DL Ledger from 127.0.0.1.  
    To expose the `scalardl-ledger-envoy` service as your local `127.0.0.1:50051` and `127.0.0.1:50052`, open another terminal, and run the `minikube tunnel` command.
@@ -354,7 +354,7 @@ We will use certificate files in the Client container. So, mount ~/scalardl-test
    $ docker ps -f name=scalardl-client
    ```
 
-## Step 9. Run Scalar DL sample contract in the Client container
+## Step 9. Run Scalar DL sample contracts in the Client container
 
 In this section, we will prepare and run the Scalar DL sample contract.  
 
@@ -392,7 +392,7 @@ This guide explains the minimum steps. If you want to know more details about Sc
    ```
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of Scalar DL Ledger and Scalar DL Java Client SDK.
 
-1. Build sample contract.
+1. Build the sample contract.
    ```console
    # ./gradlew assemble
    ```

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -1,11 +1,11 @@
 # Getting Started with Helm Charts (Scalar DL Ledger)
 
-This document explains how to get started with Scalar DL Ledger by using the Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
+This document explains how to get started with Scalar DL Ledger using the Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
 
 ## Requirement
 
 * You need the privileges to pull the Scalar DL containers (`scalar-ledger` and `scalardl-schema-loader`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).  
-* You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token), to pull the above containers.
+* You must create a Github Personal Access Token (PAT) with `read:packages` scope using the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above containers.
 
 ## Tools
 
@@ -40,7 +40,7 @@ On the Docker Network (named minikube)
 
 ## Step 1. Install tools
 
-First, you need to install the following tools that will be used in this guide.  
+First, you need to install the following tools used in this guide.
 
 1. Install the Docker according to the [Docker document](https://docs.docker.com/engine/install/)  
 
@@ -54,14 +54,14 @@ First, you need to install the following tools that will be used in this guide.
 
 ## Step 2. Start minikube with docker driver
 
-In the after steps, we will create a Cassandra container as backend storage of the Scalar DL Ledger, on the same Docker Network as minikube. So, you need to start minikube with docker driver.  
+We need to start the Cassandra container as backend storage of the Scalar DL Ledger on the same network of the minikube, so you need to be started the minikube with docker driver.
 
 1. Start minikube with docker driver.
    ```console
    $ minikube start --driver=docker
    ```
 
-1. Check minikube and the pods are running.
+1. Check the status of the minikube and pods.
    ```console
    $ kubectl get pod -A
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
@@ -73,7 +73,7 @@ In the after steps, we will create a Cassandra container as backend storage of t
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
-   If the minikube started properly, you can see some pods in the kube-system namespace are `Running`.  
+   If the minikube started properly, you can see some pods are `Running` in the kube-system namespace.
 
 ## Step 3. Start Cassandra container
 
@@ -86,10 +86,10 @@ In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledge
    * Note: 
        * The Docker Network `minikube` was created by the `minikube start --driver=docker` command that we ran in Step 2.
        * You need to specify the Cassandra version (tag) that the Scalar DB that is used in Scalar DL supports.
-           * You can see the version of Scalar DB that is used in each Scalar DL in the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
-           * Also, you can see the Cassandra version that is supported by Scalar DB in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
+           * You can see the Scalar DB version of Scalar DL from the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
+           * Also, you can see the Scalar DB-supported Cassandra versions (tag) in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
-1. Check the Cassandra container is running.
+1. Check the status of the Cassandra container.
    ```console
    $ docker ps -f name=cassandra-ledger
    CONTAINER ID   IMAGE            COMMAND                  CREATED         STATUS         PORTS                                         NAMES
@@ -105,7 +105,7 @@ In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledge
 
 ## Step 4. Create working directory
 
-In this guide, we will create some configuration files and key/certificate files in your local, after this step. So, create a working dir first.  
+In this guide, we will create some configuration files and key/certificate files locally. So, create a working directory for it.
 
 1. Create working dir.
    ```console
@@ -119,7 +119,7 @@ In this section, we will create key/certificate files for Ledger and Client.
 * Note: 
     * In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
-1. Create `certs/` dir.
+1. Create `certs/` directory.
    ```console
    $ mkdir ~/scalardl-test/certs/
    $ cd ~/scalardl-test/certs/
@@ -171,12 +171,12 @@ In this section, we will create key/certificate files for Ledger and Client.
    EOF
    ```
 
-1. Create key/certificate files of the Ledger.
+1. Create key/certificate files for the Ledger.
    ```console
    $ cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
-1. Create key/certificate files of the Client.
+1. Create key/certificate files for the Client.
    ```console
    $ cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
@@ -200,12 +200,12 @@ In this section, we will create key/certificate files for Ledger and Client.
 In this section, we will deploy Scalar DL Schema Loader on minikube by using Helm Charts.  
 The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in the Cassandra.  
 
-1. Change working dir from `certs/`.
+1. Change working directory from `certs/`.
    ```console
    $ cd ~/scalardl-test/
    ```
 
-1. Add Scalar's Helm Repository.
+1. Add scalar helm repository.
    ```console
    $ helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
@@ -232,13 +232,13 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
    $ helm install schema-loader-ledger scalar-labs/schema-loading  -f ./schema-loader-ledger-custom-values.yaml
    ```
 
-1. Check the Scalar DL Schema Loader Pod is deployed and completed.
+1. Check the Scalar DL Schema Loader pod is deployed and completed.
    ```console
    $ kubectl get pod
    NAME                                        READY   STATUS      RESTARTS   AGE
    schema-loader-ledger-schema-loading-cscr4   0/1     Completed   0          19s
    ```
-   If the Scalar DL Schema Loader Pod is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
+   If the Scalar DL Schema Loader pod is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
 
 ## Step 7. Deploy Scalar DL Ledger on minikube by Helm Charts
 
@@ -376,7 +376,7 @@ This guide explains the minimum steps. If you want to know more details about Sc
    # git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
-1. Change dir to `scalardl-java-client-sdk/`.
+1. Change directory to `scalardl-java-client-sdk/`.
    ```console
    # cd scalardl-java-client-sdk/ 
    # pwd

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -1,0 +1,538 @@
+# Getting Started with Helm Charts (Scalar DL Ledger)
+
+This document explains how to get started with Scalar DL Ledger by using the Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
+
+## Requirement
+
+* You need the privileges to pull the Scalar DL containers (`scalar-ledger` and `scalardl-schema-loader`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).  
+* You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token), to pull the above containers.
+
+## Tools
+
+In this guide, we will use the following tools for testing.  
+
+1. Docker
+1. minikube
+1. kubectl
+1. Helm
+1. cfssl / cfssljson
+
+## Environment
+
+In this guide, we will create the following environment in your local by using Docker and minikube.  
+
+```
+On the Docker Network (named minikube)
+
+                   +-----------------------+
+  +-----------+    | +------------------+  |    +-----------+
+  |           |    | | Scalar DL Ledger |  |    |           |
+  |  Client   |    | +------------------+  |    | Cassandra |
+  | Container |    |                       |    | Container |
+  |           |    | Kubernetes (minikube) |    |           |
+  +-----+-----+    +-----------+-----------+    +-----+-----+
+        |                      |                      |
+*-------+----------------------+----------------------+-------*
+             ------->                     ------->
+               gRPC                    Cassandra Driver
+```
+
+
+## Step 1. Install tools
+
+First, you need to install the following tools that will be used in this guide.  
+
+1. Install the Docker according to the [Docker document](https://docs.docker.com/engine/install/)  
+
+1. Install the minikube according to the [minikube document](https://minikube.sigs.k8s.io/docs/start/)  
+
+1. Install the kubectl according to the [Kubernetes document](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)  
+
+1. Install the helm command according to the [Helm document](https://helm.sh/docs/intro/install/)  
+
+1. Install the cfssl and cfssljson according to the [CFSSL document](https://github.com/cloudflare/cfssl)
+
+## Step 2. Start minikube with docker driver
+
+In the after steps, we will create a Cassandra container as backend storage of the Scalar DL Ledger, on the same Docker Network as minikube. So, you need to start minikube with docker driver.  
+
+1. Start minikube with docker driver.
+   ```console
+   $ minikube start --driver=docker
+   ```
+
+1. Check minikube and the pods are running.
+   ```console
+   $ kubectl get pod -A
+   NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
+   kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
+   kube-system   etcd-minikube                      1/1     Running   1 (20h ago)   21h
+   kube-system   kube-apiserver-minikube            1/1     Running   1 (20h ago)   21h
+   kube-system   kube-controller-manager-minikube   1/1     Running   1 (20h ago)   21h
+   kube-system   kube-proxy-gsl6j                   1/1     Running   1 (20h ago)   21h
+   kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
+   kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
+   ```
+   If the minikube started properly, you can see some pods in the kube-system namespace are `Running`.  
+
+## Step 3. Start Cassandra container
+
+In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledger, it will be started on the same network of Scalar DL Ledger (Pod on minikube) to enable proper communication.
+
+1. Start Cassandra container on the Docker Network `minikube`.
+   ```console
+   $ docker run --name cassandra-ledger --network minikube -d cassandra:3.11
+   ```
+   * Note: 
+       * The Docker Network `minikube` was created by the `minikube start --driver=docker` command that we ran in Step 2.
+       * You need to specify the Cassandra version (tag) that the Scalar DB that is used in Scalar DL supports.
+           * You can see the version of Scalar DB that is used in each Scalar DL in the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
+           * Also, you can see the Cassandra version that is supported by Scalar DB in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
+
+1. Check the Cassandra container is running.
+   ```console
+   $ docker ps -f name=cassandra-ledger
+   CONTAINER ID   IMAGE            COMMAND                  CREATED         STATUS         PORTS                                         NAMES
+   6dceab0007c8   cassandra:3.11   "docker-entrypoint.s…"   2 minutes ago   Up 2 minutes   7000-7001/tcp, 7199/tcp, 9042/tcp, 9160/tcp   cassandra-ledger
+   ```
+
+1. Check the status of Cassandra.
+   ```console
+   $ docker exec -t cassandra-ledger cqlsh -e "show version"
+   [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
+   ```
+   It may take some time to start Cassandra in the container. So, if this command return error, wait a moment and then re-run it.
+
+## Step 4. Create working directory
+
+In this guide, we will create some configuration files and key/certificate files in your local, after this step. So, create a working dir first.  
+
+1. Create working dir.
+   ```console
+   $ mkdir ~/scalardl-test
+   ```
+
+## Step 5. Create key/certificate files
+
+In this section, we will create key/certificate files for Ledger and Client.  
+
+* Note: 
+    * In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
+
+1. Create `certs/` dir.
+   ```console
+   $ mkdir ~/scalardl-test/certs/
+   $ cd ~/scalardl-test/certs/
+   ```
+
+1. Create a JSON file that includes Ledger information.
+   ```console
+   $ cat << EOF > ~/scalardl-test/certs/ledger.json
+   {
+       "CN": "ledger",
+       "hosts": ["example.com","*.example.com"],
+       "key": {
+           "algo": "ecdsa",
+           "size": 256
+       },
+       "names": [
+           {
+               "O": "ledger",
+               "OU": "test team",
+               "L": "Shinjuku",
+               "ST": "Tokyo",
+               "C": "JP"
+           }
+       ]
+   }
+   EOF
+   ```
+
+1. Create a JSON file that includes Client information.
+   ```console
+   $ cat << EOF > ~/scalardl-test/certs/client.json
+   {
+       "CN": "client",
+       "hosts": ["example.com","*.example.com"],
+       "key": {
+           "algo": "ecdsa",
+           "size": 256
+       },
+       "names": [
+           {
+               "O": "client",
+               "OU": "test team",
+               "L": "Shinjuku",
+               "ST": "Tokyo",
+               "C": "JP"
+           }
+       ]
+   }
+   EOF
+   ```
+
+1. Create key/certificate files of the Ledger.
+   ```console
+   $ cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
+   ```
+
+1. Create key/certificate files of the Client.
+   ```console
+   $ cfssl selfsign "" ./client.json | cfssljson -bare client
+   ```
+
+1. Confirm key/certificate files are created.
+   ```console
+   $ ls -1
+   client-key.pem
+   client.csr
+   client.json
+   client.pem
+   ledger-key.pem
+   ledger.csr
+   ledger.json
+   ledger.pem
+   ```
+
+
+## Step 6. Create DB schema for Scalar DL Ledger by Helm Charts
+
+In this section, we will deploy Scalar DL Schema Loader on minikube by using Helm Charts.  
+The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in the Cassandra.  
+
+1. Change working dir from `certs/`.
+   ```console
+   $ cd ~/scalardl-test/
+   ```
+
+1. Add Scalar's Helm Repository.
+   ```console
+   $ helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
+   ```
+
+1. Create secret resource `reg-docker-secrets` to pull the Scalar DL container images from GitHub Packages.
+   ```console
+   $ kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
+   ```
+
+1. Create a custom value file for Scalar DL Schema Loader (schema-loader-ledger-custom-values.yaml).
+   ```console
+   $ cat << EOF > schema-loader-ledger-custom-values.yaml
+   schemaLoading:
+     database: "cassandra"
+     contactPoints: "cassandra-ledger"
+     username: "cassandra"
+     password: "cassandra"
+     schemaType: "ledger"
+   EOF
+   ```
+
+1. Deploy Scalar DL Schema Loader.
+   ```console
+   $ helm install schema-loader-ledger scalar-labs/schema-loading  -f ./schema-loader-ledger-custom-values.yaml
+   ```
+
+1. Check the Scalar DL Schema Loader Pod is deployed and completed.
+   ```console
+   $ kubectl get pod
+   NAME                                        READY   STATUS      RESTARTS   AGE
+   schema-loader-ledger-schema-loading-cscr4   0/1     Completed   0          19s
+   ```
+   If the Scalar DL Schema Loader Pod is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
+
+## Step 7. Deploy Scalar DL Ledger on minikube by Helm Charts
+
+In this section, we will deploy Scalar DL Ledger on minikube by using Helm Charts.  
+
+1. Create a custom value file for Scalar DL Ledger (scalardl-ledger-custom-values.yaml).
+   ```console
+   $ cat << EOF > scalardl-ledger-custom-values.yaml
+   envoy:
+     service:
+       type: "NodePort"
+   
+   ledger:
+     scalarLedgerConfiguration:
+       dbStorage: "cassandra"
+       dbContactPoints: "cassandra-ledger"
+       dbUsername: "cassandra"
+       dbPassword: "cassandra"
+       ledgerProofEnabled: true
+   EOF
+   ```
+   * Note:
+       * If you want to access Scalar DL Ledger from 127.0.0.1 (your localhost), set `LoadBalancer` to `envoy.service.type` like the following.
+         ```yaml
+         envoy:
+           service:
+             type: "LoadBalancer"
+         
+         ledger:
+           scalarLedgerConfiguration:
+             dbStorage: "cassandra"
+             dbContactPoints: "cassandra-ledger"
+             dbUsername: "cassandra"
+             dbPassword: "cassandra"
+             ledgerProofEnabled: true
+         ```
+       * If you want to use Scalar DL Auditor, set `true` to `ledger.scalarLedgerConfiguration.ledgerAuditorEnabled`.
+         ```yaml
+         envoy:
+           service:
+             type: "NodePort"
+         
+         ledger:
+           scalarLedgerConfiguration:
+             dbStorage: "cassandra"
+             dbContactPoints: "cassandra-ledger"
+             dbUsername: "cassandra"
+             dbPassword: "cassandra"
+             ledgerProofEnabled: true
+             ledgerAuditorEnabled: true
+         ```
+
+1. Create secret resource `ledger-keys`.
+   ```console
+   $ kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
+   ```
+
+1. Deploy Scalar DL Ledger.
+   ```console
+   $ helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
+   ```
+
+1. Check the Scalar DL Ledger Pods are deployed.
+   ```console
+   $ kubectl get pod
+   NAME                                        READY   STATUS      RESTARTS   AGE
+   scalardl-ledger-envoy-84dcc85b6d-bs2xl      1/1     Running     0          5m55s
+   scalardl-ledger-envoy-84dcc85b6d-btc8c      1/1     Running     0          5m55s
+   scalardl-ledger-envoy-84dcc85b6d-c2nnp      1/1     Running     0          5m55s
+   scalardl-ledger-ledger-57dcb56f58-dgcjs     1/1     Running     0          5m55s
+   scalardl-ledger-ledger-57dcb56f58-fdnvm     1/1     Running     0          5m55s
+   scalardl-ledger-ledger-57dcb56f58-mtrfc     1/1     Running     0          5m55s
+   schema-loader-ledger-schema-loading-cscr4   0/1     Completed   0          8m16s
+   ```
+   If the Scalar DL Ledger Pods are deployed properly, you can see the STATUS are `Running`.  
+
+1. Check the Scalar DL Ledger Services are deployed.
+   ```console
+   $ kubectl get svc
+   NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
+   kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                           21h
+   scalardl-ledger-envoy           NodePort    10.98.162.209    <none>        50051:31452/TCP,50052:31118/TCP   6m23s
+   scalardl-ledger-envoy-metrics   ClusterIP   10.105.122.178   <none>        9001/TCP                          6m23s
+   scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP     6m23s
+   scalardl-ledger-metrics         ClusterIP   10.110.55.239    <none>        8080/TCP                          6m23s
+   ```
+   If the Scalar DL Ledger Services are deployed properly, you can see a private IP address in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
+
+1. (Optional) If you set `LoadBalancer` to `envoy.service.type` in the `scalardl-ledger-custom-values.yaml`, you can access Scalar DL Ledger from 127.0.0.1.  
+   To expose the `scalardl-ledger-envoy` service as your local `127.0.0.1:50051` and `127.0.0.1:50052`, open another terminal, and run the `minikube tunnel` command.
+   ```console
+   $ minikube tunnel
+   ```
+   After running the `minikube tunnel` command, you can see the  EXTERNAL-IP of the `scalardl-ledger-envoy` as  `127.0.0.1`.
+   ```console
+   $ kubectl get svc scalardl-ledger-envoy
+   NAME                    TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
+   scalardl-ledger-envoy   LoadBalancer   10.98.162.209   127.0.0.1     50051:31452/TCP,50052:31118/TCP   9m7s
+   ```
+
+## Step 8. Start Client container
+
+In this section, we will create a Client container to run a sample contract of Scalar DL.  
+We will use certificate files in the Client container. So, mount ~/scalardl-test/certs to the Client container.  
+
+1. Start the Client container on the Docker Network `minikube`.
+   ```console
+   $ docker run -d --name scalardl-client --hostname scalardl-client -v ~/scalardl-test/certs:/certs --network minikube --entrypoint sleep ubuntu:20.04 inf
+   ```
+
+1. Check the Client container is running.
+   ```console
+   $ docker ps -f name=scalardl-client
+   ```
+
+## Step 9. Run Scalar DL sample contract in the Client container
+
+In this section, we will prepare and run the Scalar DL sample contract.  
+
+This guide explains the minimum steps. If you want to know more details about Scalar DL and the contract, please refer to the [Getting Started with Scalar DL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
+
+1. Run bash in the Client container.
+   ```console
+   $ docker exec -it scalardl-client bash
+   ```
+   After this step, run each command in the Client container.  
+
+1. Install Git, OpenJDK 8, curl, and unzip in the Client container.
+   ```console
+   # apt update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt install -y git openjdk-8-jdk curl unzip
+   ```
+
+1. Clone Scalar DL Java Client SDK's git repository.
+   ```console
+   # git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
+   ```
+
+1. Change dir to `scalardl-java-client-sdk/`.
+   ```console
+   # cd scalardl-java-client-sdk/ 
+   # pwd
+   /scalardl-java-client-sdk
+   ```
+
+1. Change branch to arbitrary version.
+   ```
+   # git checkout -b v3.4.0 refs/tags/v3.4.0
+   # git branch
+     master
+   * v3.4.0
+   ```
+   If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of Scalar DL Ledger and Scalar DL Java Client SDK.
+
+1. Build sample contract.
+   ```console
+   # ./gradlew assemble
+   ```
+
+1. Download CLI tools of Scalar DL from [Scalar DL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+   ```console
+   # curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.4.0/scalardl-java-client-sdk-3.4.0.zip
+   ```
+   You need to use the same version of CLI tools and Scalar DL Ledger.
+
+1. Unzip the scalardl-java-client-sdk-3.4.0.zip file.
+   ```console
+   # unzip ./scalardl-java-client-sdk-3.4.0.zip
+   ```
+
+1. Create a configuration file (client.properties) to access Scalar DL Ledger on minikube.
+   ```console
+   # cat << EOF > client.properties
+   scalar.dl.client.server.host=minikube
+   scalar.dl.client.server.port=31452
+   scalar.dl.client.server.privileged_port=31118
+   scalar.dl.client.cert_holder_id=client
+   scalar.dl.client.cert_path=../certs/client.pem
+   scalar.dl.client.private_key_path=../certs/client-key.pem
+   EOF
+   ```
+   * Note:
+       * You need to specify the port number (NodePort) of `scalardl-ledger-envoy` (Kubernetes Service Resource) as a value of `scalar.dl.client.server.port` and `scalar.dl.client.server.privileged_port` in the `client.properties`. You can confirm the port number of `scalardl-ledger-envoy` with the `kubectl get svc scalardl-ledger-envoy` command.
+         ```console
+         $ kubectl get svc scalardl-ledger-envoy
+         NAME                    TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
+         scalardl-ledger-envoy   NodePort   10.98.162.209   <none>        50051:31452/TCP,50052:31118/TCP   21m
+         ```
+         In this case, you need to specify `31452` to `scalar.dl.client.server.port` and `31118` to `scalar.dl.client.server.privileged_port` in the `client.properties` file.
+
+1. Register certificate file of client.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./client.properties
+   ```
+
+1. Register sample contract `StateUpdater`.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
+   ```
+
+1. Register sample contract `StateReader`.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
+   ```
+
+1. Execute contract `StateUpdater`.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
+   ```
+   This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
+
+1. Execute contract `StateReader`.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
+   {
+       "status_code": "OK",
+       "output": {
+           "age": 0,
+           "input": {
+           },
+           "output": {
+               "state": 3
+           },
+           "contract_id": "client/1/StateUpdater",
+           "argument": {
+               "asset_id": "test_asset",
+               "state": 3,
+               "nonce": "04c0cc2f-8f78-4ab3-afaa-ce8150af2c5b"
+           },
+           "signature": "MEYCIQD0ixVIP0Qr/ujMa9EBpRhxIIjCQ9MK/dTdQhz89HbtqwIhAICGzZauXprs5C/twNDYVqfZYj3SJP0V+LQFFIsSHcL9",
+           "hash": "lGSUj1HPuqsxTs5RqkhcZVCrkr/1Tnm9IDTDs9z8C9E=",
+           "prev_hash": ""
+       },
+       "error_message": null
+   }
+   ```
+
+1. Execute validation request of the asset.
+   ```console
+   # ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
+   {
+       "status_code": "OK",
+       "Ledger": {
+           "id": "test_asset",
+           "age": 0,
+           "nonce": "04c0cc2f-8f78-4ab3-afaa-ce8150af2c5b",
+           "hash": "lGSUj1HPuqsxTs5RqkhcZVCrkr/1Tnm9IDTDs9z8C9E=",
+           "signature": "MEUCIGxosE88GLTP64JN/aa2gevAJl64oaesXZxAQIzY+RtRAiEA92wEUzqTJAa1iNLkwD5BUzaTMO3YhtP0wRhQLy2fpr4="
+       },
+       "Auditor": null,
+       "error_message": null
+   }
+   ```
+   * Reference information
+       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
+       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.
+         ```console
+         # ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
+         {
+             "status_code": "INVALID_OUTPUT",
+             "Ledger": {
+                 "id": "test_asset",
+                 "age": 0,
+                 "nonce": "04c0cc2f-8f78-4ab3-afaa-ce8150af2c5b",
+                 "hash": "lGSUj1HPuqsxTs5RqkhcZVCrkr/1Tnm9IDTDs9z8C9E=",
+                 "signature": "MEUCIQDlOkpxKPvLxrAPIe8nwoSANTCDcENK5K7Na9cFgHOg2AIgDZTeNejDCjQL2Th4UByy5bVy0VG6ZLsGWWyZR5qPhWQ="
+             },
+             "Auditor": null,
+             "error_message": null
+         }
+         ```
+           * In this way, the Scalar DL Ledger can detect data tampering.
+
+## Step 10. Delete all resources
+
+After completing the Scalar DL Ledger tests on minikube, remove all resources.
+
+1. Uninstall Scalar DL Schema Loader and Ledger from minikube.
+   ```console
+   $ helm uninstall schema-loader-ledger scalardl-ledger
+   ```
+
+1. Stop and remove containers (Cassandra and Client).
+   ```
+   $ docker rm $(docker kill scalardl-client cassandra-ledger)
+   ```
+
+1. Remove working dir and sample files (configuration file, key, and certificate).
+   ```console
+   $ cd ~
+   $ rm -rf ~/scalardl-test/
+   ```
+
+1. Delete minikube.
+   ```console
+   $ minikube delete --all
+   ```
+

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -9,7 +9,7 @@ This document explains how to get started with Scalar DL Ledger using the Helm C
 
 ## Tools
 
-In this guide, we will use the following tools for testing.  
+We will use the following tools for testing.  
 
 1. Docker
 1. minikube
@@ -19,7 +19,7 @@ In this guide, we will use the following tools for testing.
 
 ## Environment
 
-In this guide, we will create the following environment in your local by using Docker and minikube.  
+We will create the following environment in your local by using Docker and minikube.  
 
 ```
 On the Docker Network (named minikube)
@@ -54,8 +54,6 @@ First, you need to install the following tools used in this guide.
 
 ## Step 2. Start minikube with docker driver
 
-We need to start the Cassandra container as backend storage of the Scalar DL Ledger on the same network of the minikube, so you need to be started the minikube with docker driver.
-
 1. Start minikube with docker driver.
    ```console
    $ minikube start --driver=docker
@@ -73,13 +71,13 @@ We need to start the Cassandra container as backend storage of the Scalar DL Led
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
-   If the minikube started properly, you can see some pods are `Running` in the kube-system namespace.
+   If the minikube starts properly, you can see some pods are `Running` in the kube-system namespace.
 
 ## Step 3. Start Cassandra container
 
-In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledger, it will be started on the same network of Scalar DL Ledger (pod on minikube) to enable proper communication.
+We use Apache Cassandra as the backend storage of Scalar DL Ledger. We start a Cassandra container on the same network of Kubernetes (Scalar DL Ledger Pod on minikube) to make them communicate properly.
 
-1. Start Cassandra container on the Docker Network `minikube`.
+1. Start a Cassandra container on the Docker Network `minikube`.
    ```console
    $ docker run --name cassandra-ledger --network minikube -d cassandra:3.11
    ```
@@ -89,7 +87,7 @@ In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledge
            * You can see the Scalar DB version of Scalar DL from the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
            * Also, you can see the Scalar DB-supported Cassandra versions (tag) in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
-1. Check the status of the Cassandra container.
+1. Check if the Cassandra container is running.
    ```console
    $ docker ps -f name=cassandra-ledger
    CONTAINER ID   IMAGE            COMMAND                  CREATED         STATUS         PORTS                                         NAMES
@@ -101,11 +99,11 @@ In this guide, we use Apache Cassandra as backend storage of the Scalar DL Ledge
    $ docker exec -t cassandra-ledger cqlsh -e "show version"
    [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
    ```
-   It may take some time to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
+   It may take a while to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
 
 ## Step 4. Create working directory
 
-In this guide, we will create some configuration files and key/certificate files locally. So, create a working directory for it.
+We will create some configuration files and key/certificate files locally. So, create a working directory for it.
 
 1. Create working directory.
    ```console
@@ -113,8 +111,6 @@ In this guide, we will create some configuration files and key/certificate files
    ```
 
 ## Step 5. Create key/certificate files
-
-In this section, we will create key/certificate files for Ledger and Client.  
 
 * Note: 
     * In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
@@ -197,7 +193,7 @@ In this section, we will create key/certificate files for Ledger and Client.
 
 ## Step 6. Create DB schema for Scalar DL Ledger by Helm Charts
 
-In this section, we will deploy Scalar DL Schema Loader on minikube by using Helm Charts.  
+We will deploy a Scalar DL Schema Loader on minikube by using Helm Charts.  
 The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in the Cassandra.  
 
 1. Change working directory from `certs/`.
@@ -205,7 +201,7 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
    $ cd ~/scalardl-test/
    ```
 
-1. Add scalar helm repository.
+1. Add the Scalar Helm Repository.
    ```console
    $ helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
@@ -227,12 +223,12 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
    EOF
    ```
 
-1. Deploy Scalar DL Schema Loader.
+1. Deploy the Scalar DL Schema Loader.
    ```console
    $ helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
-1. Check the Scalar DL Schema Loader pod is deployed and completed.
+1. Check if the Scalar DL Schema Loader pod is deployed and completed.
    ```console
    $ kubectl get pod
    NAME                                        READY   STATUS      RESTARTS   AGE
@@ -240,9 +236,7 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
    ```
    If the Scalar DL Schema Loader pod is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
 
-## Step 7. Deploy Scalar DL Ledger on minikube by Helm Charts
-
-In this section, we will deploy Scalar DL Ledger on minikube by using Helm Charts.  
+## Step 7. Deploy Scalar DL Ledger on the Kubernetes (minikube) using Helm Charts
 
 1. Create a custom value file for Scalar DL Ledger (scalardl-ledger-custom-values.yaml).
    ```console
@@ -296,12 +290,12 @@ In this section, we will deploy Scalar DL Ledger on minikube by using Helm Chart
    $ kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
-1. Deploy Scalar DL Ledger.
+1. Deploy the Scalar DL Ledger.
    ```console
    $ helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
-1. Check the Scalar DL Ledger pods are deployed.
+1. Check if the Scalar DL Ledger pods are deployed.
    ```console
    $ kubectl get pod
    NAME                                        READY   STATUS      RESTARTS   AGE
@@ -315,7 +309,7 @@ In this section, we will deploy Scalar DL Ledger on minikube by using Helm Chart
    ```
    If the Scalar DL Ledger pods are deployed properly, you can see the STATUS are `Running`.  
 
-1. Check the Scalar DL Ledger Services are deployed.
+1. Check if the Scalar DL Ledger Services are deployed.
    ```console
    $ kubectl get svc
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
@@ -341,24 +335,21 @@ In this section, we will deploy Scalar DL Ledger on minikube by using Helm Chart
 
 ## Step 8. Start Client container
 
-In this section, we will create a Client container to run a sample contract of Scalar DL.  
-We will use certificate files in the Client container. So, mount ~/scalardl-test/certs to the Client container.  
+We will use certificate files in the Client container. So, we mount ~/scalardl-test/certs directory to the Client container.  
 
-1. Start the Client container on the Docker Network `minikube`.
+1. Start a Client container on the `minikube` network.
    ```console
    $ docker run -d --name scalardl-client --hostname scalardl-client -v ~/scalardl-test/certs:/certs --network minikube --entrypoint sleep ubuntu:20.04 inf
    ```
 
-1. Check the Client container is running.
+1. Check if the Client container is running.
    ```console
    $ docker ps -f name=scalardl-client
    ```
 
 ## Step 9. Run Scalar DL sample contracts in the Client container
 
-In this section, we will prepare and run the Scalar DL sample contract.  
-
-This guide explains the minimum steps. If you want to know more details about Scalar DL and the contract, please refer to the [Getting Started with Scalar DL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
+The following explains the minimum steps. If you want to know more details about Scalar DL and the contract, please refer to the [Getting Started with Scalar DL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
 1. Run bash in the Client container.
    ```console
@@ -371,7 +362,7 @@ This guide explains the minimum steps. If you want to know more details about Sc
    # apt update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt install -y git openjdk-8-jdk curl unzip
    ```
 
-1. Clone Scalar DL Java Client SDK's git repository.
+1. Clone Scalar DL Java Client SDK git repository.
    ```console
    # git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
@@ -428,28 +419,28 @@ This guide explains the minimum steps. If you want to know more details about Sc
          ```
          In this case, you need to specify `31452` to `scalar.dl.client.server.port` and `31118` to `scalar.dl.client.server.privileged_port` in the `client.properties` file.
 
-1. Register certificate file of client.
+1. Register the certificate file of client.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./client.properties
    ```
 
-1. Register sample contract `StateUpdater`.
+1. Register the sample contract `StateUpdater`.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
-1. Register sample contract `StateReader`.
+1. Register the sample contract `StateReader`.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
-1. Execute contract `StateUpdater`.
+1. Execute the contract `StateUpdater`.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
-1. Execute contract `StateReader`.
+1. Execute the contract `StateReader`.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    {
@@ -475,7 +466,7 @@ This guide explains the minimum steps. If you want to know more details about Sc
    }
    ```
 
-1. Execute validation request of the asset.
+1. Execute a validation request of the asset.
    ```console
    # ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    {


### PR DESCRIPTION
This PR add the getting started guide with helm charts of Scalar DL.

There are two documents.
* Getting Started with Helm Charts (Scalar DL Ledger)
    * Create Ledger environment on the minikube.
* Getting Started with Helm Charts (Scalar DL Auditor)
    * Add the Auditor environment on the same minikube as Ledger.
    * The minikube is same, but I use two Cassandra (for Ledger and Auditor).

I created this document with priority on reproducibility in user's environment.  
So, I describe concrete commands in all steps.  
Also, to avoid issues depending on each environment as much as possible, this guide runs all component (include the client that runs Scalar DL sample contract) as docker container.  

Also, there are some redundancy in the `Run Scalar DL sample contract` section between two document.  
However, there are some differences. For example, property files, regstering cert files, and result of Request (Contract Execution/Validation).
So, I describe details of all steps in that section in both document.  

Please take a look!