### PR TITLE
Separates the redundancy part and Update index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Index
 
 ## For users
-* [Getting Started (Scalar DB)](./getting-started-scalardb.md)
+* [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md)
 
 ## For developers
 * [Release Flow](./ReleaseFlow.md)

--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -30,43 +30,11 @@ We will create the following environment in your local by using Docker and minik
                         +---------+
 ```
 
-## Step 1. Install tools
+## Step 1. Start minikube
 
-First, you need to install the following tools used in this guide.  
+First, you need to prepare a `minikube` environment according to [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md). If you have already started the `minikube`, you can skip this step.
 
-1. Install the Docker according to the [Docker document](https://docs.docker.com/engine/install/)  
-
-1. Install the minikube according to the [minikube document](https://minikube.sigs.k8s.io/docs/start/)  
-
-1. Install the kubectl according to the [Kubernetes document](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)  
-
-1. Install the helm command according to the [Helm document](https://helm.sh/docs/intro/install/)  
-
-## Step 2. Start minikube with docker driver
-
-1. Start minikube with docker driver.
-   ```console
-   minikube start --driver=docker
-   ```
-
-1. Check the status of the minikube and pods.
-   ```console
-   kubectl get pod -A
-   ```
-   [Command execution result]
-   ```console
-   NAMESPACE     NAME                               READY   STATUS    RESTARTS        AGE
-   kube-system   coredns-64897985d-6jw6c            1/1     Running   0               3m27s
-   kube-system   etcd-minikube                      1/1     Running   27              3m38s
-   kube-system   kube-apiserver-minikube            1/1     Running   27              3m38s
-   kube-system   kube-controller-manager-minikube   1/1     Running   27              3m38s
-   kube-system   kube-proxy-5vcnc                   1/1     Running   0               3m27s
-   kube-system   kube-scheduler-minikube            1/1     Running   27              3m38s
-   kube-system   storage-provisioner                1/1     Running   1 (2m56s ago)   3m37s
-   ```
-   If the minikube starts properly, you can see some pods are `Running` in the kube-system namespace.
-
-## Step 3. Prepare a custom values file
+## Step 2. Prepare a custom values file
 
 1. Get the sample file [scalar-prometheus-custom-values.yaml](./conf/scalar-prometheus-custom-values.yaml) for `kube-prometheus-stack`.  
 
@@ -106,7 +74,7 @@ First, you need to install the following tools used in this guide.
 
 
 
-## Step 4. Deploy `kube-prometheus-stack`
+## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
    ```console
@@ -123,7 +91,7 @@ First, you need to install the following tools used in this guide.
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
 
-## Step 5. Deploy (or Upgrade) Scalar products using Helm Charts
+## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
 * Note: 
    * The following explains the minimum steps. If you want to know more details about the deployment of Scalar DB and Scalar DL, please refer to the following documents.
@@ -240,7 +208,7 @@ First, you need to install the following tools used in this guide.
          helm upgrade scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
 
