### PR TITLE
Remove unused admin port from Auditor chart

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -33,7 +33,6 @@ Current chart version is `2.2.1`
 | auditor.scalarAuditorConfiguration.auditorLedgerHost | string | `""` | The host name of Ledger. The service endpoint of Ledger-side envoy should be specified |
 | auditor.scalarAuditorConfiguration.auditorLogLevel | string | `"INFO"` | The log level of Scalar auditor |
 | auditor.scalarAuditorConfiguration.auditorPrivateKeySecretKey | string | `"private-key"` | The secret key of an Auditor private key |
-| auditor.scalarAuditorConfiguration.auditorServerAdminPort | int | `50053` | The port number of Auditor Admin Server |
 | auditor.scalarAuditorConfiguration.auditorServerPort | int | `50051` | The port number of Auditor Server |
 | auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort | int | `50052` | The port number of Auditor Privileged Server |
 | auditor.scalarAuditorConfiguration.dbContactPoints | string | `"cassandra"` | The contact points of the database such as hostnames or URLs |
@@ -44,9 +43,6 @@ Current chart version is `2.2.1`
 | auditor.scalarAuditorConfiguration.secretName | string | `"auditor-keys"` | The name of an Auditor secret |
 | auditor.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
 | auditor.service.annotations | object | `{}` | Service annotations |
-| auditor.service.ports.scalardl-auditor-admin.port | int | `50053` | scalardl-admin target port |
-| auditor.service.ports.scalardl-auditor-admin.protocol | string | `"TCP"` | scalardl-admin protocol |
-| auditor.service.ports.scalardl-auditor-admin.targetPort | int | `50053` | scalardl-admin k8s internal name |
 | auditor.service.ports.scalardl-auditor-priv.port | int | `50052` | scalardl-priv target port |
 | auditor.service.ports.scalardl-auditor-priv.protocol | string | `"TCP"` | scalardl-priv protocol |
 | auditor.service.ports.scalardl-auditor-priv.targetPort | int | `50052` | scalardl-priv k8s internal name |

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -45,7 +45,6 @@ spec:
           ports:
           - containerPort: 50051
           - containerPort: 50052
-          - containerPort: 50053
           - containerPort: 8080
           env:
           - name: SCALAR_DB_CONTACT_POINTS
@@ -76,8 +75,6 @@ spec:
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorServerPort }}"
           - name: SCALAR_DL_AUDITOR_SERVER_PRIVILEGED_PORT
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort }}"
-          - name: SCALAR_DL_AUDITOR_SERVER_ADMIN_PORT
-            value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorServerAdminPort }}"
           - name: SCALAR_DL_AUDITOR_LOG_LEVEL
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorLogLevel }}"
           - name: SCALAR_DL_AUDITOR_LEDGER_HOST

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -91,9 +91,6 @@
                         "auditorPrivateKeySecretKey": {
                             "type": "string"
                         },
-                        "auditorServerAdminPort": {
-                            "type": "integer"
-                        },
                         "auditorServerPort": {
                             "type": "integer"
                         },
@@ -133,20 +130,6 @@
                             "type": "object",
                             "properties": {
                                 "scalardl-auditor": {
-                                    "type": "object",
-                                    "properties": {
-                                        "port": {
-                                            "type": "integer"
-                                        },
-                                        "protocol": {
-                                            "type": "string"
-                                        },
-                                        "targetPort": {
-                                            "type": "integer"
-                                        }
-                                    }
-                                },
-                                "scalardl-auditor-admin": {
                                     "type": "object",
                                     "properties": {
                                         "port": {

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -132,8 +132,6 @@ auditor:
     auditorServerPort: 50051
     # -- The port number of Auditor Privileged Server
     auditorServerPrivilegedPort: 50052
-    # -- The port number of Auditor Admin Server
-    auditorServerAdminPort: 50053
     # -- The log level of Scalar auditor
     auditorLogLevel: INFO
     # -- The host name of Ledger. The service endpoint of Ledger-side envoy should be specified
@@ -201,13 +199,6 @@ auditor:
         # -- scalardl-priv k8s internal name
         targetPort: 50052
         # -- scalardl-priv protocol
-        protocol: TCP
-      scalardl-auditor-admin:
-        # -- scalardl-admin target port
-        port: 50053
-        # -- scalardl-admin k8s internal name
-        targetPort: 50053
-        # -- scalardl-admin protocol
         protocol: TCP
 
   prometheusRule:


### PR DESCRIPTION
This PR removes unused admin port (50053) from Scalar DL Auditor chart.