### PR TITLE
Add `-n monitoring` flag to `helm uninstall` command

### DIFF
--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -294,7 +294,7 @@ After completing the Monitoring tests on minikube, remove all resources.
 
 1. Uninstall `kube-prometheus-stack` from minikube.
    ```console
-   helm uninstall scalar-monitoring
+   helm uninstall scalar-monitoring -n monitoring
    ```
 
 1. (Optional) Delete minikube.


### PR DESCRIPTION
In this PR, I added the `-n monitoring` flag to `helm uninstall` command.

In the Getting Started Guide with Monitoring (Prometheus Operator), we deploy kube-prometheus-stack into the `monitoring` namespace. So, we need to specify the namespace `monitoring`, when we delete it.

If we don't specify it, the `helm uninstall` command returns error.

* Without `-n monitoring`
  ```console
  $ helm uninstall scalar-monitoring
  Error: uninstall: Release not loaded: scalar-monitoring: release: not found
  ```
* With `-n monitoring`
  ```console
  $ helm uninstall scalar-monitoring -n monitoring
  release "scalar-monitoring" uninstalled
  ```