### PR TITLE
Add default security context in Scalar DL (Ledger/Auditor) chart

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -46,7 +46,7 @@ Current chart version is `2.2.2`
 | auditor.scalarAuditorConfiguration.dbUsername | string | `"cassandra"` | The username of the database |
 | auditor.scalarAuditorConfiguration.secretName | string | `"auditor-keys"` | The name of an Auditor secret |
 | auditor.secretName | string | `""` | Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom. |
-| auditor.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
+| auditor.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod |
 | auditor.service.annotations | object | `{}` | Service annotations |
 | auditor.service.ports.scalardl-auditor-admin.port | int | `50053` | scalardl-admin target port |
 | auditor.service.ports.scalardl-auditor-admin.protocol | string | `"TCP"` | scalardl-admin protocol |

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -133,7 +133,26 @@
                     "type": "string"
                 },
                 "securityContext": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        }
+                    }
                 },
                 "service": {
                     "type": "object",

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -233,13 +233,12 @@ auditor:
     # fsGroup: 2000
 
   # -- Setting security context at the pod applies those settings to all containers in the pod
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
 
   # -- Defines additional volumes.
   extraVolumes: []

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -75,7 +75,7 @@ Current chart version is `4.2.2`
 | ledger.scalarLedgerConfiguration.ledgerProofEnabled | bool | `false` | Whether or not Asset Proof is enabled |
 | ledger.scalarLedgerConfiguration.secretName | string | `"ledger-keys"` | The name of a Ledger secret |
 | ledger.secretName | string | `""` | Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom. |
-| ledger.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
+| ledger.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod |
 | ledger.service.annotations | object | `{}` | Service annotations |
 | ledger.service.ports.scalardl-admin.port | int | `50053` | scalardl-admin target port |
 | ledger.service.ports.scalardl-admin.protocol | string | `"TCP"` | scalardl-admin protocol |

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -280,7 +280,26 @@
                     "type": "string"
                 },
                 "securityContext": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        }
+                    }
                 },
                 "service": {
                     "type": "object",

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -202,13 +202,12 @@ ledger:
     # fsGroup: 2000
 
   # -- Setting security context at the pod applies those settings to all containers in the pod
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
 
   # -- Defines additional volumes.
   extraVolumes: []


### PR DESCRIPTION
This PR adds the security context as default values in the Scalar DL (Ledger/Auditor) Helm Charts.
After this updates, the Pod (Deployment) includes the following security context by default.

```json
$ kubectl get deployment scalardl-ledger-ledger -o jsonpath='{.spec.template.spec.containers[].securityContext}' | jq .
{
  "allowPrivilegeEscalation": false,
  "capabilities": {
    "drop": [
      "ALL"
    ]
  },
  "runAsNonRoot": true
}
```
```json
$ kubectl get deployment scalardl-auditor-auditor -o jsonpath='{.spec.template.spec.containers[].securityContext}' | jq .
{
  "allowPrivilegeEscalation": false,
  "capabilities": {
    "drop": [
      "ALL"
    ]
  },
  "runAsNonRoot": true
}
```

Please take a look!
