### PR TITLE
Support customized auditor.properties in Scalar DL Auditor

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -14,6 +14,7 @@ Current chart version is `2.2.1`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | auditor.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
+| auditor.auditorProperties | string | The minimum template of auditor.properties is set by default. | The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties. |
 | auditor.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | auditor.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
@@ -33,7 +34,6 @@ Current chart version is `2.2.1`
 | auditor.scalarAuditorConfiguration.auditorLedgerHost | string | `""` | The host name of Ledger. The service endpoint of Ledger-side envoy should be specified |
 | auditor.scalarAuditorConfiguration.auditorLogLevel | string | `"INFO"` | The log level of Scalar auditor |
 | auditor.scalarAuditorConfiguration.auditorPrivateKeySecretKey | string | `"private-key"` | The secret key of an Auditor private key |
-| auditor.scalarAuditorConfiguration.auditorProperties | string | The minimum template of auditor.properties is set by default. | The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties. |
 | auditor.scalarAuditorConfiguration.auditorServerAdminPort | int | `50053` | The port number of Auditor Admin Server |
 | auditor.scalarAuditorConfiguration.auditorServerPort | int | `40051` | The port number of Auditor Server |
 | auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort | int | `40052` | The port number of Auditor Privileged Server |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -14,7 +14,7 @@ Current chart version is `2.2.1`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | auditor.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
-| auditor.auditorProperties | string | The minimum template of auditor.properties is set by default. | The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties. |
+| auditor.auditorProperties | string | The default minimum necessary values of auditor.properties are set. You can overwrite it with your own auditor.properties. | The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties. |
 | auditor.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | auditor.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -16,6 +16,8 @@ Current chart version is `2.2.1`
 | auditor.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | auditor.auditorProperties | string | The default minimum necessary values of auditor.properties are set. You can overwrite it with your own auditor.properties. | The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties. |
 | auditor.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
+| auditor.extraVolumeMounts | list | `[]` | Defines additional volume mounts. |
+| auditor.extraVolumes | list | `[]` | Defines additional volumes. |
 | auditor.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | auditor.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
@@ -63,8 +65,6 @@ Current chart version is `2.2.1`
 | auditor.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | auditor.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
-| auditor.volumeMounts | list | `[]` | If you set your properties to auditor.auditorProperties, you need to mount key and cert file to the path set in the "scalar.dl.auditor.private_key_path" and "scalar.dl.auditor.cert_path". |
-| auditor.volumes | list | `[]` | If you set your properties to auditor.auditorProperties, you need to create volume that includes key and cert file. |
 | envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -61,6 +61,11 @@ Current chart version is `2.2.1`
 | auditor.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | auditor.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
+| auditor.useCustomizedConfiguration.configMapName | string | `"auditor-customized-config"` | ConfigMap name that includes auditor.properties. |
+| auditor.useCustomizedConfiguration.enabled | bool | `false` | Use user customized auditor.properties. You need to create ConfigMap includes auditor.properties. |
+| auditor.useCustomizedConfiguration.secretKeys | list | `[{"environmentVariableName":"SCALAR_DB_USERNAME","secretKeyName":"db-username"},{"environmentVariableName":"SCALAR_DB_PASSWORD","secretKeyName":"db-password"}]` | Array of hash that includes environment variable name and secret key name. |
+| auditor.useCustomizedConfiguration.secretName | string | `"auditor-customized-secret"` | Secret name that includes credentials. |
+| auditor.useCustomizedConfiguration.useSecret | bool | `false` | Use Secret to pass the credentials as environment variable. |
 | envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -33,6 +33,7 @@ Current chart version is `2.2.1`
 | auditor.scalarAuditorConfiguration.auditorLedgerHost | string | `""` | The host name of Ledger. The service endpoint of Ledger-side envoy should be specified |
 | auditor.scalarAuditorConfiguration.auditorLogLevel | string | `"INFO"` | The log level of Scalar auditor |
 | auditor.scalarAuditorConfiguration.auditorPrivateKeySecretKey | string | `"private-key"` | The secret key of an Auditor private key |
+| auditor.scalarAuditorConfiguration.auditorProperties | string | The minimum template of auditor.properties is set by default. | The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties. |
 | auditor.scalarAuditorConfiguration.auditorServerAdminPort | int | `50053` | The port number of Auditor Admin Server |
 | auditor.scalarAuditorConfiguration.auditorServerPort | int | `40051` | The port number of Auditor Server |
 | auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort | int | `40052` | The port number of Auditor Privileged Server |
