### PR TITLE
Remove inappropriate default values in Envoy chart

### DIFF
--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -35,9 +35,6 @@ Current chart version is `2.1.0`
 | securityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Capabilities (specifically, Linux capabilities), are used for permission management in Linux. Some capabilities are enabled by default |
 | securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege) |
 | service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
-| service.ports.envoy-priv.port | int | `50052` | nvoy public port |
-| service.ports.envoy-priv.protocol | string | `"TCP"` | envoy protocol |
-| service.ports.envoy-priv.targetPort | int | `50052` | envoy k8s internal name |
 | service.ports.envoy.port | int | `50051` | envoy public port |
 | service.ports.envoy.protocol | string | `"TCP"` | envoy protocol |
 | service.ports.envoy.targetPort | int | `50051` | envoy k8s internal name |

--- a/charts/envoy/values.schema.json
+++ b/charts/envoy/values.schema.json
@@ -144,20 +144,6 @@
                                     "type": "integer"
                                 }
                             }
-                        },
-                        "envoy-priv": {
-                            "type": "object",
-                            "properties": {
-                                "port": {
-                                    "type": "integer"
-                                },
-                                "protocol": {
-                                    "type": "string"
-                                },
-                                "targetPort": {
-                                    "type": "integer"
-                                }
-                            }
                         }
                     }
                 },

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -61,13 +61,13 @@ service:
       targetPort: 50051
       # service.ports.envoy.protocol -- envoy protocol
       protocol: TCP
-    envoy-priv:
-      # service.ports.envoy-priv.port -- nvoy public port
-      port: 50052
-      # service.ports.envoy-priv.targetPort -- envoy k8s internal name
-      targetPort: 50052
-      # service.ports.envoy-priv.protocol -- envoy protocol
-      protocol: TCP
+  # envoy-priv:
+  #   # service.ports.envoy-priv.port -- envoy public port
+  #   port: 50052
+  #   # service.ports.envoy-priv.targetPort -- envoy k8s internal name
+  #   targetPort: 50052
+  #   # service.ports.envoy-priv.protocol -- envoy protocol
+  #   protocol: TCP
 
 rbac:
   # rbac.create -- If true, create and use RBAC resources


### PR DESCRIPTION
In the current Envoy chart, it listens the two ports `service.ports.envoy.port` and `service.ports.envoy-priv.port`.
And, in the Scalar DL (Ledger and Auditor) charts, they override these two ports configuration.

However, in the Scalar DB chart, it does not override `service.ports.envoy-priv.port`.
It overrides `service.ports.envoy.port` only since Scalar DB use one port (60051) only.

So, when we deploy Scalar DB, the Envoy Service listens the port of `service.ports.envoy-priv.port` despite the port is not used.
This is because Scalar DB chart does not override the values of `service.ports.envoy-priv.port` and this configuration remains as a default value of Envoy chart.
I think this is not secure, because the unused port is open.

* Current envoy service for Scalar DB (Listens unused `50052` port)
  ```console
  $ kubectl get svc scalardb-envoy
  NAME             TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
  scalardb-envoy   LoadBalancer   10.100.208.56   127.0.0.1     60051:32122/TCP,50052:31639/TCP   2m37s
  ```

After this update, the Envoy Service for Scalar DB does not listen unused port as follows. This can make it more secure.
* Updated envoy service for Scalar DB (Listens `60051` only)
  ```console
  $ kubectl get svc scalardb-envoy
  NAME             TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)           AGE
  scalardb-envoy   LoadBalancer   10.102.129.224   127.0.0.1     60051:30482/TCP   2m1s
  ```

Also, for your reference, the Scalar DL (Ledger and Auditor) can be deployed with several ports even after this updates.
This is because Ledger and Auditor charts override `service.ports.envoy.port` and add `service.ports.envoy-priv.port`.
(Envoy chart can accept several port information.)

* Ledger
  ```console
  $ kubectl get svc scalardl-ledger-envoy
  NAME                    TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
  scalardl-ledger-envoy   LoadBalancer   10.104.162.59   127.0.0.1     50051:30086/TCP,50052:30729/TCP   56s
  ```
* Auditor
  ```console
  $ kubectl get svc scalardl-auditor-envoy
  NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
  scalardl-auditor-envoy   LoadBalancer   10.107.96.232   127.0.0.1     40051:32724/TCP,40052:31634/TCP   39s
  ```

Please take a look!
