### PR TITLE
Use default port in the chart of Scalar DB and Auditor

### DIFF
--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -16,7 +16,7 @@ Current chart version is `2.2.4`
 | envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
-| envoy.envoyConfiguration.serviceListeners | string | `"scalardb-service:50051,scalardb-privileged:50052"` | list of service name and port |
+| envoy.envoyConfiguration.serviceListeners | string | `"scalardb-service:60051"` | list of service name and port |
 | envoy.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | envoy.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | envoy.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
@@ -34,7 +34,7 @@ Current chart version is `2.2.4`
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy.port | int | `60051` | envoy public port |
 | envoy.service.ports.envoy.protocol | string | `"TCP"` | envoy protocol |
-| envoy.service.ports.envoy.targetPort | int | `50051` | envoy k8s internal name |
+| envoy.service.ports.envoy.targetPort | int | `60051` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | envoy.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | envoy.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
@@ -67,9 +67,9 @@ Current chart version is `2.2.4`
 | scalardb.securityContext.allowPrivilegeEscalation | bool | `false` | AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process |
 | scalardb.securityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default |
 | scalardb.securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege) |
-| scalardb.service.ports.scalardb.port | int | `50051` | Scalar DB server port. |
+| scalardb.service.ports.scalardb.port | int | `60051` | Scalar DB server port. |
 | scalardb.service.ports.scalardb.protocol | string | `"TCP"` | Scalar DB server protocol. |
-| scalardb.service.ports.scalardb.targetPort | int | `50051` | Scalar DB server target port. |
+| scalardb.service.ports.scalardb.targetPort | int | `60051` | Scalar DB server target port. |
 | scalardb.service.type | string | `"ClusterIP"` | service types in kubernetes. |
 | scalardb.serviceMonitor.enabled | bool | `false` | Enable metrics collect with prometheus. |
 | scalardb.serviceMonitor.interval | string | `"15s"` | Custom interval to retrieve the metrics. |

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           image: "{{ .Values.scalardb.image.repository }}:{{ .Values.scalardb.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.scalardb.image.pullPolicy }}
           ports:
-            - containerPort: 50051
+            - containerPort: 60051
             - containerPort: 8080
           env:
           - name: SCALAR_DB_CONTACT_POINTS
@@ -72,15 +72,13 @@ spec:
             value: "{{ .Values.scalardb.storageConfiguration.storage }}"
           - name: SCALAR_DB_LOG_LEVEL
             value: "{{ .Values.scalardb.storageConfiguration.dbLogLevel }}"
-          - name: SCALAR_DB_SERVER_PORT
-            value: "50051"
           resources:
             {{- toYaml .Values.scalardb.resources | nindent 12 }}
           livenessProbe:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
-              - -addr=:50051
+              - -addr=:60051
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -19,7 +19,7 @@ envoy:
     # -- admin log path
     adminAccessLogPath: /dev/stdout
     # -- list of service name and port
-    serviceListeners: scalardb-service:50051,scalardb-privileged:50052
+    serviceListeners: scalardb-service:60051
 
   image:
     # -- Docker image
@@ -63,7 +63,7 @@ envoy:
         # -- envoy public port
         port: 60051
         # -- envoy k8s internal name
-        targetPort: 50051
+        targetPort: 60051
         # -- envoy protocol
         protocol: TCP
 
@@ -149,9 +149,9 @@ scalardb:
     ports:
       scalardb:
         # -- Scalar DB server port.
-        port: 50051
+        port: 60051
         # -- Scalar DB server target port.
-        targetPort: 50051
+        targetPort: 60051
         # -- Scalar DB server protocol.
         protocol: TCP
 

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -34,8 +34,8 @@ Current chart version is `2.2.1`
 | auditor.scalarAuditorConfiguration.auditorLogLevel | string | `"INFO"` | The log level of Scalar auditor |
 | auditor.scalarAuditorConfiguration.auditorPrivateKeySecretKey | string | `"private-key"` | The secret key of an Auditor private key |
 | auditor.scalarAuditorConfiguration.auditorServerAdminPort | int | `50053` | The port number of Auditor Admin Server |
-| auditor.scalarAuditorConfiguration.auditorServerPort | int | `50051` | The port number of Auditor Server |
-| auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort | int | `50052` | The port number of Auditor Privileged Server |
+| auditor.scalarAuditorConfiguration.auditorServerPort | int | `40051` | The port number of Auditor Server |
+| auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort | int | `40052` | The port number of Auditor Privileged Server |
 | auditor.scalarAuditorConfiguration.dbContactPoints | string | `"cassandra"` | The contact points of the database such as hostnames or URLs |
 | auditor.scalarAuditorConfiguration.dbContactPort | int | `9042` | The port number of the contact points |
 | auditor.scalarAuditorConfiguration.dbPassword | string | `"cassandra"` | The password of the database |
@@ -47,12 +47,12 @@ Current chart version is `2.2.1`
 | auditor.service.ports.scalardl-auditor-admin.port | int | `50053` | scalardl-admin target port |
 | auditor.service.ports.scalardl-auditor-admin.protocol | string | `"TCP"` | scalardl-admin protocol |
 | auditor.service.ports.scalardl-auditor-admin.targetPort | int | `50053` | scalardl-admin k8s internal name |