@@ -42,6 +43,7 @@ Current chart version is `2.2.1`
 | auditor.scalarAuditorConfiguration.dbStorage | string | `"cassandra"` | The storage of the database: cassandra or cosmos |
 | auditor.scalarAuditorConfiguration.dbUsername | string | `"cassandra"` | The username of the database |
 | auditor.scalarAuditorConfiguration.secretName | string | `"auditor-keys"` | The name of an Auditor secret |
+| auditor.secretName | string | `""` | Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom. |
 | auditor.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
 | auditor.service.annotations | object | `{}` | Service annotations |
 | auditor.service.ports.scalardl-auditor-admin.port | int | `50053` | scalardl-admin target port |
@@ -61,11 +63,6 @@ Current chart version is `2.2.1`
 | auditor.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | auditor.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
-| auditor.useCustomizedConfiguration.configMapName | string | `"auditor-customized-config"` | ConfigMap name that includes auditor.properties. |
-| auditor.useCustomizedConfiguration.enabled | bool | `false` | Use user customized auditor.properties. You need to create ConfigMap includes auditor.properties. |
-| auditor.useCustomizedConfiguration.secretKeys | list | `[{"environmentVariableName":"SCALAR_DB_USERNAME","secretKeyName":"db-username"},{"environmentVariableName":"SCALAR_DB_PASSWORD","secretKeyName":"db-password"}]` | Array of hash that includes environment variable name and secret key name. |
-| auditor.useCustomizedConfiguration.secretName | string | `"auditor-customized-secret"` | Secret name that includes credentials. |
-| auditor.useCustomizedConfiguration.useSecret | bool | `false` | Use Secret to pass the credentials as environment variable. |
 | envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -63,6 +63,8 @@ Current chart version is `2.2.1`
 | auditor.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | auditor.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
+| auditor.volumeMounts | list | `[]` | If you set your properties to auditor.auditorProperties, you need to mount key and cert file to the path set in the "scalar.dl.auditor.private_key_path" and "scalar.dl.auditor.cert_path". |
+| auditor.volumes | list | `[]` | If you set your properties to auditor.auditorProperties, you need to create volume that includes key and cert file. |
 | envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |

