### PR TITLE
Remove chart testing for Kubernetes v1.18

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -88,7 +88,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.18.19
           - v1.19.11
           - v1.20.7
           - v1.21.2
@@ -138,7 +137,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.18.19
           - v1.19.11
           - v1.20.7
           - v1.21.2


### PR DESCRIPTION
This PR removes Kubernetes v1.18 from the version list of the chart testing and the kubeval for the following reasons.

* Kubernetes v1.18 is no longer supported by both EKS and AKS.
* It is already stated that v1.18 is not supported by this repo. ([v1.19+ is required in the README](https://github.com/scalar-labs/helm-charts#prerequisites))
* Kubeval for Ingress resources with v1.18 resulted in an error due to a lack of the JSON schema file. https://github.com/scalar-labs/helm-charts/pull/89#issuecomment-1138297232
