### PR TITLE
Update chart version to keep main branch latest (Envoy)

### DIFF
--- a/charts/envoy/Chart.yaml
+++ b/charts/envoy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: envoy
 description: Envoy Proxy for Scalar applications
 type: application
-version: 2.1.0
+version: 2.2.0
 appVersion: 1.3.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -1,9 +1,9 @@
 # envoy
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 Envoy Proxy for Scalar applications
-Current chart version is `2.1.0`
+Current chart version is `2.2.0`
 
 **Homepage:** <https://scalar-labs.com/>
 


### PR DESCRIPTION
A new minor version of Scalar Envoy Helm Charts has been released.
This PR updates version of Scalar Envoy chart to keep main branch latest.
(This release flow will be fixed in the future.)

This PR apply the same update as the following commit.
https://github.com/scalar-labs/helm-charts/commit/715e7ad7895a9ab0e8ef508465b41774b39fa099

Please take a look!