### PR TITLE
Support customized ledger.properties in Scalar DL Ledger

### DIFF
--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -55,6 +55,7 @@ Current chart version is `4.2.1`
 | ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
 | ledger.image.version | string | `"3.4.0"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
+| ledger.ledgerProperties | string | The minimum template of ledger.properties is set by default. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | ledger.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
 | ledger.prometheusRule.enabled | bool | `false` | enable rules for prometheus |
@@ -71,6 +72,7 @@ Current chart version is `4.2.1`
 | ledger.scalarLedgerConfiguration.ledgerPrivateKeySecretKey | string | `"private-key"` | The secret key of a Ledger private key |
 | ledger.scalarLedgerConfiguration.ledgerProofEnabled | bool | `false` | Whether or not Asset Proof is enabled |
 | ledger.scalarLedgerConfiguration.secretName | string | `"ledger-keys"` | The name of a Ledger secret |
+| ledger.secretName | string | `""` | Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom. |
 | ledger.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
 | ledger.service.annotations | object | `{}` | Service annotations |
 | ledger.service.ports.scalardl-admin.port | int | `50053` | scalardl-admin target port |
@@ -90,9 +92,4 @@ Current chart version is `4.2.1`
 | ledger.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | ledger.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
-| ledger.useCustomizedConfiguration.configMapName | string | `"ledger-customized-config"` | ConfigMap name that includes ledger.properties. |
-| ledger.useCustomizedConfiguration.enabled | bool | `false` | Use user customized ledger.properties. You need to create ConfigMap includes ledger.properties. |
-| ledger.useCustomizedConfiguration.secretKeys | list | `[{"environmentVariableName":"SCALAR_DB_USERNAME","secretKeyName":"db-username"},{"environmentVariableName":"SCALAR_DB_PASSWORD","secretKeyName":"db-password"}]` | Array of hash that includes environment variable name and secret key name. |
-| ledger.useCustomizedConfiguration.secretName | string | `"ledger-customized-secret"` | Secret name that includes credentials. |
-| ledger.useCustomizedConfiguration.useSecret | bool | `false` | Use Secret to pass the credentials as environment variable. |
 | nameOverride | string | `""` | String to partially override scalardl.fullname template (will maintain the release name) |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -90,4 +90,9 @@ Current chart version is `4.2.1`
 | ledger.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | ledger.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
+| ledger.useCustomizedConfiguration.configMapName | string | `"ledger-customized-config"` | ConfigMap name that includes ledger.properties. |
+| ledger.useCustomizedConfiguration.enabled | bool | `false` | Use user customized ledger.properties. You need to create ConfigMap includes ledger.properties. |
+| ledger.useCustomizedConfiguration.secretKeys | list | `[{"environmentVariableName":"SCALAR_DB_USERNAME","secretKeyName":"db-username"},{"environmentVariableName":"SCALAR_DB_PASSWORD","secretKeyName":"db-password"}]` | Array of hash that includes environment variable name and secret key name. |
+| ledger.useCustomizedConfiguration.secretName | string | `"ledger-customized-secret"` | Secret name that includes credentials. |
+| ledger.useCustomizedConfiguration.useSecret | bool | `false` | Use Secret to pass the credentials as environment variable. |
 | nameOverride | string | `""` | String to partially override scalardl.fullname template (will maintain the release name) |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -49,6 +49,8 @@ Current chart version is `4.2.1`
 | fullnameOverride | string | `""` | String to fully override scalardl.fullname template |
 | ledger.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | ledger.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
+| ledger.extraVolumeMounts | list | `[]` | Defines additional volume mounts. |
+| ledger.extraVolumes | list | `[]` | Defines additional volumes. |
 | ledger.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
@@ -92,6 +94,4 @@ Current chart version is `4.2.1`
 | ledger.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | ledger.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
-| ledger.volumeMounts | list | `[]` | If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties, you need to mount key file to the path set in the "scalar.dl.ledger.proof.private_key_path". |
-| ledger.volumes | list | `[]` | If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties, you need to create volume that includes key file. |
 | nameOverride | string | `""` | String to partially override scalardl.fullname template (will maintain the release name) |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -92,4 +92,6 @@ Current chart version is `4.2.1`
 | ledger.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | ledger.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
+| ledger.volumeMounts | list | `[]` | If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties, you need to mount key file to the path set in the "scalar.dl.ledger.proof.private_key_path". |
+| ledger.volumes | list | `[]` | If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties, you need to create volume that includes key file. |
 | nameOverride | string | `""` | String to partially override scalardl.fullname template (will maintain the release name) |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -55,7 +55,7 @@ Current chart version is `4.2.1`
 | ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
 | ledger.image.version | string | `"3.4.0"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