-## Step 6. Access Dashboards
+## Step 5. Access Dashboards
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
    ```console
@@ -283,7 +251,7 @@ First, you need to install the following tools used in this guide.
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
 
-## Step 7. Delete all resources
+## Step 6. Delete all resources
 
 After completing the Monitoring tests on minikube, remove all resources.
 

--- a/docs/getting-started-scalar-helm-charts.md
+++ b/docs/getting-started-scalar-helm-charts.md
@@ -1,0 +1,63 @@
+# Getting Started with Scalar Helm Charts
+
+This document explains how to get started with Scalar Helm Chart in your test environment using `Minikube`. Here, we assume that you already have a Mac or Linux environment for testing.  
+
+## Tools
+
+We will use the following tools for testing.  
+
+1. Docker
+1. minikube
+1. kubectl
+1. Helm
+1. cfssl / cfssljson
+
+## Step 1. Install tools
+
+First, you need to install the following tools used in this guide.
+
+1. Install the Docker according to the [Docker document](https://docs.docker.com/engine/install/)  
+
+1. Install the minikube according to the [minikube document](https://minikube.sigs.k8s.io/docs/start/)  
+
+1. Install the kubectl according to the [Kubernetes document](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)  
+
+1. Install the helm command according to the [Helm document](https://helm.sh/docs/intro/install/)  
+
+1. Install the cfssl and cfssljson according to the [CFSSL document](https://github.com/cloudflare/cfssl)
+   * Note:
+        * You need the cfssl and cfssljson when you try Scalar DL. If you try Scalar Helm Charts other than Scalar DL (e.g., Scalar DB, Monitoring, Logging, etc...), the cfssl and cfssljson are not necessary.
+
+## Step 2. Start minikube with docker driver
+
+1. Start minikube with docker driver.
+   ```console
+   minikube start --driver=docker
+   ```
+
+1. Check the status of the minikube and pods.
+   ```console
+   kubectl get pod -A
+   ```
+   [Command execution result]
+   ```console
+   NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
+   kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
+   kube-system   etcd-minikube                      1/1     Running   1 (20h ago)   21h
+   kube-system   kube-apiserver-minikube            1/1     Running   1 (20h ago)   21h
+   kube-system   kube-controller-manager-minikube   1/1     Running   1 (20h ago)   21h
+   kube-system   kube-proxy-gsl6j                   1/1     Running   1 (20h ago)   21h
+   kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
+   kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
+   ```
+   If the minikube starts properly, you can see some pods are `Running` in the kube-system namespace.
+
+## Step 3. 
+
+After the minikube starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
+
+* [Scalar DB Server](./getting-started-scalardb.md)
+* [Scalar DL Ledger](./getting-started-scalardl-ledger.md)
+* [Scalar DL Auditor](./getting-started-scalardl-auditor.md)
+* [Monitoring using Prometheus Operator](./getting-started-monitoring.md)
+* [Logging using Loki Stack](./getting-started-logging.md)

--- a/docs/getting-started-scalar-helm-charts.md
+++ b/docs/getting-started-scalar-helm-charts.md
@@ -60,4 +60,4 @@ After the minikube starts, you can try each Scalar Helm Charts on it. Please ref
 * [Scalar DL Ledger](./getting-started-scalardl-ledger.md)
 * [Scalar DL Auditor](./getting-started-scalardl-auditor.md)
 * [Monitoring using Prometheus Operator](./getting-started-monitoring.md)
-* [Logging using Loki Stack](./getting-started-logging.md)
+  * [Logging using Loki Stack](./getting-started-logging.md)

--- a/docs/getting-started-scalardb.md
+++ b/docs/getting-started-scalardb.md
@@ -2,15 +2,6 @@
 
 This document explains how to get started with Scalar DB Server using Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
 
-## Tools
-
-We will use the following tools for testing.  
-
-1. Docker
-1. minikube
-1. kubectl
-1. Helm
-
 ## Environment
 
 We will create the following environment in your local by using Docker and minikube.  
@@ -31,44 +22,11 @@ On the Docker Network (named minikube)
                gRPC                    Cassandra Driver
 ```
 
-## Step 1. Install tools
+## Step 1. Start minikube
 
-First, you need to install the following tools used in this guide.  
+First, you need to prepare a `minikube` environment according to [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md). If you have already started the `minikube`, you can skip this step.
 
