### PR TITLE
Configure Grafana to allow the embedding feature

### DIFF
--- a/docs/conf/scalar-prometheus-custom-values.yaml
+++ b/docs/conf/scalar-prometheus-custom-values.yaml
@@ -26,6 +26,13 @@ grafana:
     # requests:
     #   memory: 400Mi
 
+  # -- Grafana's primary configuration
+  grafana.ini:
+    security:
+      # -- allow Grafana to be embedded (not set the X-Frame-Options header)
+      # -- https://grafana.com/docs/grafana/latest/administration/configuration/#allow_embedding
+      allow_embedding: true
+
 kubeApiServer:
   # -- Scraping kube-apiserver is disabled
   enabled: false

--- a/docs/conf/scalar-prometheus-custom-values.yaml
+++ b/docs/conf/scalar-prometheus-custom-values.yaml
@@ -30,8 +30,9 @@ grafana:
   grafana.ini:
     security:
       # -- allow Grafana to be embedded (not set the X-Frame-Options header)
+      # -- If you use Scalar Manager, you need to set allow_embedding to true.
       # -- https://grafana.com/docs/grafana/latest/administration/configuration/#allow_embedding
-      allow_embedding: true
+      allow_embedding: false
 
 kubeApiServer:
   # -- Scraping kube-apiserver is disabled


### PR DESCRIPTION
This PR adds a configuration to the sample custom values of the "Getting Started Monitoring" guide to allow Grafana to be embedded in the other websites (mainly, for Scalar Manager by far).