-| ledger.ledgerProperties | string | The minimum template of ledger.properties is set by default. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |
+| ledger.ledgerProperties | string | The default minimum necessary values of ledger.properties are set. You can overwrite it with your own ledger.properties. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | ledger.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
 | ledger.prometheusRule.enabled | bool | `false` | enable rules for prometheus |

--- a/charts/scalardl/templates/ledger/configmap.yaml
+++ b/charts/scalardl/templates/ledger/configmap.yaml
@@ -1,3 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "scalardl.fullname" . }}-ledger-properties
+  namespace: {{ .Release.Namespace }}
+data:
+  # Create a ledger.properties file which is config file of Scalar DL Ledger.
+  ledger.properties.tmpl:
+    {{- toYaml .Values.ledger.ledgerProperties | nindent 4 }}
+---
 {{- if .Values.ledger.grafanaDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -34,6 +34,11 @@ spec:
           secret:
             secretName: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
       {{- end }}
+      {{- if .Values.ledger.useCustomizedConfiguration.enabled }}
+        - name: ledger-customized-config-file-volume
+          configMap:
+            name: {{ .Values.ledger.useCustomizedConfiguration.configMapName }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ledger
           securityContext:
@@ -46,11 +51,17 @@ spec:
               mountPath: "/keys"
               readOnly: true
           {{- end }}
+          {{- if .Values.ledger.useCustomizedConfiguration.enabled }}
+            - name: ledger-customized-config-file-volume
+              mountPath: /scalar/ledger/ledger.properties.tmpl
+              subPath: ledger.properties.tmpl
+          {{- end }}
           ports:
           - containerPort: 50051
           - containerPort: 50052
           - containerPort: 50053
           - containerPort: 8080
+          {{- if not .Values.ledger.useCustomizedConfiguration.enabled }}
           env:
           - name: SCALAR_DB_CONTACT_POINTS
             value: "{{ .Values.ledger.scalarLedgerConfiguration.dbContactPoints }}"
@@ -85,6 +96,16 @@ spec:
           {{- if .Values.ledger.scalarLedgerConfiguration.ledgerAuditorEnabled }}
           - name: SCALAR_DL_LEDGER_AUDITOR_ENABLED
             value: "{{ .Values.ledger.scalarLedgerConfiguration.ledgerAuditorEnabled }}"
+          {{- end }}
+          {{- else if .Values.ledger.useCustomizedConfiguration.useSecret }}
+          env:
+          {{- range .Values.ledger.useCustomizedConfiguration.secretKeys }}
+          - name: {{ .environmentVariableName }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Values.ledger.useCustomizedConfiguration.secretName }}
+                key: {{ .secretKeyName }}
+          {{- end }}
           {{- end }}
           livenessProbe:
             exec:

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: scalardl-ledger-properties-volume
           configMap:
             name: {{ include "scalardl.fullname" . }}-ledger-properties
-      {{- with .Values.ledger.volumes }}
+      {{- with .Values.ledger.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
@@ -57,7 +57,7 @@ spec:
             - name: scalardl-ledger-properties-volume
               mountPath: /scalar/ledger/ledger.properties.tmpl
               subPath: ledger.properties.tmpl
-          {{- with .Values.ledger.volumeMounts }}
+          {{- with .Values.ledger.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         {{- toYaml .Values.ledger.podSecurityContext | nindent 8 }}
       volumes:
-      {{- if (lookup "v1" "Secret" .Release.Namespace .Values.ledger.scalarLedgerConfiguration.secretName) }}
+      {{- if or (.Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled) (lookup "v1" "Secret" .Release.Namespace .Values.ledger.scalarLedgerConfiguration.secretName) }}
         - name: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
           secret:
             secretName: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
@@ -46,7 +46,7 @@ spec:
           image: "{{ .Values.ledger.image.repository }}:{{ .Values.ledger.image.version }}"
           imagePullPolicy: {{ .Values.ledger.image.pullPolicy }}
           volumeMounts:
-          {{- if (lookup "v1" "Secret" .Release.Namespace .Values.ledger.scalarLedgerConfiguration.secretName) }}
+          {{- if or (.Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled) (lookup "v1" "Secret" .Release.Namespace .Values.ledger.scalarLedgerConfiguration.secretName) }}
             - name: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
               mountPath: "/keys"
               readOnly: true

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -17,6 +17,8 @@ spec:
   {{- end }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ledger/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "scalardl-ledger.selectorLabels" . | nindent 8 }}
     spec:
@@ -29,16 +31,14 @@ spec:
       securityContext:
         {{- toYaml .Values.ledger.podSecurityContext | nindent 8 }}
       volumes:
-      {{- if .Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled }}
+      {{- if (lookup "v1" "Secret" .Release.Namespace .Values.ledger.scalarLedgerConfiguration.secretName) }}
         - name: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
           secret:
             secretName: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
       {{- end }}
-      {{- if .Values.ledger.useCustomizedConfiguration.enabled }}
-        - name: ledger-customized-config-file-volume
+        - name: scalardl-ledger-properties-volume
           configMap:
-            name: {{ .Values.ledger.useCustomizedConfiguration.configMapName }}
-      {{- end }}
+            name: {{ include "scalardl.fullname" . }}-ledger-properties
       containers:
         - name: {{ .Chart.Name }}-ledger
           securityContext:
@@ -46,28 +46,25 @@ spec:
           image: "{{ .Values.ledger.image.repository }}:{{ .Values.ledger.image.version }}"
           imagePullPolicy: {{ .Values.ledger.image.pullPolicy }}
           volumeMounts:
-          {{- if .Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled }}
+          {{- if (lookup "v1" "Secret" .Release.Namespace .Values.ledger.scalarLedgerConfiguration.secretName) }}
             - name: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
               mountPath: "/keys"
               readOnly: true
           {{- end }}
-          {{- if .Values.ledger.useCustomizedConfiguration.enabled }}
-            - name: ledger-customized-config-file-volume
+            - name: scalardl-ledger-properties-volume
               mountPath: /scalar/ledger/ledger.properties.tmpl
               subPath: ledger.properties.tmpl
-          {{- end }}
           ports:
           - containerPort: 50051
           - containerPort: 50052
           - containerPort: 50053
           - containerPort: 8080
-          {{- if not .Values.ledger.useCustomizedConfiguration.enabled }}
           env:
-          - name: SCALAR_DB_CONTACT_POINTS
+          - name: HELM_SCALAR_DB_CONTACT_POINTS
             value: "{{ .Values.ledger.scalarLedgerConfiguration.dbContactPoints }}"
-          - name: SCALAR_DB_CONTACT_PORT
+          - name: HELM_SCALAR_DB_CONTACT_PORT
             value: "{{ .Values.ledger.scalarLedgerConfiguration.dbContactPort }}"
-          - name: SCALAR_DB_USERNAME
+          - name: HELM_SCALAR_DB_USERNAME
             valueFrom:
               secretKeyRef:
               {{- if .Values.ledger.existingSecret }}
@@ -76,7 +73,7 @@ spec:
                 name: {{ include "scalardl.fullname" . }}-ledger
               {{- end }}
                 key: db-username
-          - name: SCALAR_DB_PASSWORD
+          - name: HELM_SCALAR_DB_PASSWORD
             valueFrom:
               secretKeyRef:
               {{- if .Values.ledger.existingSecret }}
@@ -85,27 +82,22 @@ spec:
                 name: {{ include "scalardl.fullname" . }}-ledger
               {{- end }}
                 key: db-password
-          - name: SCALAR_DB_STORAGE
+          - name: HELM_SCALAR_DB_STORAGE
             value: "{{ .Values.ledger.scalarLedgerConfiguration.dbStorage }}"
           - name: SCALAR_DL_LEDGER_LOG_LEVEL
             value: "{{ .Values.ledger.scalarLedgerConfiguration.ledgerLogLevel }}"
-          - name: SCALAR_DL_LEDGER_PROOF_ENABLED
+          - name: HELM_SCALAR_DL_LEDGER_PROOF_ENABLED
             value: "{{ .Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled }}"
-          - name: SCALAR_DL_LEDGER_PROOF_PRIVATE_KEY_PATH
+          - name: HELM_SCALAR_DL_LEDGER_PROOF_PRIVATE_KEY_PATH
             value: "/keys/{{ .Values.ledger.scalarLedgerConfiguration.ledgerPrivateKeySecretKey }}"
           {{- if .Values.ledger.scalarLedgerConfiguration.ledgerAuditorEnabled }}
-          - name: SCALAR_DL_LEDGER_AUDITOR_ENABLED
+          - name: HELM_SCALAR_DL_LEDGER_AUDITOR_ENABLED
             value: "{{ .Values.ledger.scalarLedgerConfiguration.ledgerAuditorEnabled }}"
           {{- end }}
-          {{- else if .Values.ledger.useCustomizedConfiguration.useSecret }}
-          env:
-          {{- range .Values.ledger.useCustomizedConfiguration.secretKeys }}
-          - name: {{ .environmentVariableName }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $.Values.ledger.useCustomizedConfiguration.secretName }}
-                key: {{ .secretKeyName }}
-          {{- end }}
+          {{- if .Values.ledger.secretName }}
+          envFrom:
+          - secretRef:
+              name: "{{ .Values.ledger.secretName }}"
           {{- end }}
           livenessProbe:
             exec:

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         {{- toYaml .Values.ledger.podSecurityContext | nindent 8 }}
       volumes:
-      {{- if or (.Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled) (lookup "v1" "Secret" .Release.Namespace .Values.ledger.scalarLedgerConfiguration.secretName) }}
+      {{- if .Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled }}
         - name: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
           secret:
             secretName: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
@@ -39,6 +39,9 @@ spec:
         - name: scalardl-ledger-properties-volume
           configMap:
             name: {{ include "scalardl.fullname" . }}-ledger-properties
+      {{- with .Values.ledger.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ledger
           securityContext:
@@ -46,7 +49,7 @@ spec:
           image: "{{ .Values.ledger.image.repository }}:{{ .Values.ledger.image.version }}"
           imagePullPolicy: {{ .Values.ledger.image.pullPolicy }}
           volumeMounts:
-          {{- if or (.Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled) (lookup "v1" "Secret" .Release.Namespace .Values.ledger.scalarLedgerConfiguration.secretName) }}
+          {{- if .Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled }}
             - name: "{{ .Values.ledger.scalarLedgerConfiguration.secretName }}"
               mountPath: "/keys"
               readOnly: true
@@ -54,6 +57,9 @@ spec:
             - name: scalardl-ledger-properties-volume
               mountPath: /scalar/ledger/ledger.properties.tmpl
               subPath: ledger.properties.tmpl
+          {{- with .Values.ledger.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
           - containerPort: 50051
           - containerPort: 50052

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -209,6 +209,9 @@
                         }
                     }
                 },
+                "ledgerProperties": {
+                    "type": "string"
+                },
                 "nodeSelector": {
                     "type": "object"
                 },
@@ -266,6 +269,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "secretName": {
+                    "type": "string"
                 },
                 "securityContext": {
                     "type": "object"
@@ -363,37 +369,6 @@
                 },
                 "tolerations": {
                     "type": "array"
-                },
-                "useCustomizedConfiguration": {
-                    "type": "object",
-                    "properties": {
-                        "configMapName": {
-                            "type": "string"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "secretKeys": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "environmentVariableName": {
-                                        "type": "string"
-                                    },
-                                    "secretKeyName": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "secretName": {
-                            "type": "string"
-                        },
-                        "useSecret": {
-                            "type": "boolean"
-                        }
-                    }
                 }
             }
         },

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -363,6 +363,37 @@
                 },
                 "tolerations": {
                     "type": "array"
+                },
+                "useCustomizedConfiguration": {
+                    "type": "object",
+                    "properties": {
+                        "configMapName": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "secretKeys": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "environmentVariableName": {
+                                        "type": "string"
+                                    },
+                                    "secretKeyName": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "secretName": {
+                            "type": "string"
+                        },
+                        "useSecret": {
+                            "type": "boolean"
+                        }
+                    }
                 }
             }
         },

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -173,6 +173,12 @@
                 "existingSecret": {
                     "type": "string"
                 },
+                "extraVolumeMounts": {
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "type": "array"
+                },
                 "grafanaDashboard": {
                     "type": "object",
                     "properties": {
@@ -368,12 +374,6 @@
                     }
                 },
                 "tolerations": {
-                    "type": "array"
-                },
-                "volumeMounts": {
-                    "type": "array"
-                },
-                "volumes": {
                     "type": "array"
                 }
             }

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -369,6 +369,12 @@
                 },
                 "tolerations": {
                     "type": "array"
+                },
+                "volumeMounts": {
+                    "type": "array"
+                },
+                "volumes": {
+                    "type": "array"
                 }
             }
         },

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -140,6 +140,22 @@ ledger:
     # -- The secret key of a Ledger private key
     ledgerPrivateKeySecretKey: private-key
 
