### PR TITLE
Disable Pod Security Policy by default in Envoy chart

### DIFF
--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -23,7 +23,7 @@ Current chart version is `2.1.0`
 | nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | podAnnotations | object | `{"seccomp.security.alpha.kubernetes.io/pod":"runtime/default"}` | Pod annotations for the envoy Deployment |
 | podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
-| podSecurityPolicy.enabled | bool | `true` | enable pod security policy |
+| podSecurityPolicy.enabled | bool | `false` | enable pod security policy |
 | prometheusRule.enabled | bool | `false` | enable rules for prometheus |
 | prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | rbac.create | bool | `true` | If true, create and use RBAC resources |

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -77,7 +77,7 @@ rbac:
 
 podSecurityPolicy:
   # podSecurityPolicy.enabled -- enable pod security policy
-  enabled: true
+  enabled: false
 
 serviceMonitor:
   # serviceMonitor.enabled -- enable metrics collect with prometheus


### PR DESCRIPTION
This PR disables Pod Security Policy by default since this feature is deprecated  and it will be removed in the next Kubernetes release.
Also, I updated the security configurations in the following PRs.

https://github.com/scalar-labs/helm-charts/pull/116
https://github.com/scalar-labs/helm-charts/pull/117
https://github.com/scalar-labs/helm-charts/pull/118

So, this PR should be merged after the above PRs are merged.
Please take a look!