### PR TITLE
Add monitoring resources to scalardb-graphql chart

### DIFF
--- a/charts/scalardb-graphql/README.md
+++ b/charts/scalardb-graphql/README.md
@@ -22,6 +22,8 @@ Current chart version is `1.0.0`
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings. |
+| prometheusRule.enabled | bool | `false` | enable rules for prometheus |
+| prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | replicaCount | int | `3` |  |
 | resources | object | `{}` | Resources allowed to the pod. |
 | scalarDbGraphQlConfiguration.consensuscommitIsolationLevel | string | `""` | Default isolation level for ConsensusCommit. |
@@ -40,6 +42,9 @@ Current chart version is `1.0.0`
 | service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | service.port | int | `8080` | Scalar DB GraphQL server port. |
 | service.type | string | `"ClusterIP"` | service types in kubernetes. |
+| serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
+| serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
+| serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |

--- a/charts/scalardb-graphql/templates/scalardb-graphql/prometheusrules.yaml
+++ b/charts/scalardb-graphql/templates/scalardb-graphql/prometheusrules.yaml
@@ -1,0 +1,55 @@
+{{- if ( .Values.prometheusRule.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    release: prometheus
+  name: {{ include "scalardb-graphql.fullname" . }}-prometheus-alerts-rules
+{{- if .Values.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheusRule.namespace }}
+{{- end }}
+spec:
+  groups:
+  - name: ScalarDbGraphQlAlerts
+    rules:
+    - alert: ScalarDbGraphQlClusterDown
+      expr: kube_deployment_spec_replicas{deployment="{{ include "scalardb-graphql.fullname" . }}"} - kube_deployment_status_replicas_unavailable{deployment="{{ include "scalardb-graphql.fullname" . }}"} == 0
+      for: 1m
+      labels:
+        severity: critical
+        app: ScalarDbGraphQl
+      annotations:
+        summary: 'Scalar DB GraphQL cluster is down'
+        description: 'Scalar DB GraphQL cluster is down, no resquest can be process'
+
+    - alert: ScalarDbGraphQlClusterDegraded
+      expr: kube_deployment_status_replicas_unavailable{namespace="{{ .Release.Namespace }}", deployment="{{ include "scalardb-graphql.fullname" . }}"} >= 1
+      for: 1m
+      labels:
+        severity: warning
+        app: ScalarDbGraphQl
+      annotations:
+        summary: 'Scalar DB GraphQL cluster is running in a degraded mode'
+        description: 'Scalar DB GraphQL cluster is running in a degraded mode, some of the Scalar DB GraphQL pods are not healthy'
+
+    - alert: ScalarDbGraphQlPodsPending
+      expr: kube_pod_status_phase{namespace="{{ .Release.Namespace }}", pod=~"^{{ include "scalardb-graphql.fullname" . }}-.*", phase="Pending"} > 0
+      for: 1m
+      labels:
+        severity: warning
+        app: ScalarDbGraphQl
+      annotations:
+        description: 'Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}} has been in pending status for more than 1 minute.'
+        summary: 'Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}} in pending status.'
+
+    - alert: ScalarDbGraphQlPodsError
+      expr: kube_pod_container_status_waiting_reason{namespace="{{ .Release.Namespace }}",reason!="ContainerCreating",pod=~"^{{ include "scalardb-graphql.fullname" . }}-.*"} > 0
+      for: 1m
+      labels:
+        severity: warning
+        app: ScalarDbGraphQl
+      annotations:
+        description: 'Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}} has an error for more than 1 minute.'
+        summary: 'Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}} has an error status.'
+{{- end }}

--- a/charts/scalardb-graphql/templates/scalardb-graphql/service.yaml
+++ b/charts/scalardb-graphql/templates/scalardb-graphql/service.yaml
@@ -16,3 +16,19 @@ spec:
       name: http
   selector:
     {{- include "scalardb-graphql.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scalardb-graphql.fullname" . }}-metrics
+  labels:
+    {{- include "scalardb-graphql.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: scalardb-graphql-prometheus
+    port: 9080
+    targetPort: 9080
+    protocol: TCP
+  selector:
+    {{- include "scalardb-graphql.selectorLabels" . | nindent 4 }}
+  type: ClusterIP

--- a/charts/scalardb-graphql/templates/scalardb-graphql/servicemonitor.yaml
+++ b/charts/scalardb-graphql/templates/scalardb-graphql/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "scalardb-graphql.fullname" . }}-metrics
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "scalardb-graphql.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: scalardb-graphql-prometheus
+    path: /stats/prometheus
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/charts/scalardb-graphql/values.yaml
+++ b/charts/scalardb-graphql/values.yaml
@@ -61,6 +61,20 @@ service:
   # -- Service annotations, e.g: prometheus, etc.
   annotations: {}
 
+serviceMonitor:
+  # -- enable metrics collect with prometheus
+  enabled: false
+  # -- custom interval to retrieve the metrics
+  interval: "15s"
+  # -- which namespace prometheus is located. by default monitoring
+  namespace: monitoring
+
+prometheusRule:
+  # -- enable rules for prometheus
+  enabled: false
+  # -- which namespace prometheus is located. by default monitoring
+  namespace: monitoring
+
 ingress:
   # -- Enable ingress resource.
   enabled: true


### PR DESCRIPTION
This PR adds Service, ServiceMonitor, and PrometheusRule resources to `scalardb-graphql` chart as `scalardb` and `scalardl` charts do.

The latest build of the docker image from the `scalardb-graphql` `main` branch is needed.

I confirmed on a minikube cluster:

* Build a docker image of scalardb-graphql

    ```console
    cd /path/to/scalardb-graphql
    ./gradlew docker
    minikube image load ghcr.io/scalar-labs/scalardb-graphql:4.0.0-SNAPSHOT
    minikube image tag ghcr.io/scalar-labs/scalardb-graphql:4.0.0-SNAPSHOT local/test/scalardb-graphql:4.0.0-SNAPSHOT
    ```

* Start a database in the `minikube` network and load a schema

    ```console
    docker run -d --name cassandra-scalardb --network minikube -p 9042:9042 cassandra:3.11
    java -jar scalardb-schema-loader-3.5.0.jar ...
    ```

* Create a custom values file

    ```
    cat <<EOF > test-custom-values.yaml
    image:
      repository: local/test/scalardb-graphql
      tag: 4.0.0-SNAPSHOT
    
    scalarDbGraphQlConfiguration:
      contactPoints: cassandra-scalardb
      contactPort: 9042
      username: cassandra
      password: cassandra
      storage: cassandra
      logLevel: INFO
      path: /graphql
      namespaces: emoney
      graphiql: "true"
    
    service:
      type: LoadBalancer

    serviceMonitor:
      enabled: true
    prometheusRule:
      enabled: true
    ingress:
      enabled: true
      className: nginx
    EOF
    ```
    
* Deploy using Helm

    ```console
    helm install scalardb-graphql ./charts/scalardb-graphql/ -f /path/to/test-custom-values.yaml
    ```

Then, confirmed that monitoring is working by following the guide: https://github.com/scalar-labs/helm-charts/blob/main/docs/getting-started-monitoring.md

---

The Grafana Dashboard configuration is going to be added in another PR since it will be large.