-1. Install the Docker according to the [Docker document](https://docs.docker.com/engine/install/)  
-
-1. Install the minikube according to the [minikube document](https://minikube.sigs.k8s.io/docs/start/)  
-
-1. Install the kubectl according to the [Kubernetes document](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)  
-
-1. Install the helm command according to the [Helm document](https://helm.sh/docs/intro/install/)  
-
-## Step 2. Start minikube with docker driver
-
-
-1. Start minikube with docker driver.
-   ```console
-   minikube start --driver=docker
-   ```
-
-1. Check the status of the minikube and pods.
-   ```console
-   kubectl get pod -A
-   ```
-   [Command execution result]
-   ```console
-   NAMESPACE     NAME                               READY   STATUS    RESTARTS        AGE
-   kube-system   coredns-64897985d-6jw6c            1/1     Running   0               3m27s
-   kube-system   etcd-minikube                      1/1     Running   27              3m38s
-   kube-system   kube-apiserver-minikube            1/1     Running   27              3m38s
-   kube-system   kube-controller-manager-minikube   1/1     Running   27              3m38s
-   kube-system   kube-proxy-5vcnc                   1/1     Running   0               3m27s
-   kube-system   kube-scheduler-minikube            1/1     Running   27              3m38s
-   kube-system   storage-provisioner                1/1     Running   1 (2m56s ago)   3m37s
-   ```
-   If the minikube starts properly, you can see some pods are `Running` in the kube-system namespace.
-
-## Step 3. Start Cassandra container
+## Step 2. Start Cassandra container
 
 We use Apache Cassandra as the backend storage of Scalar DB Server. We start a Cassandra container on the same network of Kubernetes (Scalar DB Server Pod on minikube) to make them communicate properly.
 
@@ -104,7 +62,7 @@ We use Apache Cassandra as the backend storage of Scalar DB Server. We start a C
    ```
    It may take a while to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
 
-## Step 4. Deploy Scalar DB Server on the Kubernetes (minikube) using Helm Charts
+## Step 3. Deploy Scalar DB Server on the Kubernetes (minikube) using Helm Charts
 
 1. Add the Scalar Helm Repository.
    ```console
@@ -194,7 +152,7 @@ We use Apache Cassandra as the backend storage of Scalar DB Server. We start a C
    scalardb-envoy   LoadBalancer   10.103.103.188   127.0.0.1     60051:32344/TCP,50052:30921/TCP   13m
    ```
 
-## Step 5. Start Client container
+## Step 4. Start Client container
 
 
 1. Start a Client container on the `minikube` network.
@@ -212,7 +170,7 @@ We use Apache Cassandra as the backend storage of Scalar DB Server. We start a C
    a49eaf0c2442   ubuntu:20.04   "sleep inf"   About a minute ago   Up About a minute             scalardb-client
    ```
 
-## Step 6. Run Scalar DB sample application in the Client container
+## Step 5. Run Scalar DB sample application in the Client container
 
 
 The following explains the minimum steps. If you want to know more details about Scalar DB, please refer to the [Getting Started with Scalar DB
@@ -355,7 +313,7 @@ The following explains the minimum steps. If you want to know more details about
    * Note:
        * Usually, you need to access data (record) through Scalar DB. The above command is used to explain and confirm the working of the sample application.
 
-## Step 7. Delete all resources
+## Step 6. Delete all resources
 
 After completing the Scalar DB Server tests on minikube, remove all resources.
 

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -10,16 +10,6 @@ This document explains how to get started with Scalar DL Ledger and Auditor usin
 ## Note
 To make Byzantine fault detection with auditing work properly, Ledger and Auditor should be deployed and managed in different administrative domains. However, in this guide, we will deploy Ledger and Auditor in the same Kubernetes (minikube) to make the test easier.  
 
-## Tools
-
-We will use the following tools for testing.  
-
-1. Docker
-1. minikube
-1. kubectl
-1. Helm
-1. cfssl / cfssljson
-
 ## Environment
 
 We will create the following environment in your local by using Docker and minikube.  

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -7,16 +7,6 @@ This document explains how to get started with Scalar DL Ledger using the Helm C
 * You need the privileges to pull the Scalar DL containers (`scalar-ledger` and `scalardl-schema-loader`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).  
 * You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above containers.
 
-## Tools
-
-We will use the following tools for testing.  
-
-1. Docker
-1. minikube
-1. kubectl
-1. Helm
-1. cfssl / cfssljson
-
 ## Environment
 
 We will create the following environment in your local by using Docker and minikube.  
@@ -37,46 +27,11 @@ On the Docker Network (named minikube)
                gRPC                    Cassandra Driver
 ```
 
+## Step 1. Start minikube
 
-## Step 1. Install tools
+First, you need to prepare a `minikube` environment according to [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md). If you have already started the `minikube`, you can skip this step.
 
-First, you need to install the following tools used in this guide.
-
-1. Install the Docker according to the [Docker document](https://docs.docker.com/engine/install/)  
-
-1. Install the minikube according to the [minikube document](https://minikube.sigs.k8s.io/docs/start/)  
-
-1. Install the kubectl according to the [Kubernetes document](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)  
-
-1. Install the helm command according to the [Helm document](https://helm.sh/docs/intro/install/)  
-
-1. Install the cfssl and cfssljson according to the [CFSSL document](https://github.com/cloudflare/cfssl)
-
-## Step 2. Start minikube with docker driver
-
-1. Start minikube with docker driver.
-   ```console
-   minikube start --driver=docker
-   ```
-
-1. Check the status of the minikube and pods.
-   ```console
-   kubectl get pod -A
-   ```
-   [Command execution result]
-   ```console
-   NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
-   kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
-   kube-system   etcd-minikube                      1/1     Running   1 (20h ago)   21h
-   kube-system   kube-apiserver-minikube            1/1     Running   1 (20h ago)   21h
-   kube-system   kube-controller-manager-minikube   1/1     Running   1 (20h ago)   21h
-   kube-system   kube-proxy-gsl6j                   1/1     Running   1 (20h ago)   21h
-   kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
-   kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
-   ```
-   If the minikube starts properly, you can see some pods are `Running` in the kube-system namespace.
-
-## Step 3. Start Cassandra container
+## Step 2. Start Cassandra container
 
 We use Apache Cassandra as the backend storage of Scalar DL Ledger. We start a Cassandra container on the same network of Kubernetes (Scalar DL Ledger Pod on minikube) to make them communicate properly.
 
@@ -110,7 +65,7 @@ We use Apache Cassandra as the backend storage of Scalar DL Ledger. We start a C
    ```
    It may take a while to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
 
-## Step 4. Create working directory
+## Step 3. Create working directory
 
 We will create some configuration files and key/certificate files locally. So, create a working directory for it.
 
@@ -119,7 +74,7 @@ We will create some configuration files and key/certificate files locally. So, c
    mkdir ~/scalardl-test
    ```
 
-## Step 5. Create key/certificate files
+## Step 4. Create key/certificate files
 
 * Note: 
     * In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
@@ -205,7 +160,7 @@ We will create some configuration files and key/certificate files locally. So, c
    ```
 
 
-## Step 6. Create DB schema for Scalar DL Ledger by Helm Charts
+## Step 5. Create DB schema for Scalar DL Ledger by Helm Charts
 
 We will deploy a Scalar DL Schema Loader on minikube by using Helm Charts.  
 The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in the Cassandra.  
@@ -253,7 +208,7 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
    ```
    If the Scalar DL Schema Loader pod is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
 
-## Step 7. Deploy Scalar DL Ledger on the Kubernetes (minikube) using Helm Charts
+## Step 6. Deploy Scalar DL Ledger on the Kubernetes (minikube) using Helm Charts
 
 1. Create a custom value file for Scalar DL Ledger (scalardl-ledger-custom-values.yaml).
    ```console
@@ -363,7 +318,7 @@ The Scalar DL Schema Loader will create the DB schema for Scalar DL Ledger in th
    scalardl-ledger-envoy   LoadBalancer   10.98.162.209   127.0.0.1     50051:31452/TCP,50052:31118/TCP   9m7s
    ```
 
-## Step 8. Start Client container
+## Step 7. Start Client container
 
 We will use certificate files in the Client container. So, we mount ~/scalardl-test/certs directory to the Client container.  
 
@@ -377,7 +332,7 @@ We will use certificate files in the Client container. So, we mount ~/scalardl-t
    docker ps -f name=scalardl-client
    ```
 
-## Step 9. Run Scalar DL sample contracts in the Client container
+## Step 8. Run Scalar DL sample contracts in the Client container
 
 The following explains the minimum steps. If you want to know more details about Scalar DL and the contract, please refer to the [Getting Started with Scalar DL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
@@ -555,7 +510,7 @@ The following explains the minimum steps. If you want to know more details about
          ```
            * In this way, the Scalar DL Ledger can detect data tampering.
 
-## Step 10. Delete all resources
+## Step 9. Delete all resources
 
 After completing the Scalar DL Ledger tests on minikube, remove all resources.
 


### PR DESCRIPTION
According to the following two comment in the another PR, this PR separates the redundancy part from Getting Started Guide with Helm Charts.
https://github.com/scalar-labs/helm-charts/pull/85#discussion_r852755807
https://github.com/scalar-labs/helm-charts/pull/85#discussion_r852756235

Also, I updated index of document to make uses reach each document properly via separated document.
Users can access each Getting Started Guide according to this index as follows.
```
                               +---> [Scalar DB Server]
                               |
                               +---> [Scalar DL Ledger]
                               |
[Start minikube (root doc)] ---+---> [Scalar DL Auditor]
                               |
                               +---> [Monitoring using Prometheus Operator]
                               |
                               +---> [Logging using Loki Stack]
```

Please take a look!