+  useCustomizedConfiguration:
+    # -- Use user customized ledger.properties. You need to create ConfigMap includes ledger.properties.
+    enabled: false
+    # -- ConfigMap name that includes ledger.properties.
+    configMapName: "ledger-customized-config"
+    # -- Use Secret to pass the credentials as environment variable.
+    useSecret: false
+    # -- Secret name that includes credentials.
+    secretName: "ledger-customized-secret"
+    # -- Array of hash that includes environment variable name and secret key name.
+    secretKeys:
+      - environmentVariableName: SCALAR_DB_USERNAME
+        secretKeyName: db-username
+      - environmentVariableName: SCALAR_DB_PASSWORD
+        secretKeyName: db-password
+
   image:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -140,21 +140,42 @@ ledger:
     # -- The secret key of a Ledger private key
     ledgerPrivateKeySecretKey: private-key
 
-  useCustomizedConfiguration:
-    # -- Use user customized ledger.properties. You need to create ConfigMap includes ledger.properties.
-    enabled: false
-    # -- ConfigMap name that includes ledger.properties.
-    configMapName: "ledger-customized-config"
-    # -- Use Secret to pass the credentials as environment variable.
-    useSecret: false
-    # -- Secret name that includes credentials.
-    secretName: "ledger-customized-secret"
-    # -- Array of hash that includes environment variable name and secret key name.
-    secretKeys:
-      - environmentVariableName: SCALAR_DB_USERNAME
-        secretKeyName: db-username
-      - environmentVariableName: SCALAR_DB_PASSWORD
-        secretKeyName: db-password
+  # -- The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties.
+  # @default -- The minimum template of ledger.properties is set by default.
+  ledgerProperties: |
+    # Comma separated contact points
+    # The value of ledger.scalarLedgerConfiguration.dbContactPoints is set by default.
+    scalar.db.contact_points={{ default .Env.HELM_SCALAR_DB_CONTACT_POINTS "" }}
+
+    # Port number for all the contact points. Default port number for each database is used if empty.
+    # The value of ledger.scalarLedgerConfiguration.dbContactPort is set by default.
+    scalar.db.contact_port={{ default .Env.HELM_SCALAR_DB_CONTACT_PORT "" }}
+
+    # Credential information to access the database
+    # The value of ledger.scalarLedgerConfiguration.dbUsername is set by default.
+    scalar.db.username={{ default .Env.HELM_SCALAR_DB_USERNAME "" }}
+    # The value of ledger.scalarLedgerConfiguration.dbPassword is set by default.
+    scalar.db.password={{ default .Env.HELM_SCALAR_DB_PASSWORD "" }}
+
+    # Storage implementation. Either cassandra or cosmos can be set.
+    # The value of ledger.scalarLedgerConfiguration.dbStorage is set by default.
+    scalar.db.storage={{ default .Env.HELM_SCALAR_DB_STORAGE "" }}
+
+    # A flag to enable asset proof that is used to verify assets.
+    # This feature must be enabled in both client and server.
+    # The value of ledger.scalarLedgerConfiguration.ledgerProofEnabled is set by default.
+    scalar.dl.ledger.proof.enabled={{ default .Env.HELM_SCALAR_DL_LEDGER_PROOF_ENABLED "" }}
+
+    # A flag to use Auditor.
+    # The value of ledger.scalarLedgerConfiguration.ledgerAuditorEnabled is set by default.
+    scalar.dl.ledger.auditor.enabled={{ default .Env.HELM_SCALAR_DL_LEDGER_AUDITOR_ENABLED "" }}
+
+    # Private key file used for signing a proof entry.
+    # The value "/keys/ledger.scalarLedgerConfiguration.ledgerPrivateKeySecretKey" is set by default.
+    scalar.dl.ledger.proof.private_key_path={{ default .Env.HELM_SCALAR_DL_LEDGER_PROOF_PRIVATE_KEY_PATH "" }}
+
+  # -- Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom.
+  secretName: ""
 
   image:
     # -- Docker image

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -210,10 +210,21 @@ ledger:
     # runAsNonRoot: true
     # runAsUser: 1000
 
