### PR TITLE
Update Auditor chart to use `40053` port for scalar-admin by default

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -36,7 +36,7 @@ Current chart version is `2.2.2`
 | auditor.scalarAuditorConfiguration.auditorLedgerHost | string | `""` | The host name of Ledger. The service endpoint of Ledger-side envoy should be specified |
 | auditor.scalarAuditorConfiguration.auditorLogLevel | string | `"INFO"` | The log level of Scalar auditor |
 | auditor.scalarAuditorConfiguration.auditorPrivateKeySecretKey | string | `"private-key"` | The secret key of an Auditor private key |
-| auditor.scalarAuditorConfiguration.auditorServerAdminPort | int | `50053` | The port number of Auditor Admin Server |
+| auditor.scalarAuditorConfiguration.auditorServerAdminPort | int | `40053` | The port number of Auditor Admin Server |
 | auditor.scalarAuditorConfiguration.auditorServerPort | int | `40051` | The port number of Auditor Server |
 | auditor.scalarAuditorConfiguration.auditorServerPrivilegedPort | int | `40052` | The port number of Auditor Privileged Server |
 | auditor.scalarAuditorConfiguration.dbContactPoints | string | `"cassandra"` | The contact points of the database such as hostnames or URLs |
@@ -48,9 +48,9 @@ Current chart version is `2.2.2`
 | auditor.secretName | string | `""` | Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom. |
 | auditor.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true}` | Setting security context at the pod applies those settings to all containers in the pod |
 | auditor.service.annotations | object | `{}` | Service annotations |
-| auditor.service.ports.scalardl-auditor-admin.port | int | `50053` | scalardl-admin target port |
+| auditor.service.ports.scalardl-auditor-admin.port | int | `40053` | scalardl-admin target port |
 | auditor.service.ports.scalardl-auditor-admin.protocol | string | `"TCP"` | scalardl-admin protocol |
-| auditor.service.ports.scalardl-auditor-admin.targetPort | int | `50053` | scalardl-admin k8s internal name |
+| auditor.service.ports.scalardl-auditor-admin.targetPort | int | `40053` | scalardl-admin k8s internal name |
 | auditor.service.ports.scalardl-auditor-priv.port | int | `40052` | scalardl-priv target port |
 | auditor.service.ports.scalardl-auditor-priv.protocol | string | `"TCP"` | scalardl-priv protocol |
 | auditor.service.ports.scalardl-auditor-priv.targetPort | int | `40052` | scalardl-priv k8s internal name |

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           ports:
           - containerPort: 40051
           - containerPort: 40052
-          - containerPort: 50053
+          - containerPort: 40053
           - containerPort: 8080
           env:
           - name: HELM_SCALAR_DB_CONTACT_POINTS

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -63,7 +63,7 @@ auditor:
     # -- The port number of Auditor Privileged Server
     auditorServerPrivilegedPort: 40052
     # -- The port number of Auditor Admin Server
-    auditorServerAdminPort: 50053
+    auditorServerAdminPort: 40053
     # -- The log level of Scalar auditor
     auditorLogLevel: INFO
     # -- The host name of Ledger. The service endpoint of Ledger-side envoy should be specified
@@ -210,9 +210,9 @@ auditor:
         protocol: TCP
       scalardl-auditor-admin:
         # -- scalardl-admin target port
-        port: 50053
+        port: 40053
         # -- scalardl-admin k8s internal name
-        targetPort: 50053
+        targetPort: 40053
         # -- scalardl-admin protocol
         protocol: TCP
 


### PR DESCRIPTION
This PR updates Auditor chart to use `40053` port for scalar-admin by default.
Please take a look!

---

For your reference, I tested this update using Scalar DL v3.5.0 as follows.

### Configurations after deployment (Use `40053` in each resource)
* Headless Service
  ```console
  $ kubectl get svc scalardl-auditor-headless
  NAME                        TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                         AGE
  scalardl-auditor-headless   ClusterIP   None         <none>        40051/TCP,40053/TCP,40052/TCP   89s
  ```
  ```json
  $ kubectl get svc scalardl-auditor-headless -o jsonpath='{.spec.ports}' | jq .
  [
    {
      "name": "scalardl-auditor",
      "port": 40051,
      "protocol": "TCP",
      "targetPort": 40051
    },
    {
      "name": "scalardl-auditor-admin",
      "port": 40053,
      "protocol": "TCP",
      "targetPort": 40053
    },
    {
      "name": "scalardl-auditor-priv",
      "port": 40052,
      "protocol": "TCP",
      "targetPort": 40052
    }
  ]
  ```
* Containers
  ```json
  $ kubectl get deployment scalardl-auditor-auditor -o jsonpath='{.spec.template.spec.containers[].ports}' | jq .
  [
    {
      "containerPort": 40051,
      "protocol": "TCP"
    },
    {
      "containerPort": 40052,
      "protocol": "TCP"
    },
    {
      "containerPort": 40053,
      "protocol": "TCP"
    },
    {
      "containerPort": 8080,
      "protocol": "TCP"
    }
  ]
  ```

### Test of pause/unpause

* Pause
  ```console
  $ kubectl run scalar-admin-pause -it --image=ghcr.io/scalar-labs/scalar-admin:1.2.0 --restart=Never -- -c pause -s _scalardl-auditor-admin._tcp.scalardl-auditor-headless.default.svc.cluster.local
  If you don't see a command prompt, try pressing enter.
  
  $ kubectl logs scalar-admin-pause
  Pause completed at 2022-08-03T07:55:27.561Z UTC (1659513327561)
  ```
* Confirm the request is rejected after pausing
  ```console
  $ ./bin/execute-contract --config ./client.properties --contract-id Charge --contract-argument '{"account": "A", "val": 100}'
  {
      "status_code": "UNAVAILABLE",
      "output": null,
      "error_message": "the service is temporarily unavailable"
  }
  ```
* Unpause
  ```console
  $ kubectl run scalar-admin-unpause -it --image=ghcr.io/scalar-labs/scalar-admin:1.2.0 --restart=Never -- -c unpause -s _scalardl-auditor-admin._tcp.scalardl-auditor-headless.default.svc.cluster.local
  If you don't see a command prompt, try pressing enter.
  
  $ kubectl logs scalar-admin-unpause
  Unpause started at 2022-08-03T08:06:55.590Z UTC (1659514015590)
  ```
* Confirm the request is accepted after unpausing
  ```console
  $ ./bin/execute-contract --config ./client.properties --contract-id Charge --contract-argument '{"account": "A", "val": 100}'
  {
      "status_code": "OK",
      "output": null,
      "error_message": null
  }
  ```
