### PR TITLE
Update version of each chart to latest

### DIFF
--- a/charts/envoy/Chart.yaml
+++ b/charts/envoy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: envoy
 description: Envoy Proxy for Scalar applications
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.2.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -1,9 +1,9 @@
 # envoy
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Envoy Proxy for Scalar applications
-Current chart version is `2.0.0`
+Current chart version is `2.0.1`
 
 **Homepage:** <https://scalar-labs.com/>
 

--- a/charts/scalardb/Chart.lock
+++ b/charts/scalardb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 2.0.0
-digest: sha256:f5a5633b88391c5cf39b38262ac33a44cacef9c0d423608277b9e57bfb00da76
-generated: "2021-12-08T10:31:16.133835+09:00"
+  version: 2.0.1
+digest: sha256:102a060fe4b6e667428ee5ef242bbf994da80841e17ebe178368f7e1904deb53
+generated: "2022-04-07T18:36:10.973938802+09:00"

--- a/charts/scalardb/Chart.yaml
+++ b/charts/scalardb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardb
 description: Scalar DB server
 type: application
-version: 2.1.0
-appVersion: 3.4.1
+version: 2.2.4
+appVersion: 3.5.2
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardb
 dependencies:
 - name: envoy
-  version: ~2.0.0
+  version: ~2.0.1
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -1,13 +1,13 @@
 # scalardb
 
 Scalar DB server
-Current chart version is `2.1.0`
+Current chart version is `2.2.4`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.0 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.1 |
 
 ## Values
 
@@ -51,7 +51,7 @@ Current chart version is `2.1.0`
 | scalardb.grafanaDashboard.namespace | string | `"monitoring"` | Which namespace grafana dashboard is located. by default monitoring. |
 | scalardb.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | scalardb.image.repository | string | `"ghcr.io/scalar-labs/scalardb-server"` | Docker image reposiory of Scalar DB server. |
-| scalardb.image.tag | string | `"3.4.1"` | Docker tag of the image. |
+| scalardb.image.tag | string | `"3.5.2"` | Docker tag of the image. |
 | scalardb.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalardb.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalardb.podAnnotations | object | `{"seccomp.security.alpha.kubernetes.io/pod":"runtime/default"}` | Pod annotations for the scalardb deployment |

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -129,7 +129,7 @@ scalardb:
     # -- Specify a image pulling policy.
     pullPolicy: IfNotPresent
     # -- Docker tag of the image.
-    tag: 3.4.1
+    tag: 3.5.2
 
   # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: []

--- a/charts/scalardl-audit/Chart.lock
+++ b/charts/scalardl-audit/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 2.0.0
-digest: sha256:f5a5633b88391c5cf39b38262ac33a44cacef9c0d423608277b9e57bfb00da76
-generated: "2021-12-08T10:31:50.667584+09:00"
+  version: 2.0.1
+digest: sha256:102a060fe4b6e667428ee5ef242bbf994da80841e17ebe178368f7e1904deb53
+generated: "2022-04-07T19:32:32.973428378+09:00"

--- a/charts/scalardl-audit/Chart.yaml
+++ b/charts/scalardl-audit/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl-audit
 description: Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
 type: application
-version: 2.1.0
-appVersion: 3.3.1
+version: 2.2.1
+appVersion: 3.4.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardl
 dependencies:
 - name: envoy
-  version: ~2.0.0
+  version: ~2.0.1
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -1,13 +1,13 @@
 # scalardl-audit
 
 Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
-Current chart version is `2.1.0`
+Current chart version is `2.2.1`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.0 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.1 |
 
 ## Values
 
@@ -19,7 +19,7 @@ Current chart version is `2.1.0`
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | auditor.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | auditor.image.repository | string | `"ghcr.io/scalar-labs/scalar-auditor"` | Docker image |
-| auditor.image.version | string | `"3.3.1"` | Docker tag |
+| auditor.image.version | string | `"3.4.0"` | Docker tag |
 | auditor.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | auditor.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | auditor.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -153,7 +153,7 @@ auditor:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-auditor
     # -- Docker tag
