### PR TITLE
Remove unnecessary envoy default setting from each chart

### DIFF
--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -13,36 +13,15 @@ Current chart version is `2.3.0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
-| envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardb-service:60051"` | list of service name and port |
-| envoy.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
-| envoy.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
-| envoy.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
-| envoy.image.repository | string | `"ghcr.io/scalar-labs/scalar-envoy"` | Docker image |
 | envoy.image.version | string | `"1.3.0"` | Docker tag |
-| envoy.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | envoy.nameOverride | string | `"scalardb"` | String to partially override envoy.fullname template |
-| envoy.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
-| envoy.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
-| envoy.prometheusRule.enabled | bool | `false` | enable rules for prometheus |
-| envoy.prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
-| envoy.replicaCount | int | `3` | number of replicas to deploy |
-| envoy.resources | object | `{}` | resources allowed to the pod |
-| envoy.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy.port | int | `60051` | envoy public port |
 | envoy.service.ports.envoy.protocol | string | `"TCP"` | envoy protocol |
 | envoy.service.ports.envoy.targetPort | int | `60051` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
-| envoy.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
-| envoy.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
-| envoy.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
-| envoy.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
-| envoy.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
-| envoy.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
-| envoy.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | fullnameOverride | string | `""` | String to fully override scalardb.fullname template |
 | nameOverride | string | `""` | String to partially override scalardb.fullname template (will maintain the release name) |
 | scalardb.affinity | object | `{}` | The affinity/anti-affinity feature, greatly expands the types of constraints you can express. |

--- a/charts/scalardb/values.schema.json
+++ b/charts/scalardb/values.schema.json
@@ -5,30 +5,13 @@
         "envoy": {
             "type": "object",
             "properties": {
-                "affinity": {
-                    "type": "object"
-                },
                 "enabled": {
                     "type": "boolean"
                 },
                 "envoyConfiguration": {
                     "type": "object",
                     "properties": {
-                        "adminAccessLogPath": {
-                            "type": "string"
-                        },
                         "serviceListeners": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "grafanaDashboard": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
                             "type": "string"
                         }
                     }
@@ -36,48 +19,13 @@
                 "image": {
                     "type": "object",
                     "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
                         "version": {
                             "type": "string"
                         }
                     }
                 },
-                "imagePullSecrets": {
-                    "type": "array"
-                },
                 "nameOverride": {
                     "type": "string"
-                },
-                "nodeSelector": {
-                    "type": "object"
-                },
-                "podSecurityContext": {
-                    "type": "object"
-                },
-                "prometheusRule": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "replicaCount": {
-                    "type": "integer"
-                },
-                "resources": {
-                    "type": "object"
-                },
-                "securityContext": {
-                    "type": "object"
                 },
                 "service": {
                     "type": "object",
@@ -108,42 +56,6 @@
                             "type": "string"
                         }
                     }
