### PR TITLE
Remove Scalar Manager from index.yaml to make it invisible

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -201,17 +201,6 @@ entries:
     urls:
     - https://github.com/scalar-labs/helm-charts/releases/download/envoy-1.0.0/envoy-1.0.0.tgz
     version: 1.0.0
-  scalar-manager:
-  - apiVersion: v2
-    appVersion: 1.0.0
-    created: "2022-07-19T06:25:43.856309893Z"
-    description: Scalar Manager
-    digest: 4c6c3fbf05e1073ddb32405077aba1415aa1306a324cfd029b59587266958be3
-    name: scalar-manager
-    type: application
-    urls:
-    - https://github.com/scalar-labs/helm-charts/releases/download/scalar-manager-1.0.0/scalar-manager-1.0.0.tgz
-    version: 1.0.0
   scalardb:
   - apiVersion: v2
     appVersion: 3.6.0


### PR DESCRIPTION
This PR removes Scalar Manager Helm Chart from index to make it invisible from users in the `helm search` command.

---

When I updated the Scalar DB version of main branch to keep it latest in the following PR, there were some conflicts.
https://github.com/scalar-labs/helm-charts/pull/114

To resolve the above conflicts, I merged  main branch to prepare-release-v2.3.0 branch (This branch uses for release of Scalar DB).
In this merge operation merged Scalar Manager Helm Chart from main to prepare-release-v2.3.0.
As a result, the Chart Releaser in the release workflow detects Scalar Manager Helm Chart and released it.
This is an unexpected release...

The tag and asset of Scalar Manager v1.0.0 has already created by Chart Releaser.
However, I think we can make it invisible from users in the `helm` command by removing entry of Scalar Manager from `index.yaml`.
The index entry that is created by Chart Releaser is the following.
https://github.com/scalar-labs/helm-charts/commit/097d807bb5fba288d5194904ada2212e7cb9afbf

So, I remove it.
Sorry for my mistake...
I will update this release workflow in the future to avoid these unexpected behavior.

Also, when we release Scalar Manager Helm Chart officially, we need to use other than v1.0.0 (e.g. v1.0.1 or v.1.1.0...) version.