### PR TITLE
Set `automountServiceAccountToken: false` in Ledger and Auditor chart

### DIFF
--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Always
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 60
     {{- with .Values.auditor.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- include "scalardl-ledger.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Always
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 60
     {{- with .Values.ledger.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
This PR adds `automountServiceAccountToken: false` in the pod definition in `deployment.yaml` of Ledger and Auditor chart.

If there is not this configuration, the `kubeaudit` returns error as follows.

```console
$ kubeaudit all -k .github/kube-audit.yaml -f <(helm template --generate-name "charts/scalardl") -m error

(snip)

-- [error] AutomountServiceAccountTokenTrueAndDefaultSA
   Message: Default service account with token mounted. automountServiceAccountToken should be set to 'false' on either the ServiceAccount or on the PodSpec or a non-default service account should be used.
```

```console
$ kubeaudit all -k .github/kube-audit.yaml -f <(helm template --generate-name "charts/scalardl-audit") -m error

(snip)

-- [error] AutomountServiceAccountTokenTrueAndDefaultSA
   Message: Default service account with token mounted. automountServiceAccountToken should be set to 'false' on either the ServiceAccount or on the PodSpec or a non-default service account should be used.
```

Also, this update does not affect behavior of Scalar DL since Ledger and Auditor does not use Service Account Token (does not run Kubernetes API in the pod). It only makes them more secure.

Please take a look!
