### PR TITLE
[WIP] Use secret resource for usename and password in Scalar DB chart

### DIFF
--- a/charts/scalardb/templates/scalardb/configmap.yaml
+++ b/charts/scalardb/templates/scalardb/configmap.yaml
@@ -8,8 +8,8 @@ data:
   database.properties: |-
     scalar.db.contact_points={{.Values.scalardb.storageConfiguration.contactPoints}}
     scalar.db.contact_port={{.Values.scalardb.storageConfiguration.contactPort}}
-    scalar.db.username={{.Values.scalardb.storageConfiguration.username}}
-    scalar.db.password={{.Values.scalardb.storageConfiguration.password}}
+    scalar.db.username={{ "{{ default .Env.SCALAR_DB_USERNAME \"\" }}" }}
+    scalar.db.password={{ "{{ default .Env.SCALAR_DB_PASSWORD \"\" }}" }}
     scalar.db.storage={{.Values.scalardb.storageConfiguration.storage}}
     scalar.db.server.port=50051
 ---

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -49,6 +49,24 @@ spec:
           env:
           - name: JAVA_OPTS
             value: "-Dlog4j.logLevel={{ .Values.scalardb.storageConfiguration.dbLogLevel }}"
+          - name: SCALAR_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.scalardb.existingSecret }}
+                name: {{ .Values.scalardb.existingSecret }}
+              {{- else }}
+                name: {{ include "scalardb.fullname" . }}-secret
+              {{- end }}
+                key: db-username
+          - name: SCALAR_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.scalardb.existingSecret }}
+                name: {{ .Values.scalardb.existingSecret }}
+              {{- else }}
+                name: {{ include "scalardb.fullname" . }}-secret
+              {{- end }}
+                key: db-password
           resources:
             {{- toYaml .Values.scalardb.resources | nindent 12 }}
           livenessProbe:
@@ -63,8 +81,8 @@ spec:
             timeoutSeconds: 1
           volumeMounts:
             - name: scalardb-config-file-volume
-              mountPath: /scalardb/server/database.properties
-              subPath: database.properties
+              mountPath: /scalardb/server/database.properties.tmpl
+              subPath: database.properties.tmpl
       volumes:
         - name: scalardb-config-file-volume
           configMap:

--- a/charts/scalardb/templates/scalardb/secret.yaml
+++ b/charts/scalardb/templates/scalardb/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.scalardb.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "scalardb.fullname" . }}-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardb.labels" . | nindent 4 }}
+type: Opaque
+data:
+  db-username: {{ .Values.scalardb.storageConfiguration.username | b64enc | quote }}
+  db-password: {{ .Values.scalardb.storageConfiguration.password | b64enc | quote }}
+{{- end -}}


### PR DESCRIPTION
* Note: 
    * This is a PR for discussion.
    * If we choose this way, we need to apply this update after releasing new version Scalar DB that includes the following PR.
      https://github.com/scalar-labs/scalardb/pull/590

---

This PR update Scalar DB Server Helm Charts to pass the username and password via Secret resource.
In this PR, we use environment variable (Secret) for username/password only.
Another values are passed as ConfigMap.

I would like to discuss which of the following two is better.
* Use secret (environment variable) for username/password only (This PR).
* Use environment variable for all configurations as well as [Scalar DL](https://github.com/scalar-labs/helm-charts/blob/scalardl-4.2.1/charts/scalardl/templates/ledger/deployment.yaml#L54-L87).