-  # -- If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties, you need to create volume that includes key file.
-  volumes: []
-  # -- If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties, you need to mount key file to the path set in the "scalar.dl.ledger.proof.private_key_path".
-  volumeMounts: []
+  # -- Defines additional volumes.
+  extraVolumes: []
+  # If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties,
+  # you need to create volume that includes key file.
+  # - name: ledger-keys
+  #   secret:
+  #     secretName: ledger-keys
+
+  # -- Defines additional volume mounts.
+  extraVolumeMounts: []
+  # If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties,
+  # you need to mount key file to the path set in the "scalar.dl.ledger.proof.private_key_path".
+  # - name: ledger-keys
+  #   mountPath: /keys
+  #   readOnly: true
 
   service:
     # -- service types in kubernetes

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -141,7 +141,7 @@ ledger:
     ledgerPrivateKeySecretKey: private-key
 
   # -- The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties.
-  # @default -- The minimum template of ledger.properties is set by default.
+  # @default -- The default minimum necessary values of ledger.properties are set. You can overwrite it with your own ledger.properties.
   ledgerProperties: |
     # Comma separated contact points
     # The value of ledger.scalarLedgerConfiguration.dbContactPoints is set by default.

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -210,6 +210,11 @@ ledger:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  # -- If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties, you need to create volume that includes key file.
+  volumes: []
+  # -- If you set "scalar.dl.ledger.proof.enabled=true" to ledger.ledgerProperties, you need to mount key file to the path set in the "scalar.dl.ledger.proof.private_key_path".
+  volumeMounts: []
+
   service:
     # -- service types in kubernetes
     type: ClusterIP


