### PR TITLE
Add values.schema.json to scalardb-graphql chart

### DIFF
--- a/charts/scalardb-graphql/README.md
+++ b/charts/scalardb-graphql/README.md
@@ -40,7 +40,7 @@ Current chart version is `1.0.0`
 | scalarDbGraphQlConfiguration.storage | string | `"cassandra"` | Storage implementation. Either cassandra or cosmos or dynamo or jdbc can be set. |
 | scalarDbGraphQlConfiguration.transactionManager | string | `"consensus-commit"` | The type of the transaction manager. |
 | scalarDbGraphQlConfiguration.username | string | `"cassandra"` | The username of the database. For Cosmos DB please leave blank. For Dynamo DB please specify key id here. |
-| securityContext | string | `nil` | Setting security context at the pod applies those settings to all containers in the pod. |
+| securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod. |
 | service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | service.port | int | `8080` | Scalar DB GraphQL server port. |
 | service.type | string | `"ClusterIP"` | service types in kubernetes. |

--- a/charts/scalardb-graphql/values.schema.json
+++ b/charts/scalardb-graphql/values.schema.json
@@ -1,0 +1,213 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "existingSecret": {
+            "type": "string"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "grafanaDashboard": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "host": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "className": {
+                    "type": "string"
+                },
+                "tls": {
+                    "type": "array"
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "type": "object"
+        },
+        "podSecurityPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "prometheusRule": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "scalarDbGraphQlConfiguration": {
+            "type": "object",
+            "properties": {
+                "consensuscommitIsolationLevel": {
+                    "type": "string"
+                },
+                "consensuscommitSerializableStarategy": {
+                    "type": "string"
+                },
+                "contactPoints": {
+                    "type": "string"
+                },
+                "contactPort": {
+                    "type": "integer"
+                },
+                "graphiql": {
+                    "type": "string"
+                },
+                "logLevel": {
+                    "type": "string"
+                },
+                "namespaces": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "storage": {
+                    "type": "string"
+                },
+                "transactionManager": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object"
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "strategy": {
+            "type": "object",
+            "properties": {
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxSurge": {
+                            "type": "string"
+                        },
+                        "maxUnavailable": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array"
+        }
+    }
+}

--- a/charts/scalardb-graphql/values.schema.json
+++ b/charts/scalardb-graphql/values.schema.json
@@ -36,14 +36,66 @@
                 }
             }
         },
+        "imagePullSecrets": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "ingress": {
             "type": "object",
             "properties": {
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "alb.ingress.kubernetes.io/healthcheck-path": {
+                            "type": "string"
+                        },
+                        "alb.ingress.kubernetes.io/scheme": {
+                            "type": "string"
+                        },
+                        "alb.ingress.kubernetes.io/target-group-attributes": {
+                            "type": "string"
+                        },
+                        "alb.ingress.kubernetes.io/target-type": {
+                            "type": "string"
+                        },
+                        "nginx.ingress.kubernetes.io/affinity": {
+                            "type": "string"
+                        },
+                        "nginx.ingress.kubernetes.io/session-cookie-hash": {
+                            "type": "string"
+                        },
+                        "nginx.ingress.kubernetes.io/session-cookie-max-age": {
+                            "type": "string"
+                        },
+                        "nginx.ingress.kubernetes.io/session-cookie-name": {
+                            "type": "string"
+                        },
+                        "nginx.ingress.kubernetes.io/session-cookie-path": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "className": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "hosts": {
                     "type": "array",
                     "items": {
                         "type": "object",
                         "properties": {
+                            "host": {
+                                "type": "string"
+                            },
                             "paths": {
                                 "type": "array",
                                 "items": {
@@ -57,29 +109,14 @@
                                         }
                                     }
                                 }
-                            },
-                            "host": {
-                                "type": "string"
                             }
                         }
                     }
                 },
-                "annotations": {
-                    "type": "object"
-                },
-                "className": {
-                    "type": "string"
-                },
                 "tls": {
                     "type": "array"
-                },
-                "enabled": {
-                    "type": "boolean"
                 }
             }
-        },
-        "imagePullSecrets": {
-            "type": "array"
         },
         "nameOverride": {
             "type": "string"
@@ -89,14 +126,6 @@
         },
         "podSecurityContext": {
             "type": "object"
-        },
-        "podSecurityPolicy": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                }
-            }
         },
         "prometheusRule": {
             "type": "object",
@@ -121,7 +150,7 @@
                 "consensuscommitIsolationLevel": {
                     "type": "string"
                 },
-                "consensuscommitSerializableStarategy": {
+                "consensuscommitSerializableStrategy": {
                     "type": "string"
                 },
                 "contactPoints": {

--- a/charts/scalardb-graphql/values.yaml
+++ b/charts/scalardb-graphql/values.yaml
@@ -122,7 +122,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 # -- Setting security context at the pod applies those settings to all containers in the pod.
-securityContext:
+securityContext: {}
     # capabilities:
     #   drop:
     #   - ALL


### PR DESCRIPTION
This PR adds the `values.schema.json` for the `helm lint` command to the scalardb-graphql chart since it is missing in this chart only.

```console
$ helm lint ./charts/scalardb-graphql
==> Linting ./charts/scalardb-graphql

1 chart(s) linted, 0 chart(s) failed
```