--- a/charts/scalardl-audit/templates/auditor/configmap.yaml
+++ b/charts/scalardl-audit/templates/auditor/configmap.yaml
@@ -1,3 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "scalardl-audit.fullname" . }}-auditor-properties
+  namespace: {{ .Release.Namespace }}
+data:
+  # Create a auditor.properties file which is config file of Scalar DL Auditor.
+  auditor.properties.tmpl:
+    {{- toYaml .Values.auditor.auditorProperties | nindent 4 }}
+---
 {{- if .Values.auditor.grafanaDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -29,15 +29,15 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-        {{- if not .Values.auditor.volumes }}
+      {{- if not .Values.auditor.extraVolumes }}
         - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
           secret:
             secretName: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
-        {{- end }}
+      {{- end }}
         - name: scalardl-auditor-properties-volume
           configMap:
             name: {{ include "scalardl-audit.fullname" . }}-auditor-properties
-      {{- with .Values.auditor.volumes }}
+      {{- with .Values.auditor.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
@@ -49,7 +49,7 @@ spec:
           image: "{{ .Values.auditor.image.repository }}:{{ .Values.auditor.image.version }}"
           imagePullPolicy: {{ .Values.auditor.image.pullPolicy }}
           volumeMounts:
-          {{- if not .Values.auditor.volumeMounts }}
+          {{- if not .Values.auditor.extraVolumeMounts }}
             - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
               mountPath: "/keys"
               readOnly: true
@@ -57,7 +57,7 @@ spec:
             - name: scalardl-auditor-properties-volume
               mountPath: /scalar/auditor/auditor.properties.tmpl
               subPath: auditor.properties.tmpl
-          {{- with .Values.auditor.volumeMounts }}
+          {{- with .Values.auditor.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -30,6 +30,11 @@ spec:
       - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
         secret:
           secretName: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
+      {{- if .Values.auditor.useCustomizedConfiguration.enabled }}
+      - name: auditor-customized-config-file-volume
+        configMap:
+          name: {{ .Values.auditor.useCustomizedConfiguration.configMapName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.auditor.podSecurityContext | nindent 8 }}
       containers:
@@ -42,11 +47,17 @@ spec:
             - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
               mountPath: "/keys"
               readOnly: true
+            {{- if .Values.auditor.useCustomizedConfiguration.enabled }}
+            - name: auditor-customized-config-file-volume
+              mountPath: /scalar/auditor/auditor.properties.tmpl
+              subPath: auditor.properties.tmpl
+            {{- end }}
           ports:
           - containerPort: 40051
           - containerPort: 40052
           - containerPort: 50053
           - containerPort: 8080
+          {{- if not .Values.auditor.useCustomizedConfiguration.enabled }}
           env:
           - name: SCALAR_DB_CONTACT_POINTS
             value: "{{ .Values.auditor.scalarAuditorConfiguration.dbContactPoints }}"
@@ -90,6 +101,16 @@ spec:
             value: "/keys/{{ .Values.auditor.scalarAuditorConfiguration.auditorCertSecretKey }}"
           - name: SCALAR_DL_AUDITOR_PRIVATE_KEY_PATH
             value: "/keys/{{ .Values.auditor.scalarAuditorConfiguration.auditorPrivateKeySecretKey }}"
+          {{- else if .Values.auditor.useCustomizedConfiguration.useSecret }}
+          env:
+          {{- range .Values.auditor.useCustomizedConfiguration.secretKeys }}
+          - name: {{ .environmentVariableName }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Values.auditor.useCustomizedConfiguration.secretName }}
+                key: {{ .secretKeyName }}
+          {{- end }}
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -29,12 +29,17 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-      - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
-        secret:
-          secretName: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
-      - name: scalardl-auditor-properties-volume
-        configMap:
-          name: {{ include "scalardl-audit.fullname" . }}-auditor-properties
+        {{- if not .Values.auditor.volumes }}
+        - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
+          secret:
+            secretName: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
+        {{- end }}
+        - name: scalardl-auditor-properties-volume
+          configMap:
+            name: {{ include "scalardl-audit.fullname" . }}-auditor-properties
+      {{- with .Values.auditor.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.auditor.podSecurityContext | nindent 8 }}
       containers:
@@ -44,12 +49,17 @@ spec:
           image: "{{ .Values.auditor.image.repository }}:{{ .Values.auditor.image.version }}"
           imagePullPolicy: {{ .Values.auditor.image.pullPolicy }}
           volumeMounts:
+          {{- if not .Values.auditor.volumeMounts }}
             - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
               mountPath: "/keys"
               readOnly: true
+          {{- end }}
             - name: scalardl-auditor-properties-volume
               mountPath: /scalar/auditor/auditor.properties.tmpl
               subPath: auditor.properties.tmpl
+          {{- with .Values.auditor.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
           - containerPort: 40051
           - containerPort: 40052

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -17,6 +17,8 @@ spec:
   {{- end }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/auditor/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 8 }}
     spec:
@@ -30,11 +32,9 @@ spec:
       - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
         secret:
           secretName: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
-      {{- if .Values.auditor.useCustomizedConfiguration.enabled }}
-      - name: auditor-customized-config-file-volume
+      - name: scalardl-auditor-properties-volume
         configMap:
-          name: {{ .Values.auditor.useCustomizedConfiguration.configMapName }}
-      {{- end }}
+          name: {{ include "scalardl-audit.fullname" . }}-auditor-properties
       securityContext:
         {{- toYaml .Values.auditor.podSecurityContext | nindent 8 }}
       containers:
@@ -47,23 +47,20 @@ spec:
             - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
               mountPath: "/keys"
               readOnly: true
-            {{- if .Values.auditor.useCustomizedConfiguration.enabled }}
-            - name: auditor-customized-config-file-volume
+            - name: scalardl-auditor-properties-volume
               mountPath: /scalar/auditor/auditor.properties.tmpl
               subPath: auditor.properties.tmpl
-            {{- end }}
           ports:
           - containerPort: 40051
           - containerPort: 40052
           - containerPort: 50053
           - containerPort: 8080
-          {{- if not .Values.auditor.useCustomizedConfiguration.enabled }}
           env:
-          - name: SCALAR_DB_CONTACT_POINTS
+          - name: HELM_SCALAR_DB_CONTACT_POINTS
             value: "{{ .Values.auditor.scalarAuditorConfiguration.dbContactPoints }}"
-          - name: SCALAR_DB_CONTACT_PORT
+          - name: HELM_SCALAR_DB_CONTACT_PORT
             value: "{{ .Values.auditor.scalarAuditorConfiguration.dbContactPort }}"
-          - name: SCALAR_DB_USERNAME
+          - name: HELM_SCALAR_DB_USERNAME
             valueFrom:
               secretKeyRef:
               {{- if .Values.auditor.existingSecret }}
@@ -72,7 +69,7 @@ spec:
                 name: {{ include "scalardl-audit.fullname" . }}-auditor
               {{- end }}
                 key: db-username
-          - name: SCALAR_DB_PASSWORD
+          - name: HELM_SCALAR_DB_PASSWORD
             valueFrom:
               secretKeyRef:
               {{- if .Values.auditor.existingSecret }}
@@ -81,35 +78,30 @@ spec:
                 name: {{ include "scalardl-audit.fullname" . }}-auditor
               {{- end }}
                 key: db-password
-          - name: SCALAR_DB_STORAGE
+          - name: HELM_SCALAR_DB_STORAGE
             value: "{{ .Values.auditor.scalarAuditorConfiguration.dbStorage }}"
-          - name: SCALAR_DL_AUDITOR_SERVER_PORT
+          - name: HELM_SCALAR_DL_AUDITOR_SERVER_PORT
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorServerPort }}"
-          - name: SCALAR_DL_AUDITOR_SERVER_PRIVILEGED_PORT
+          - name: HELM_SCALAR_DL_AUDITOR_SERVER_PRIVILEGED_PORT
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort }}"
-          - name: SCALAR_DL_AUDITOR_SERVER_ADMIN_PORT
+          - name: HELM_SCALAR_DL_AUDITOR_SERVER_ADMIN_PORT
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorServerAdminPort }}"
           - name: SCALAR_DL_AUDITOR_LOG_LEVEL
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorLogLevel }}"
-          - name: SCALAR_DL_AUDITOR_LEDGER_HOST
+          - name: HELM_SCALAR_DL_AUDITOR_LEDGER_HOST
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorLedgerHost }}"
-          - name: SCALAR_DL_AUDITOR_CERT_HOLDER_ID
+          - name: HELM_SCALAR_DL_AUDITOR_CERT_HOLDER_ID
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorCertHolderId }}"
-          - name: SCALAR_DL_AUDITOR_CERT_VERSION
+          - name: HELM_SCALAR_DL_AUDITOR_CERT_VERSION
             value: "{{ .Values.auditor.scalarAuditorConfiguration.auditorCertVersion }}"
