### PR TITLE
Update default Ingress paths configuration in values.yaml

### DIFF
--- a/charts/scalardb-graphql/README.md
+++ b/charts/scalardb-graphql/README.md
@@ -17,7 +17,7 @@ Current chart version is `1.0.0`
 | ingress.annotations | object | `{"alb.ingress.kubernetes.io/healthcheck-path":"/graphql?query=%7B__typename%7D","alb.ingress.kubernetes.io/scheme":"internal","alb.ingress.kubernetes.io/target-group-attributes":"stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60","alb.ingress.kubernetes.io/target-type":"ip","nginx.ingress.kubernetes.io/affinity":"cookie","nginx.ingress.kubernetes.io/session-cookie-hash":"sha1","nginx.ingress.kubernetes.io/session-cookie-max-age":"300","nginx.ingress.kubernetes.io/session-cookie-name":"INGRESSCOOKIE","nginx.ingress.kubernetes.io/session-cookie-path":"/"}` | The class-specific annotations for the ingress resource. |
 | ingress.className | string | `""` | The ingress class name. Specify "alb" for AWS Application Load Balancer. |
 | ingress.enabled | bool | `true` | Enable ingress resource. |
-| ingress.hosts | list | `[{"host":"","paths":[{"path":"/","pathType":"Prefix"}]}]` | List of rules that are handled with the the ingress. |
+| ingress.hosts | list | `[{"host":"","paths":[{"path":"/graphql","pathType":"Exact"}]}]` | List of rules that are handled with the the ingress. |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |

--- a/charts/scalardb-graphql/values.yaml
+++ b/charts/scalardb-graphql/values.yaml
@@ -89,12 +89,8 @@ ingress:
   hosts:
     - host: ""
       paths:
-        # For `className: alb`
-        # - path: /graphql
-        #   pathType: ImplementationSpecific
-        # For `className: nginx`
-        - path: /
-          pathType: Prefix
+        - path: /graphql
+          pathType: Exact
 
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
This PR updates the default Ingress paths configuration.

`pathType: Exact` is enough for the GraphQL single endpoint. And I confirmed this works with ALB.
https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types

<img width="1235" alt="Screen Shot 2022-07-01 at 20 10 48" src="https://user-images.githubusercontent.com/11030/176886185-64bc97e9-a7ba-4a45-867e-794ea3504d17.png">

(If it is set to `Prefix`, the ALB path becomes `/graphql OR /graphql/*`, but the second is not needed.)

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/11030/176888517-b0c1c77f-8d8c-4b83-9deb-16f6875212e5.png">
