### PR TITLE
Update chart version to keep main branch latest (Ledger)

### DIFF
--- a/charts/scalardl/Chart.lock
+++ b/charts/scalardl/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 2.0.1
-digest: sha256:102a060fe4b6e667428ee5ef242bbf994da80841e17ebe178368f7e1904deb53
-generated: "2022-04-07T18:56:29.964507445+09:00"
+  version: 2.2.0
+digest: sha256:2400613e162d0acb575e173d8623a67281e131d0e00b0da7925177e793c13643
+generated: "2022-08-04T12:11:51.570434124+09:00"

--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl
 description: Scalar DL is a tamper-evident and scalable distributed database.
 type: application
-version: 4.2.2
-appVersion: 3.4.1
+version: 4.3.0
+appVersion: 3.5.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardl
 dependencies:
 - name: envoy
-  version: ~2.0.1
+  version: ~2.2.0
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,13 +1,13 @@
 # scalardl
 
 Scalar DL is a tamper-evident and scalable distributed database.
-Current chart version is `4.2.2`
+Current chart version is `4.3.0`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.1 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.2.0 |
 
 ## Values
 
@@ -15,7 +15,7 @@ Current chart version is `4.2.2`
 |-----|------|---------|-------------|
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardl-service:50051,scalardl-privileged:50052"` | list of service name and port |
-| envoy.image.version | string | `"1.2.0"` | Docker tag |
+| envoy.image.version | string | `"1.3.0"` | Docker tag |
 | envoy.nameOverride | string | `"scalardl"` | String to partially override envoy.fullname template |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy-priv.port | int | `50052` | nvoy public port |
@@ -34,7 +34,7 @@ Current chart version is `4.2.2`
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
-| ledger.image.version | string | `"3.4.1"` | Docker tag |
+| ledger.image.version | string | `"3.5.0"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.ledgerProperties | string | The default minimum necessary values of ledger.properties are set. You can overwrite it with your own ledger.properties. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -20,7 +20,7 @@ envoy:
 
   image:
     # -- Docker tag
-    version: 1.2.0
+    version: 1.3.0
 
   service:
     # -- service types in kubernetes
@@ -110,7 +110,7 @@ ledger:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger
     # -- Docker tag
-    version: 3.4.1
+    version: 3.5.0
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
A new minor version of Scalar DL Ledger Helm Charts has been released.
This PR updates version of Scalar DL Ledger chart to keep main branch latest.
(This release flow will be fixed in the future.)

This PR apply the same update as the following commit.
https://github.com/scalar-labs/helm-charts/commit/09f98fabf65bed61bcb5e6273af97164b1577fc7

Please take a look!