-          - name: SCALAR_DL_AUDITOR_CERT_PATH
+          - name: HELM_SCALAR_DL_AUDITOR_CERT_PATH
             value: "/keys/{{ .Values.auditor.scalarAuditorConfiguration.auditorCertSecretKey }}"
-          - name: SCALAR_DL_AUDITOR_PRIVATE_KEY_PATH
+          - name: HELM_SCALAR_DL_AUDITOR_PRIVATE_KEY_PATH
             value: "/keys/{{ .Values.auditor.scalarAuditorConfiguration.auditorPrivateKeySecretKey }}"
-          {{- else if .Values.auditor.useCustomizedConfiguration.useSecret }}
-          env:
-          {{- range .Values.auditor.useCustomizedConfiguration.secretKeys }}
-          - name: {{ .environmentVariableName }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $.Values.auditor.useCustomizedConfiguration.secretName }}
-                key: {{ .secretKeyName }}
-          {{- end }}
+          {{- if .Values.auditor.secretName }}
+          envFrom:
+          - secretRef:
+              name: "{{ .Values.auditor.secretName }}"
           {{- end }}
           livenessProbe:
             exec:

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -14,6 +14,12 @@
                 "existingSecret": {
                     "type": "string"
                 },
+                "extraVolumeMounts": {
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "type": "array"
+                },
                 "grafanaDashboard": {
                     "type": "object",
                     "properties": {
@@ -221,12 +227,6 @@
                     }
                 },
                 "tolerations": {
-                    "type": "array"
-                },
-                "volumeMounts": {
-                    "type": "array"
-                },
-                "volumes": {
                     "type": "array"
                 }
             }

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -216,6 +216,37 @@
                 },
                 "tolerations": {
                     "type": "array"
+                },
+                "useCustomizedConfiguration": {
+                    "type": "object",
+                    "properties": {
+                        "configMapName": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "secretKeys": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "environmentVariableName": {
+                                        "type": "string"
+                                    },
+                                    "secretKeyName": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "secretName": {
+                            "type": "string"
+                        },
+                        "useSecret": {
+                            "type": "boolean"
+                        }
+                    }
                 }
             }
         },

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -91,6 +91,9 @@
                         "auditorPrivateKeySecretKey": {
                             "type": "string"
                         },