-                },
-                "serviceMonitor": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "interval": {
-                            "type": "string"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "strategy": {
-                    "type": "object",
-                    "properties": {
-                        "rollingUpdate": {
-                            "type": "object",
-                            "properties": {
-                                "maxSurge": {
-                                    "type": "string"
-                                },
-                                "maxUnavailable": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "tolerations": {
-                    "type": "array"
                 }
             }
         },

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -12,47 +12,15 @@ envoy:
   enabled: true
   # -- String to partially override envoy.fullname template
   nameOverride: scalardb
-  # -- number of replicas to deploy
-  replicaCount: 3
 
   envoyConfiguration:
-    # -- admin log path
-    adminAccessLogPath: /dev/stdout
     # -- list of service name and port
     serviceListeners: scalardb-service:60051
 
   image:
-    # -- Docker image
-    repository: ghcr.io/scalar-labs/scalar-envoy
     # -- Docker tag
     version: 1.3.0
-    # -- Specify a imagePullPolicy
-    pullPolicy: IfNotPresent
 
-  # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
-  imagePullSecrets: []
-
-  strategy:
-    rollingUpdate:
-      # -- The number of pods that can be created above the desired amount of pods during an update
-      maxSurge: 25%
-      # -- The number of pods that can be unavailable during the update process
-      maxUnavailable: 25%
-    # -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
-    type: RollingUpdate
-
-  # -- PodSecurityContext holds pod-level security attributes and common container settings
-  podSecurityContext: {}
-    # fsGroup: 2000
-
-  # -- Setting security context at the pod applies those settings to all containers in the pod
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
   service:
     # -- service types in kubernetes
     type: ClusterIP
@@ -66,44 +34,6 @@ envoy:
         targetPort: 60051
         # -- envoy protocol
         protocol: TCP
-
-  serviceMonitor:
-    # -- enable metrics collect with prometheus
-    enabled: false
-    # -- custom interval to retrieve the metrics
-    interval: "15s"
-    # -- which namespace prometheus is located. by default monitoring
-    namespace: monitoring
-
-  prometheusRule:
-    # -- enable rules for prometheus
-    enabled: false
-    # -- which namespace prometheus is located. by default monitoring
-    namespace: monitoring
-
-  grafanaDashboard:
-    # -- enable grafana dashboard
-    enabled: false
-    # -- which namespace grafana dashboard is located. by default monitoring
-    namespace: monitoring
-
-  # -- resources allowed to the pod
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
-  # -- nodeSelector is form of node selection constraint
-  nodeSelector: {}
-
-  # -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
-  tolerations: []
-
-  # -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
-  affinity: {}
 
 scalardb:
   # -- Default values for number of replicas.

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -65,24 +65,10 @@ Current chart version is `2.2.2`
 | auditor.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | auditor.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
-| envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
-| envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardl-audit-service:40051,scalardl-audit-privileged:40052"` | list of service name and port |
-| envoy.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
-| envoy.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
-| envoy.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
-| envoy.image.repository | string | `"ghcr.io/scalar-labs/scalar-envoy"` | Docker image |
 | envoy.image.version | string | `"1.2.0"` | Docker tag |
-| envoy.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | envoy.nameOverride | string | `"scalardl-audit"` | String to partially override envoy.fullname template |
-| envoy.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
-| envoy.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
-| envoy.prometheusRule.enabled | bool | `false` | enable rules for prometheus |
-| envoy.prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
-| envoy.replicaCount | int | `3` | number of replicas to deploy |
-| envoy.resources | object | `{}` | resources allowed to the pod |
-| envoy.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy-priv.port | int | `40052` | envoy public port |
 | envoy.service.ports.envoy-priv.protocol | string | `"TCP"` | envoy protocol |
@@ -91,12 +77,5 @@ Current chart version is `2.2.2`
 | envoy.service.ports.envoy.protocol | string | `"TCP"` | envoy protocol |
 | envoy.service.ports.envoy.targetPort | int | `40051` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
-| envoy.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
-| envoy.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
-| envoy.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
-| envoy.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
-| envoy.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
-| envoy.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
-| envoy.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | fullnameOverride | string | `""` | String to fully override scalardl-audit.fullname template |
 | nameOverride | string | `""` | String to partially override scalardl-audit.fullname template (will maintain the release name) |

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -234,30 +234,13 @@
         "envoy": {
             "type": "object",
             "properties": {
-                "affinity": {
-                    "type": "object"
-                },
                 "enabled": {
                     "type": "boolean"
                 },
                 "envoyConfiguration": {
                     "type": "object",
                     "properties": {
-                        "adminAccessLogPath": {
-                            "type": "string"
-                        },
                         "serviceListeners": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "grafanaDashboard": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
                             "type": "string"
                         }
                     }
@@ -265,48 +248,13 @@
                 "image": {
                     "type": "object",
                     "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
                         "version": {
                             "type": "string"
                         }
                     }
                 },
-                "imagePullSecrets": {
-                    "type": "array"
-                },
                 "nameOverride": {
                     "type": "string"
-                },
-                "nodeSelector": {
-                    "type": "object"
-                },
-                "podSecurityContext": {
-                    "type": "object"
-                },
-                "prometheusRule": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "replicaCount": {
-                    "type": "integer"
-                },
-                "resources": {
-                    "type": "object"
-                },
-                "securityContext": {
-                    "type": "object"
                 },
                 "service": {
                     "type": "object",
@@ -351,42 +299,6 @@
                             "type": "string"
                         }
                     }
-                },
-                "serviceMonitor": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "interval": {
-                            "type": "string"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "strategy": {
-                    "type": "object",
-                    "properties": {
-                        "rollingUpdate": {
-                            "type": "object",
-                            "properties": {
-                                "maxSurge": {
-                                    "type": "string"
-                                },
-                                "maxUnavailable": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "tolerations": {
-                    "type": "array"
                 }
             }
         },

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -13,47 +13,15 @@ envoy:
   enabled: true
   # -- String to partially override envoy.fullname template
   nameOverride: scalardl-audit
-  # -- number of replicas to deploy
-  replicaCount: 3
 
   envoyConfiguration:
-    # -- admin log path
-    adminAccessLogPath: /dev/stdout
     # -- list of service name and port
     serviceListeners: scalardl-audit-service:40051,scalardl-audit-privileged:40052
 
   image:
-    # -- Docker image
-    repository: ghcr.io/scalar-labs/scalar-envoy
     # -- Docker tag
     version: 1.2.0
-    # -- Specify a imagePullPolicy
-    pullPolicy: IfNotPresent
 
-  # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
-  imagePullSecrets: []
-
-  strategy:
-    rollingUpdate:
-      # -- The number of pods that can be created above the desired amount of pods during an update
-      maxSurge: 25%
-      # -- The number of pods that can be unavailable during the update process
-      maxUnavailable: 25%
-    # -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
-    type: RollingUpdate
-
-  # -- PodSecurityContext holds pod-level security attributes and common container settings
-  podSecurityContext: {}
-    # fsGroup: 2000
-
-  # -- Setting security context at the pod applies those settings to all containers in the pod
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
   service:
     # -- service types in kubernetes
     type: ClusterIP
@@ -74,44 +42,6 @@ envoy:
         targetPort: 40052
         # -- envoy protocol
         protocol: TCP
-
-  serviceMonitor:
-    # -- enable metrics collect with prometheus
-    enabled: false
-    # -- custom interval to retrieve the metrics
-    interval: "15s"
-    # -- which namespace prometheus is located. by default monitoring
-    namespace: monitoring
-
-  prometheusRule:
-    # -- enable rules for prometheus
-    enabled: false
-    # -- which namespace prometheus is located. by default monitoring
-    namespace: monitoring
-
-  grafanaDashboard:
-    # -- enable grafana dashboard
-    enabled: false
-    # -- which namespace grafana dashboard is located. by default monitoring
-    namespace: monitoring
-
-  # -- resources allowed to the pod
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
-  # -- nodeSelector is form of node selection constraint
-  nodeSelector: {}
-
-  # -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
-  tolerations: []
-
-  # -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
-  affinity: {}
 
 auditor:
   # -- number of replicas to deploy

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -13,24 +13,10 @@ Current chart version is `4.2.2`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| envoy.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoy.enabled | bool | `true` | enable envoy |
-| envoy.envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardl-service:50051,scalardl-privileged:50052"` | list of service name and port |
-| envoy.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
-| envoy.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
-| envoy.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
-| envoy.image.repository | string | `"ghcr.io/scalar-labs/scalar-envoy"` | Docker image |
 | envoy.image.version | string | `"1.2.0"` | Docker tag |
-| envoy.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | envoy.nameOverride | string | `"scalardl"` | String to partially override envoy.fullname template |
-| envoy.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
-| envoy.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |
-| envoy.prometheusRule.enabled | bool | `false` | enable rules for prometheus |
-| envoy.prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
-| envoy.replicaCount | int | `3` | number of replicas to deploy |
-| envoy.resources | object | `{}` | resources allowed to the pod |
-| envoy.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy-priv.port | int | `50052` | nvoy public port |
 | envoy.service.ports.envoy-priv.protocol | string | `"TCP"` | envoy protocol |
@@ -39,13 +25,6 @@ Current chart version is `4.2.2`
 | envoy.service.ports.envoy.protocol | string | `"TCP"` | envoy protocol |
 | envoy.service.ports.envoy.targetPort | int | `50051` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
-| envoy.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
-| envoy.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
-| envoy.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
-| envoy.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
-| envoy.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
-| envoy.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
-| envoy.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | fullnameOverride | string | `""` | String to fully override scalardl.fullname template |
 | ledger.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | ledger.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -5,30 +5,13 @@
         "envoy": {
             "type": "object",
             "properties": {
-                "affinity": {
-                    "type": "object"
-                },
                 "enabled": {
                     "type": "boolean"
                 },
                 "envoyConfiguration": {
                     "type": "object",
                     "properties": {
-                        "adminAccessLogPath": {
-                            "type": "string"
-                        },
                         "serviceListeners": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "grafanaDashboard": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
                             "type": "string"
                         }
                     }
@@ -36,48 +19,13 @@
                 "image": {
                     "type": "object",
                     "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
                         "version": {
                             "type": "string"
                         }
                     }
                 },
-                "imagePullSecrets": {
-                    "type": "array"
-                },
                 "nameOverride": {
                     "type": "string"
-                },
-                "nodeSelector": {
-                    "type": "object"
-                },
-                "podSecurityContext": {
-                    "type": "object"
-                },
-                "prometheusRule": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "replicaCount": {
-                    "type": "integer"
-                },
-                "resources": {
-                    "type": "object"
-                },
-                "securityContext": {
-                    "type": "object"
                 },
                 "service": {
                     "type": "object",
@@ -122,42 +70,6 @@
                             "type": "string"
                         }
                     }
-                },
-                "serviceMonitor": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "interval": {
-                            "type": "string"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "strategy": {
-                    "type": "object",
-                    "properties": {
-                        "rollingUpdate": {
-                            "type": "object",
-                            "properties": {
-                                "maxSurge": {
-                                    "type": "string"
-                                },
-                                "maxUnavailable": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "tolerations": {
-                    "type": "array"
                 }
             }
         },

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -13,47 +13,14 @@ envoy:
   enabled: true
   # -- String to partially override envoy.fullname template
   nameOverride: "scalardl"
-  # -- number of replicas to deploy
-  replicaCount: 3
 
   envoyConfiguration:
-    # -- admin log path
-    adminAccessLogPath: /dev/stdout
     # -- list of service name and port
     serviceListeners: scalardl-service:50051,scalardl-privileged:50052
 
   image:
-    # -- Docker image
-    repository: ghcr.io/scalar-labs/scalar-envoy
     # -- Docker tag
     version: 1.2.0
-    # -- Specify a imagePullPolicy
-    pullPolicy: IfNotPresent
-
-  # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
-  imagePullSecrets: []
-
-  strategy:
-    rollingUpdate:
-      # -- The number of pods that can be created above the desired amount of pods during an update
-      maxSurge: 25%
-      # -- The number of pods that can be unavailable during the update process
-      maxUnavailable: 25%
-    # -- New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate
-    type: RollingUpdate
-
-  # -- PodSecurityContext holds pod-level security attributes and common container settings
-  podSecurityContext: {}
-    # fsGroup: 2000
-
-  # -- Setting security context at the pod applies those settings to all containers in the pod
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
 
   service:
     # -- service types in kubernetes
@@ -75,44 +42,6 @@ envoy:
         targetPort: 50052
         # -- envoy protocol
         protocol: TCP
-
-  serviceMonitor:
-    # -- enable metrics collect with prometheus
-    enabled: false
-    # -- custom interval to retrieve the metrics
-    interval: "15s"
-    # -- which namespace prometheus is located. by default monitoring
-    namespace: monitoring
-
-  prometheusRule:
-    # -- enable rules for prometheus
-    enabled: false
-    # -- which namespace prometheus is located. by default monitoring
-    namespace: monitoring
-
-  grafanaDashboard:
-    # -- enable grafana dashboard
-    enabled: false
-    # -- which namespace grafana dashboard is located. by default monitoring
-    namespace: monitoring
-
-  # -- resources allowed to the pod
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
-  # -- nodeSelector is form of node selection constraint
-  nodeSelector: {}
-
-  # -- Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints.
-  tolerations: []
-
-  # -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
-  affinity: {}
 
 ledger:
   # -- number of replicas to deploy


### PR DESCRIPTION
This PR removes some envoy default values from Scalar DB/DL chart.

Regarding envoy values, the same values are set as default values in Envoy chart and Scalar DB/DL chart.
In other words, there are some redundancy default values between Envoy chart and Scalar DB/DL chart.

Now, even if we update the default values of Envoy chart, it is not applied when we deploy Scalar DB/DL since Scalar DB/DL chart override that default values.
So, we need to update both Envoy and Scalar DB/DL chart if we want to update default values of Envoy chart.

I removed the above redundancy default values.
Also, I remains some values that we need to override to make them work properly.
I will add comment in each remaining values in Scalar DB/DL chart.

Please take a look!