### PR TITLE
Update chart version to keep main branch latest (Auditor)

### DIFF
--- a/charts/scalardl-audit/Chart.lock
+++ b/charts/scalardl-audit/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 2.0.1
-digest: sha256:102a060fe4b6e667428ee5ef242bbf994da80841e17ebe178368f7e1904deb53
-generated: "2022-04-07T19:32:32.973428378+09:00"
+  version: 2.2.0
+digest: sha256:2400613e162d0acb575e173d8623a67281e131d0e00b0da7925177e793c13643
+generated: "2022-08-04T12:28:27.876461314+09:00"

--- a/charts/scalardl-audit/Chart.yaml
+++ b/charts/scalardl-audit/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl-audit
 description: Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
 type: application
-version: 2.2.2
-appVersion: 3.4.1
+version: 2.3.0
+appVersion: 3.5.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardl
 dependencies:
 - name: envoy
-  version: ~2.0.1
+  version: ~2.2.0
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -1,13 +1,13 @@
 # scalardl-audit
 
 Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
-Current chart version is `2.2.2`
+Current chart version is `2.3.0`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.0.1 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.2.0 |
 
 ## Values
 
@@ -22,7 +22,7 @@ Current chart version is `2.2.2`
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | auditor.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | auditor.image.repository | string | `"ghcr.io/scalar-labs/scalar-auditor"` | Docker image |
-| auditor.image.version | string | `"3.4.1"` | Docker tag |
+| auditor.image.version | string | `"3.5.0"` | Docker tag |
 | auditor.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | auditor.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | auditor.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings |
@@ -67,7 +67,7 @@ Current chart version is `2.2.2`
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardl-audit-service:40051,scalardl-audit-privileged:40052"` | list of service name and port |
-| envoy.image.version | string | `"1.2.0"` | Docker tag |
+| envoy.image.version | string | `"1.3.0"` | Docker tag |
 | envoy.nameOverride | string | `"scalardl-audit"` | String to partially override envoy.fullname template |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy-priv.port | int | `40052` | envoy public port |

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -20,7 +20,7 @@ envoy:
 
   image:
     # -- Docker tag
-    version: 1.2.0
+    version: 1.3.0
 
   service:
     # -- service types in kubernetes
@@ -142,7 +142,7 @@ auditor:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-auditor
     # -- Docker tag
-    version: 3.4.1
+    version: 3.5.0
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
A new minor version of Scalar DL Auditor Helm Charts has been released.
This PR updates version of Scalar DL Auditor chart to keep main branch latest.
(This release flow will be fixed in the future.)

This PR apply the same update as the following commit.
https://github.com/scalar-labs/helm-charts/commit/a806578e34a522f2f65e69f2b79810eded78a995

Please take a look!