-    version: 3.3.1
+    version: 3.4.0
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 

--- a/charts/scalardl/Chart.lock
+++ b/charts/scalardl/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 2.0.0
-digest: sha256:f5a5633b88391c5cf39b38262ac33a44cacef9c0d423608277b9e57bfb00da76
-generated: "2021-12-08T10:30:24.574499+09:00"
+  version: 2.0.1
+digest: sha256:102a060fe4b6e667428ee5ef242bbf994da80841e17ebe178368f7e1904deb53
+generated: "2022-04-07T18:56:29.964507445+09:00"

--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl
 description: Scalar DL is a tamper-evident and scalable distributed database.
 type: application
-version: 4.1.1
-appVersion: 3.3.2
+version: 4.2.1
+appVersion: 3.4.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardl
 dependencies:
 - name: envoy
-  version: ~2.0.0
+  version: ~2.0.1
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,13 +1,13 @@
 # scalardl
 
 Scalar DL is a tamper-evident and scalable distributed database.
-Current chart version is `4.1.1`
+Current chart version is `4.2.1`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.0 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.1 |
 
 ## Values
 

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -53,7 +53,7 @@ Current chart version is `4.2.1`
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
-| ledger.image.version | string | `"3.3.2"` | Docker tag |
+| ledger.image.version | string | `"3.4.0"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | ledger.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -144,7 +144,7 @@ ledger:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger
     # -- Docker tag
-    version: 3.3.2
+    version: 3.4.0
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 

--- a/charts/schema-loading/Chart.yaml
+++ b/charts/schema-loading/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: schema-loading
 description: A schema loading tool for Scalar DL.
 type: application
-version: 2.4.0
-appVersion: 3.3.0
+version: 2.5.1
+appVersion: 3.4.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/schema-loading/README.md
+++ b/charts/schema-loading/README.md
@@ -1,7 +1,7 @@
 # schema-loading
 
 A schema loading tool for Scalar DL.
-Current chart version is `2.4.0`
+Current chart version is `2.5.1`
 
 ## Values
 
@@ -17,7 +17,7 @@ Current chart version is `2.4.0`
 | schemaLoading.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | schemaLoading.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | schemaLoading.image.repository | string | `"ghcr.io/scalar-labs/scalardl-schema-loader"` | Docker image |
-| schemaLoading.image.version | string | `"3.3.0"` | Docker tag |
+| schemaLoading.image.version | string | `"3.4.0"` | Docker tag |
 | schemaLoading.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | schemaLoading.password | string | `"cassandra"` | The password of the database. For Cosmos DB, please specify a key here. |
 | schemaLoading.schemaType | string | `"ledger"` | Type of schema to apply (ledger or auditor). |

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -26,7 +26,7 @@ schemaLoading:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalardl-schema-loader
     # -- Docker tag
-    version: 3.3.0
+    version: 3.4.0
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This PR update version of each chart to keep main branch latest.
We need to update version in main branch when we release most recent version of Helm Charts to keep main branch latest, but I forgot it.
Sorry for overlooking this issue...

Also, we don't need to do any release operation because all latest charts are released correctly as follows.
```console
$ helm search repo scalar-labs
NAME                            CHART VERSION   APP VERSION     DESCRIPTION
scalar-labs/envoy               2.0.1           1.2.0           Envoy Proxy for Scalar applications
scalar-labs/scalardb            2.2.4           3.5.2           Scalar DB server
scalar-labs/scalardl            4.2.1           3.4.0           Scalar DL is a tamper-evident and scalable dist...
scalar-labs/scalardl-audit      2.2.1           3.4.0           Scalar DL is a tamper-evident and scalable dist...
scalar-labs/schema-loading      2.5.1           3.4.0           A schema loading tool for Scalar DL.
```

The purpose of this PR is only keeping main branch latest.
Please take a look.
(I will update the docs about release flow in the another PR.)
