### PR TITLE
Remove unnecessary capabilities from Scalar DB and Envoy chert

### DIFF
--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -30,9 +30,9 @@ Current chart version is `2.1.0`
 | rbac.serviceAccountAnnotations | object | `{}` | Annotations for the Service Account |
 | replicaCount | int | `3` | number of replicas to deploy |
 | resources | object | `{}` | resources allowed to the pod |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod |
 | securityContext.allowPrivilegeEscalation | bool | `false` | AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process |
-| securityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default |
+| securityContext.capabilities | object | `{"drop":["ALL"]}` | Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default |
 | securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege) |
 | service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | service.ports.envoy-priv.port | int | `50052` | nvoy public port |

--- a/charts/envoy/values.schema.json
+++ b/charts/envoy/values.schema.json
@@ -103,12 +103,6 @@
                 "capabilities": {
                     "type": "object",
                     "properties": {
-                        "add": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "drop": {
                             "type": "array",
                             "items": {

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -37,8 +37,6 @@ securityContext:
   capabilities:
     drop:
       - ALL
-    add:
-      - NET_BIND_SERVICE
   # securityContext.runAsNonRoot -- Containers should be run as a non-root user with the minimum required permissions (principle of least privilege)
   runAsNonRoot: true
   # securityContext.allowPrivilegeEscalation -- AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -65,9 +65,9 @@ Current chart version is `2.3.0`
 | scalardb.replicaCount | int | `3` | Default values for number of replicas. |
 | scalardb.resources | object | `{}` | Resources allowed to the pod. |
 | scalardb.secretName | string | `""` | Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom. |
-| scalardb.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod. |
+| scalardb.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod. |
 | scalardb.securityContext.allowPrivilegeEscalation | bool | `false` | AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process |
-| scalardb.securityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default |
+| scalardb.securityContext.capabilities | object | `{"drop":["ALL"]}` | Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default |
 | scalardb.securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege) |
 | scalardb.service.ports.scalardb.port | int | `60051` | Scalar DB server port. |
 | scalardb.service.ports.scalardb.protocol | string | `"TCP"` | Scalar DB server protocol. |

--- a/charts/scalardb/values.schema.json
+++ b/charts/scalardb/values.schema.json
@@ -255,12 +255,6 @@
                         "capabilities": {
                             "type": "object",
                             "properties": {
-                                "add": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
                                 "drop": {
                                     "type": "array",
                                     "items": {

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -220,8 +220,6 @@ scalardb:
     capabilities:
       drop:
         - ALL
-      add:
-        - NET_BIND_SERVICE
     # -- Containers should be run as a non-root user with the minimum required permissions (principle of least privilege)
     runAsNonRoot: true
     # -- AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process


### PR DESCRIPTION
This PR removes unnecessary Linux capability `NET_BIND_SERVICE` from Scalar DB and Envoy chart.
`NET_BIND_SERVICE` allows binding a socket to internet domain privileged ports (port numbers less than 1024).

https://man7.org/linux/man-pages/man7/capabilities.7.html
https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities

However, Scalar DB and Envoy does not bind any ports less than 1024.
So, I remove this unnecessary capability to make them more secure.

Please take a look!