-| auditor.service.ports.scalardl-auditor-priv.port | int | `50052` | scalardl-priv target port |
+| auditor.service.ports.scalardl-auditor-priv.port | int | `40052` | scalardl-priv target port |
 | auditor.service.ports.scalardl-auditor-priv.protocol | string | `"TCP"` | scalardl-priv protocol |
-| auditor.service.ports.scalardl-auditor-priv.targetPort | int | `50052` | scalardl-priv k8s internal name |
-| auditor.service.ports.scalardl-auditor.port | int | `50051` | scalardl target port |
+| auditor.service.ports.scalardl-auditor-priv.targetPort | int | `40052` | scalardl-priv k8s internal name |
+| auditor.service.ports.scalardl-auditor.port | int | `40051` | scalardl target port |
 | auditor.service.ports.scalardl-auditor.protocol | string | `"TCP"` | scalardl protocol |
-| auditor.service.ports.scalardl-auditor.targetPort | int | `50051` | scalardl k8s internal name |
+| auditor.service.ports.scalardl-auditor.targetPort | int | `40051` | scalardl k8s internal name |
 | auditor.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | auditor.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | auditor.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
@@ -64,7 +64,7 @@ Current chart version is `2.2.1`
 | envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
-| envoy.envoyConfiguration.serviceListeners | string | `"scalardl-audit-service:50051,scalardl-audit-privileged:50052"` | list of service name and port |
+| envoy.envoyConfiguration.serviceListeners | string | `"scalardl-audit-service:40051,scalardl-audit-privileged:40052"` | list of service name and port |
 | envoy.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | envoy.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | envoy.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
@@ -82,10 +82,10 @@ Current chart version is `2.2.1`
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy-priv.port | int | `40052` | envoy public port |
 | envoy.service.ports.envoy-priv.protocol | string | `"TCP"` | envoy protocol |
-| envoy.service.ports.envoy-priv.targetPort | int | `50052` | envoy k8s internal name |
+| envoy.service.ports.envoy-priv.targetPort | int | `40052` | envoy k8s internal name |
 | envoy.service.ports.envoy.port | int | `40051` | envoy public port |
 | envoy.service.ports.envoy.protocol | string | `"TCP"` | envoy protocol |
-| envoy.service.ports.envoy.targetPort | int | `50051` | envoy k8s internal name |
+| envoy.service.ports.envoy.targetPort | int | `40051` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | envoy.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | envoy.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -43,8 +43,8 @@ spec:
               mountPath: "/keys"
               readOnly: true
           ports:
-          - containerPort: 50051
-          - containerPort: 50052
+          - containerPort: 40051
+          - containerPort: 40052
           - containerPort: 50053
           - containerPort: 8080
           env:
@@ -94,7 +94,7 @@ spec:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
-              - -addr=:50051
+              - -addr=:40051
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -20,7 +20,7 @@ envoy:
     # -- admin log path
     adminAccessLogPath: /dev/stdout
     # -- list of service name and port
-    serviceListeners: scalardl-audit-service:50051,scalardl-audit-privileged:50052
+    serviceListeners: scalardl-audit-service:40051,scalardl-audit-privileged:40052
 
   image:
     # -- Docker image
@@ -64,14 +64,14 @@ envoy:
         # -- envoy public port
         port: 40051
         # -- envoy k8s internal name
-        targetPort: 50051
+        targetPort: 40051
         # -- envoy protocol
         protocol: TCP
       envoy-priv:
         # -- envoy public port
         port: 40052
         # -- envoy k8s internal name
-        targetPort: 50052
+        targetPort: 40052
         # -- envoy protocol
         protocol: TCP
 
@@ -129,9 +129,9 @@ auditor:
     # -- The storage of the database: cassandra or cosmos
     dbStorage: cassandra
     # -- The port number of Auditor Server
-    auditorServerPort: 50051
+    auditorServerPort: 40051
     # -- The port number of Auditor Privileged Server
-    auditorServerPrivilegedPort: 50052
+    auditorServerPrivilegedPort: 40052
     # -- The port number of Auditor Admin Server
     auditorServerAdminPort: 50053
     # -- The log level of Scalar auditor
@@ -190,16 +190,16 @@ auditor:
     ports:
       scalardl-auditor:
         # -- scalardl target port
-        port: 50051
+        port: 40051
         # -- scalardl k8s internal name
-        targetPort: 50051
+        targetPort: 40051
         # -- scalardl protocol
         protocol: TCP
       scalardl-auditor-priv:
         # -- scalardl-priv target port
-        port: 50052
+        port: 40052
         # -- scalardl-priv k8s internal name
-        targetPort: 50052
+        targetPort: 40052
         # -- scalardl-priv protocol
         protocol: TCP
       scalardl-auditor-admin:


### PR DESCRIPTION
This PR updates Scalar DB and Auditor charts to use default ports (Scalar DB -> 60051 / Auditor -> 40051, 40052).

Please take a look!