### PR TITLE
Use Secret resource for username and password in the Scalar DB chart

### DIFF
--- a/charts/scalardb/templates/scalardb/configmap.yaml
+++ b/charts/scalardb/templates/scalardb/configmap.yaml
@@ -1,18 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "scalardb.fullname" . }}-config-file
-  namespace: {{ .Release.Namespace }}
-data:
-  # Create a database.properties file which is config file of Scalar DB server.
-  database.properties: |-
-    scalar.db.contact_points={{.Values.scalardb.storageConfiguration.contactPoints}}
-    scalar.db.contact_port={{.Values.scalardb.storageConfiguration.contactPort}}
-    scalar.db.username={{.Values.scalardb.storageConfiguration.username}}
-    scalar.db.password={{.Values.scalardb.storageConfiguration.password}}
-    scalar.db.storage={{.Values.scalardb.storageConfiguration.storage}}
-    scalar.db.server.port=50051
----
 {{- if .Values.scalardb.grafanaDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -36,7 +36,6 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.scalardb.podSecurityContext | nindent 8 }}
-
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -47,8 +46,34 @@ spec:
             - containerPort: 50051
             - containerPort: 8080
           env:
-          - name: JAVA_OPTS
-            value: "-Dlog4j.logLevel={{ .Values.scalardb.storageConfiguration.dbLogLevel }}"
+          - name: SCALAR_DB_CONTACT_POINTS
+            value: "{{ .Values.scalardb.storageConfiguration.contactPoints }}"
+          - name: SCALAR_DB_CONTACT_PORT
+            value: "{{ .Values.scalardb.storageConfiguration.contactPort }}"
+          - name: SCALAR_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.scalardb.existingSecret }}
+                name: {{ .Values.scalardb.existingSecret }}
+              {{- else }}
+                name: {{ include "scalardb.fullname" . }}-secret
+              {{- end }}
+                key: db-username
+          - name: SCALAR_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.scalardb.existingSecret }}
+                name: {{ .Values.scalardb.existingSecret }}
+              {{- else }}
+                name: {{ include "scalardb.fullname" . }}-secret
+              {{- end }}
+                key: db-password
+          - name: SCALAR_DB_STORAGE
+            value: "{{ .Values.scalardb.storageConfiguration.storage }}"
+          - name: SCALAR_DB_LOG_LEVEL
+            value: "{{ .Values.scalardb.storageConfiguration.dbLogLevel }}"
+          - name: SCALAR_DB_SERVER_PORT
+            value: "50051"
           resources:
             {{- toYaml .Values.scalardb.resources | nindent 12 }}
           livenessProbe:
@@ -61,14 +86,6 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          volumeMounts:
-            - name: scalardb-config-file-volume
-              mountPath: /scalardb/server/database.properties
-              subPath: database.properties
-      volumes:
-        - name: scalardb-config-file-volume
-          configMap:
-            name: {{ include "scalardb.fullname" . }}-config-file
       {{- with .Values.scalardb.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/scalardb/templates/scalardb/secret.yaml
+++ b/charts/scalardb/templates/scalardb/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.scalardb.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "scalardb.fullname" . }}-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardb.labels" . | nindent 4 }}
+type: Opaque
+data:
+  db-username: {{ .Values.scalardb.storageConfiguration.username | b64enc | quote }}
+  db-password: {{ .Values.scalardb.storageConfiguration.password | b64enc | quote }}
+{{- end -}}


### PR DESCRIPTION
This PR updates Scalar DB Helm Charts to use `Secret` resource for passing username/password to containers.

As a result of discussion, we decided to update Scalar DB Dockerfile and Helm Charts to the same as Scalar DL for keeping consistency among Scalar products and for improving maintainability.
So, I update Scalar DB Helm Charts based on the Scalar DL Helm Charts in this PR.

Please take a look!

---

Note that we need to apply this update after releasing new version Scalar DB that includes the following PR.
* https://github.com/scalar-labs/scalardb/pull/590

So, we cannot test this Helm Charts now (CI does not work).
We can only test it in the local environment only.
For example, you can test this chart on minikube as follows.

* Create a docker image of Scalar DB Server that supports templating by docerize command.
  ```
  git clone https://github.com/scalar-labs/scalardb.git
  cd scalardb/
  git checkout -b update-dockerfile-to-use-dockerize origin/update-dockerfile-to-use-dockerize
  eval $(minikube -p minikube docker-env)
  ./gradlew docker
  docker tag ghcr.io/scalar-labs/scalardb-server:4.0.0-SNAPSHOT local/test/scalardb-server:4.0.0-SNAPSHOT
  ```
* Run a cassandra container
  ```
  helm install cassandra bitnami/cassandra --set dbUser.password=cassandra
  ```
* Create custom values file
  ```
  cat << EOF > test-custom-values.yaml
  scalardb:
    image:
      repository: "local/test/scalardb-server"
      tag: "4.0.0-SNAPSHOT"
  EOF
  ```
* Deploy Scalar DB using Helm
  ```
  git clone https://github.com/scalar-labs/helm-charts.git
  cd helm-charts/
  git checkout -b use-secret-for-password-scalardb origin/use-secret-for-password-scalardb
  helm install scalardb ./charts/scalardb/ -f /path/to/test-custom-values.yaml
  ```

---

As I mentioned above, since the CI does not work now, I confirmed the following points in my local environment.

* Environment variables in the Scalar DB Server Pod
  ```
  $ kubectl describe pod scalardb-57c8784fc8-lszkh
  Name:         scalardb-57c8784fc8-lszkh
  
  (snip)
  
      Environment:
        SCALAR_DB_CONTACT_POINTS:  cassandra
        SCALAR_DB_CONTACT_PORT:    9042
        SCALAR_DB_USERNAME:        <set to the key 'db-username' in secret 'scalardb-secret'>  Optional: false
        SCALAR_DB_PASSWORD:        <set to the key 'db-password' in secret 'scalardb-secret'>  Optional: false
        SCALAR_DB_STORAGE:         cassandra
        SCALAR_DB_LOG_LEVEL:       INFO
        SCALAR_DB_SERVER_PORT:     50051
  ```
  * We can see the environment variables and the default values are set based on the values.yaml.
* Secret resource
  ```
  $ kubectl get secret scalardb-secret -o jsonpath='{.data.db-username}' | base64 -d
  cassandra
  
  $ kubectl get secret scalardb-secret -o jsonpath='{.data.db-password}' | base64 -d
  cassandra
  ```
  * We can see the Secret resource and the default values are set based on the values.yaml.
* `database.properties` file in the Pod
  ```
  $ kubectl exec -it scalardb-57c8784fc8-lszkh -- cat database.properties | grep -v -e "^\s*#" -e "^\s*$"
  scalar.db.contact_points=cassandra
  scalar.db.contact_port=9042
  scalar.db.username=cassandra
  scalar.db.password=cassandra
  scalar.db.storage=cassandra
  scalar.db.transaction_manager=consensus-commit
  scalar.db.consensus_commit.isolation_level=
  scalar.db.isolation_level=
  scalar.db.consensus_commit.serializable_strategy=
  scalar.db.server.port=50051
  ```
  * The default values are set in the `database.properties` in the Scalar DB Server container. This file created by the `dockerize` command using environment variables.