### PR DESCRIPTION
This PR add a new feature that accepting user customized ledger.properties file in the Scalar DL Ledger Helm Charts.
By default, it is disabled.

Please take a look!

---

## How to use your customized ledger.properties file

You can use your customized ledger.properties by the following steps.

1. Set `ledger.useCustomizedConfiguration.enabled=true` in your custom value file.
1. Create a `ConfigMap` resource using your ledger.properties file as follows.
   ```console
   kubectl create configmap ledger-customized-config --from-file=ledger.properties.tmpl=ledger.properties
   ```
1. Create schema using the Scalar DL Schema Loader Helm Chats.
1. Deploy Scalar DL using Helm Charts.

---

## How to pass the credentials as a environment variables using `Secret` resource

Also, you can use a `Secret` resource to pass the credentials as a environment variables as follows.

1. Set `ledger.useCustomizedConfiguration.useSecret=true` in your custom value file.
1. Create the `ConfigMap` includes environment variable name as Go template syntax.
   ```
   scalar.dl.ledger.proof.enabled=false
   scalar.dl.ledger.auditor.enabled=false
   
   scalar.db.contact_points=jdbc:postgresql://postgresql-ledger:5432/postgres
   scalar.db.username={{ default .Env.CUSTOMIZED_CONFIG_POSTGRES_USERNAME "" }}
   scalar.db.password={{ default .Env.CUSTOMIZED_CONFIG_POSTGRES_PASSWORD "" }}
   scalar.db.storage=jdbc
   ```
1. Create the `Secret` includes credentials.
   ```console
   kubectl create secret generic ledger-customized-secret \
     --from-literal=customized-config-username=postgres \
     --from-literal=customized-config-password=xxxxxxxx
   ```
1. Specify the **environment variable name** and **key name** of `Secret` in the custom values file.
   ```yaml
   ledger:
     useCustomizedConfiguration:
       enabled: true
       configMapName: "ledger-customized-config"
       useSecret: true
       secretKeys:
         - environmentVariableName: CUSTOMIZED_CONFIG_POSTGRES_USERNAME
           secretKeyName: customized-config-username
         - environmentVariableName: CUSTOMIZED_CONFIG_POSTGRES_PASSWORD
           secretKeyName: customized-config-password
   ```

As a result, the credentials are set in the ledger.properties file in each container as follows.
```
scalar.dl.ledger.proof.enabled=false
scalar.dl.ledger.auditor.enabled=false

scalar.db.contact_points=jdbc:postgresql://postgresql-ledger:5432/postgres
scalar.db.username=postgres
scalar.db.password=xxxxxxxx
scalar.db.storage=jdbc
```
