### PR TITLE
Add `seccompProfile` field in `securityContext` instead of annotation

### DIFF
--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -21,8 +21,8 @@ Current chart version is `2.1.0`
 | image.version | string | `"1.3.0"` |  |
 | imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
-| podAnnotations | object | `{"seccomp.security.alpha.kubernetes.io/pod":"runtime/default"}` | Pod annotations for the envoy Deployment |
-| podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
+| podAnnotations | object | `{}` | Pod annotations for the envoy Deployment |
+| podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings |
 | podSecurityPolicy.enabled | bool | `true` | enable pod security policy |
 | prometheusRule.enabled | bool | `false` | enable rules for prometheus |
 | prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |

--- a/charts/envoy/values.schema.json
+++ b/charts/envoy/values.schema.json
@@ -48,15 +48,20 @@
             "type": "object"
         },
         "podAnnotations": {
-            "type": "object",
-            "properties": {
-                "seccomp.security.alpha.kubernetes.io/pod": {
-                    "type": "string"
-                }
-            }
+            "type": "object"
         },
         "podSecurityContext": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         },
         "podSecurityPolicy": {
             "type": "object",

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -28,8 +28,9 @@ strategy:
   type: RollingUpdate
 
 # podSecurityContext -- PodSecurityContext holds pod-level security attributes and common container settings
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
 # securityContext -- Setting security context at the pod applies those settings to all containers in the pod
 securityContext:
@@ -45,8 +46,7 @@ securityContext:
   allowPrivilegeEscalation: false
 
 # podAnnotations -- Pod annotations for the envoy Deployment
-podAnnotations:
-  seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
+podAnnotations: {}
 
 service:
   # service.type -- service types in kubernetes

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -55,8 +55,8 @@ Current chart version is `2.3.0`
 | scalardb.image.tag | string | `"3.6.0"` | Docker tag of the image. |
 | scalardb.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalardb.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
-| scalardb.podAnnotations | object | `{"seccomp.security.alpha.kubernetes.io/pod":"runtime/default"}` | Pod annotations for the scalardb deployment |
-| scalardb.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings. |
+| scalardb.podAnnotations | object | `{}` | Pod annotations for the scalardb deployment |
+| scalardb.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings. |
 | scalardb.podSecurityPolicy.enabled | bool | `true` | Enable pod security policy |
 | scalardb.prometheusRule.enabled | bool | `false` | Enable rules for prometheus. |
 | scalardb.prometheusRule.namespace | string | `"monitoring"` | Which namespace prometheus is located. by default monitoring. |

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -19,7 +19,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/scalardb/configmap.yaml") . | sha256sum }}
+        {{- if .Values.scalardb.podAnnotations }}
         {{- toYaml .Values.scalardb.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "scalardb.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/scalardb/values.schema.json
+++ b/charts/scalardb/values.schema.json
@@ -197,15 +197,20 @@
                     "type": "object"
                 },
                 "podAnnotations": {
-                    "type": "object",
-                    "properties": {
-                        "seccomp.security.alpha.kubernetes.io/pod": {
-                            "type": "string"
-                        }
-                    }
+                    "type": "object"
                 },
                 "podSecurityContext": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 },
                 "podSecurityPolicy": {
                     "type": "object",

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -211,8 +211,8 @@ scalardb:
 
   # -- PodSecurityContext holds pod-level security attributes and common container settings.
   podSecurityContext:
-    {}
-    # fsGroup: 2000
+    seccompProfile:
+      type: RuntimeDefault
 
   # -- Setting security context at the pod applies those settings to all containers in the pod.
   securityContext:
@@ -228,8 +228,7 @@ scalardb:
     allowPrivilegeEscalation: false
 
   # -- Pod annotations for the scalardb deployment
-  podAnnotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
+  podAnnotations: {}
 
   # -- Resources allowed to the pod.
   resources:

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -25,7 +25,7 @@ Current chart version is `2.2.2`
 | auditor.image.version | string | `"3.4.1"` | Docker tag |
 | auditor.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | auditor.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
-| auditor.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
+| auditor.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings |
 | auditor.prometheusRule.enabled | bool | `false` | enable rules for prometheus |
 | auditor.prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | auditor.replicaCount | int | `3` | number of replicas to deploy |

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -60,7 +60,17 @@
                     "type": "object"
                 },
                 "podSecurityContext": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 },
                 "prometheusRule": {
                     "type": "object",

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -229,8 +229,9 @@ auditor:
     type: RollingUpdate
 
   # -- PodSecurityContext holds pod-level security attributes and common container settings
-  podSecurityContext: {}
-    # fsGroup: 2000
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
 
   # -- Setting security context at the pod applies those settings to all containers in the pod
   securityContext: {}

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -59,7 +59,7 @@ Current chart version is `4.2.2`
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.ledgerProperties | string | The default minimum necessary values of ledger.properties are set. You can overwrite it with your own ledger.properties. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
-| ledger.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
+| ledger.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings |
 | ledger.prometheusRule.enabled | bool | `false` | enable rules for prometheus |
 | ledger.prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | ledger.replicaCount | int | `3` | number of replicas to deploy |

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -222,7 +222,17 @@
                     "type": "object"
                 },
                 "podSecurityContext": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 },
                 "prometheusRule": {
                     "type": "object",

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -198,8 +198,9 @@ ledger:
     type: RollingUpdate
 
   # -- PodSecurityContext holds pod-level security attributes and common container settings
-  podSecurityContext: {}
-    # fsGroup: 2000
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
 
   # -- Setting security context at the pod applies those settings to all containers in the pod
   securityContext: {}


### PR DESCRIPTION
This PR adds `securityContext.seccompProfile` in each chart.

---

In Scalar DB and Envoy chart, they are using annotation `seccomp.security.alpha.kubernetes.io/pod` for setting seccomp configuration.
However, this annotation is deprecated and it will be not-functional in next Kubernetes release as follows.

* Message when I deploy current chart
  ```console
  Warning: spec.template.metadata.annotations[seccomp.security.alpha.kubernetes.io/pod]: deprecated since v1.19, non-functional in v1.25+; use the "seccompProfile" field instead
  ```

So, I removed deprecated annotation and added `securityContext.seccompProfile` for setting the same seccomp configuration.

---

In Scalar DL (Ledger and Auditor) chart, there is no configuration related to the seccomp now.
So, I just added `securityContext.seccompProfile` for setting seccomp configuration to make them more secure.

Please take a look!