+                        "auditorProperties": {
+                            "type": "string"
+                        },
                         "auditorServerAdminPort": {
                             "type": "integer"
                         },
@@ -119,6 +122,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "secretName": {
+                    "type": "string"
                 },
                 "securityContext": {
                     "type": "object"
@@ -216,37 +222,6 @@
                 },
                 "tolerations": {
                     "type": "array"
-                },
-                "useCustomizedConfiguration": {
-                    "type": "object",
-                    "properties": {
-                        "configMapName": {
-                            "type": "string"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "secretKeys": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "environmentVariableName": {
-                                        "type": "string"
-                                    },
-                                    "secretKeyName": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "secretName": {
-                            "type": "string"
-                        },
-                        "useSecret": {
-                            "type": "boolean"
-                        }
-                    }
                 }
             }
         },

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -222,6 +222,12 @@
                 },
                 "tolerations": {
                     "type": "array"
+                },
+                "volumeMounts": {
+                    "type": "array"
+                },
+                "volumes": {
+                    "type": "array"
                 }
             }
         },

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -8,6 +8,9 @@
                 "affinity": {
                     "type": "object"
                 },
+                "auditorProperties": {
+                    "type": "string"
+                },
                 "existingSecret": {
                     "type": "string"
                 },
@@ -89,9 +92,6 @@
                             "type": "string"
                         },
                         "auditorPrivateKeySecretKey": {
-                            "type": "string"
-                        },
-                        "auditorProperties": {
                             "type": "string"
                         },
                         "auditorServerAdminPort": {

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -150,7 +150,7 @@ auditor:
     auditorPrivateKeySecretKey: private-key
 
   # -- The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties.
-  # @default -- The minimum template of auditor.properties is set by default.
+  # @default -- The default minimum necessary values of auditor.properties are set. You can overwrite it with your own auditor.properties.
   auditorProperties: |
     # Comma separated contact points
     # The value of auditor.scalarAuditorConfiguration.dbContactPoints is set by default.

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -241,6 +241,11 @@ auditor:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  # -- If you set your properties to auditor.auditorProperties, you need to create volume that includes key and cert file.
+  volumes: []
+  # -- If you set your properties to auditor.auditorProperties, you need to mount key and cert file to the path set in the "scalar.dl.auditor.private_key_path" and "scalar.dl.auditor.cert_path".
+  volumeMounts: []
+
   service:
     # -- service types in kubernetes
     type: ClusterIP

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -149,6 +149,22 @@ auditor:
     # -- The secret key of an Auditor private key
     auditorPrivateKeySecretKey: private-key
 
+  useCustomizedConfiguration:
+    # -- Use user customized auditor.properties. You need to create ConfigMap includes auditor.properties.
+    enabled: false
+    # -- ConfigMap name that includes auditor.properties.
+    configMapName: "auditor-customized-config"
+    # -- Use Secret to pass the credentials as environment variable.
+    useSecret: false
+    # -- Secret name that includes credentials.
+    secretName: "auditor-customized-secret"
+    # -- Array of hash that includes environment variable name and secret key name.
+    secretKeys:
+      - environmentVariableName: SCALAR_DB_USERNAME
+        secretKeyName: db-username
+      - environmentVariableName: SCALAR_DB_PASSWORD
+        secretKeyName: db-password
+
   image:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-auditor

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -241,10 +241,22 @@ auditor:
     # runAsNonRoot: true
     # runAsUser: 1000
 
-  # -- If you set your properties to auditor.auditorProperties, you need to create volume that includes key and cert file.
-  volumes: []
-  # -- If you set your properties to auditor.auditorProperties, you need to mount key and cert file to the path set in the "scalar.dl.auditor.private_key_path" and "scalar.dl.auditor.cert_path".
-  volumeMounts: []
+  # -- Defines additional volumes.
+  extraVolumes: []
+  # If you set your properties to auditor.auditorProperties,
+  # you need to create volume that includes key and cert file.
+  # - name: auditor-keys
+  #   secret:
+  #     secretName: auditor-keys
+
+  # -- Defines additional volume mounts.
+  extraVolumeMounts: []
+  # If you set your properties to auditor.auditorProperties,
+  # you need to mount key and cert file to the path set in the "scalar.dl.auditor.private_key_path"
+  # and "scalar.dl.auditor.cert_path".
+  # - name: auditor-keys
+  #   mountPath: /keys
+  #   readOnly: true
 
   service:
     # -- service types in kubernetes

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -149,21 +149,64 @@ auditor:
     # -- The secret key of an Auditor private key
     auditorPrivateKeySecretKey: private-key
 
-  useCustomizedConfiguration:
-    # -- Use user customized auditor.properties. You need to create ConfigMap includes auditor.properties.
-    enabled: false
-    # -- ConfigMap name that includes auditor.properties.
-    configMapName: "auditor-customized-config"
-    # -- Use Secret to pass the credentials as environment variable.
-    useSecret: false
-    # -- Secret name that includes credentials.
-    secretName: "auditor-customized-secret"
-    # -- Array of hash that includes environment variable name and secret key name.
-    secretKeys:
-      - environmentVariableName: SCALAR_DB_USERNAME
-        secretKeyName: db-username
-      - environmentVariableName: SCALAR_DB_PASSWORD
-        secretKeyName: db-password
+  # -- The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties.
+  # @default -- The minimum template of auditor.properties is set by default.
+  auditorProperties: |
+    # Comma separated contact points
+    # The value of auditor.scalarAuditorConfiguration.dbContactPoints is set by default.
+    scalar.db.contact_points={{ default .Env.HELM_SCALAR_DB_CONTACT_POINTS "" }}
+
+    # Port number for all the contact points. Default port number for each database is used if empty.
+    # The value of auditor.scalarAuditorConfiguration.dbContactPort is set by default.
+    scalar.db.contact_port={{ default .Env.HELM_SCALAR_DB_CONTACT_PORT "" }}
+
+    # Credential information to access the database
+    # The value of auditor.scalarAuditorConfiguration.dbUsername is set by default.
+    scalar.db.username={{ default .Env.HELM_SCALAR_DB_USERNAME "" }}
+    # The value of auditor.scalarAuditorConfiguration.dbPassword is set by default.
+    scalar.db.password={{ default .Env.HELM_SCALAR_DB_PASSWORD "" }}
+
+    # Storage implementation. Either cassandra or cosmos can be set.
+    # The value of auditor.scalarAuditorConfiguration.dbStorage is set by default.
+    scalar.db.storage={{ default .Env.HELM_SCALAR_DB_STORAGE "" }}
+
+    # Server port.
+    # The value of auditor.scalarAuditorConfiguration.auditorServerPort is set by default.
+    scalar.dl.auditor.server.port={{ default .Env.HELM_SCALAR_DL_AUDITOR_SERVER_PORT "" }}
+
+    # Server privileged port.
+    # The value of auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort is set by default.
+    scalar.dl.auditor.server.privileged_port={{ default .Env.HELM_SCALAR_DL_AUDITOR_SERVER_PRIVILEGED_PORT "" }}
+
+    # Server admin port.
+    # The value of auditor.scalarAuditorConfiguration.auditorServerAdminPort is set by default.
+    scalar.dl.auditor.server.admin_port={{ default .Env.HELM_SCALAR_DL_AUDITOR_SERVER_ADMIN_PORT "" }}
+
+    # Optional. A hostname or an IP address of the ledger server.
+    # It assumes that there is a single endpoint that is given by DNS or a load balancer.
+    # The value of auditor.scalarAuditorConfiguration.auditorLedgerHost is set by default.
+    scalar.dl.auditor.ledger.host={{ default .Env.HELM_SCALAR_DL_AUDITOR_LEDGER_HOST "" }}
+
+    # Required. The holder ID of a certificate.
+    # It must be configured for each private key and unique in the system.
+    # The value of auditor.scalarAuditorConfiguration.auditorCertHolderId is set by default.
+    scalar.dl.auditor.cert_holder_id={{ default .Env.HELM_SCALAR_DL_AUDITOR_CERT_HOLDER_ID "" }}
+
+    # Optional. The version of the certificate.
+    # Use another bigger integer if you need to change your private key.
+    # The value of auditor.scalarAuditorConfiguration.auditorCertVersion is set by default.
+    scalar.dl.auditor.cert_version={{ default .Env.HELM_SCALAR_DL_AUDITOR_CERT_VERSION "" }}
+
+    # Required. The path of the certificate file in PEM format.
+    # The value "/keys/auditor.scalarAuditorConfiguration.auditorCertSecretKey" is set by default.
+    scalar.dl.auditor.cert_path={{ default .Env.HELM_SCALAR_DL_AUDITOR_CERT_PATH "" }}
+
+    # Required. The path of a corresponding private key file in PEM format to the certificate.
+    # The value "/keys/auditor.scalarAuditorConfiguration.auditorPrivateKeySecretKey" is set by default.
+    scalar.dl.auditor.private_key_path={{ default .Env.HELM_SCALAR_DL_AUDITOR_PRIVATE_KEY_PATH "" }}
+
+  # -- Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom.
+  secretName: ""
 
   image:
     # -- Docker image


### PR DESCRIPTION
This PR add a new feature that accepting user customized auditor.properties file in the Scalar DL Auditor Helm Charts.
By default, it is disabled.

Please take a look!

---

## How to use your customized auditor.properties file

You can use your customized auditor.properties by the following steps.

1. Deploy Scalar DL Ledger.
1. Set `auditor.useCustomizedConfiguration.enabled=true` in your custom value file.
1. Create a `ConfigMap` resource using your auditor.properties file as follows.
   ```console
   kubectl create configmap auditor-customized-config --from-file=auditor.properties.tmpl=auditor.properties
   ```
1. Create schema using the Scalar DL Schema Loader Helm Chats.
1. Deploy Scalar DL Auditor using Helm Charts.

---

## How to pass the credentials as a environment variables using `Secret` resource

Also, you can use a `Secret` resource to pass the credentials as a environment variables as follows.

1. Set `auditor.useCustomizedConfiguration.useSecret=true` in your custom value file.
1. Create the `ConfigMap` includes environment variable name as Go template syntax.
   ```
   scalar.dl.auditor.ledger.host=ledger-scalardl-envoy
   scalar.dl.auditor.cert_path=/keys/certificate
   scalar.dl.auditor.private_key_path=/keys/private-key
   
   scalar.db.contact_points=jdbc:postgresql://postgresql-auditor:5432/postgres
   scalar.db.username={{ default .Env.CUSTOMIZED_CONFIG_POSTGRES_USERNAME "" }}
   scalar.db.password={{ default .Env.CUSTOMIZED_CONFIG_POSTGRES_PASSWORD "" }}
   scalar.db.storage=jdbc
   ```
1. Create the `Secret` includes credentials.
   ```console
   kubectl create secret generic auditor-customized-secret \
     --from-literal=customized-config-username=postgres \
     --from-literal=customized-config-password=xxxxxxxx
   ```
1. Specify the **environment variable name** and **key name** of `Secret` in the custom values file.
   ```yaml
   auditor:
     useCustomizedConfiguration:
       enabled: true
       configMapName: "auditor-customized-config"
       useSecret: true
       secretKeys:
         - environmentVariableName: CUSTOMIZED_CONFIG_POSTGRES_USERNAME
           secretKeyName: customized-config-username
         - environmentVariableName: CUSTOMIZED_CONFIG_POSTGRES_PASSWORD
           secretKeyName: customized-config-password
   ```

As a result, the credentials are set in the auditor.properties file in each container as follows.
```
scalar.dl.auditor.ledger.host=ledger-scalardl-envoy
scalar.dl.auditor.cert_path=/keys/certificate
scalar.dl.auditor.private_key_path=/keys/private-key

scalar.db.contact_points=jdbc:postgresql://postgresql-auditor:5432/postgres
scalar.db.username=postgres
scalar.db.password=postgres-pass-auditor
scalar.db.storage=jdbc
```
