### PR TITLE
Disable seccomp checking in CI (kubeaudit)

### DIFF
--- a/.github/kube-audit.yaml
+++ b/.github/kube-audit.yaml
@@ -11,7 +11,7 @@ enabledAuditors:
   privesc: true
   privileged: true
   rootfs: false
-  seccomp: true
+  seccomp: false
 auditors:
   capabilities:
     allowAddList: ['NET_BIND_SERVICE']


### PR DESCRIPTION
I updated the security configurations in the following PR.
https://github.com/scalar-labs/helm-charts/pull/118

Now,  in the Scalar Helm Charts, we use `securityContext.seccompProfile` instead of `seccomp.security.alpha.kubernetes.io/pod` annotation. This is because this annotation is deprecated now and it will be removed in the next kubernetes release.
However, the `kubeaudit` returns error as a result of `seccomp` checking since the `kubeaudit` does not understand `PodSecurityContext.seccompProfile`.
This is a known issue in the `kubeaudit`.

Please see the following comment too.
https://github.com/scalar-labs/helm-charts/pull/118#issuecomment-1189894201

So, I updated the configuration of `kubeaudit` to disable `seccomp` checking.
We can enable it again after the known issue of `kubeaudit` will be fixed.

Please take a look!