### PR TITLE
Update scalardb-graphql version to 3.6.0

### DIFF
--- a/.github/schema-loading.yaml
+++ b/.github/schema-loading.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: schema-loading-config
+data:
+  database.properties: |-
+    scalar.db.contact_points=cassandra
+    scalar.db.contact_port=9042
+    scalar.db.username=cassandra
+    scalar.db.password=cassandra
+    scalar.db.storage=cassandra
+  schema.json: |-
+    {
+      "ct.t1": {
+        "transaction": true,
+        "partition-key": [
+          "c1"
+        ],
+        "clustering-key": [
+          "c2"
+        ],
+        "columns": {
+          "c1": "INT",
+          "c2": "INT",
+          "c3": "INT"
+        }
+      }
+    }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: schema-loading
+spec:
+  template:
+    metadata:
+      labels:
+        app: schema-loading
+    spec:
+      containers:
+      - name: schema-loading
+        image: ghcr.io/scalar-labs/scalardb-schema-loader:3.5.2
+        imagePullPolicy: IfNotPresent
+        args:
+        - "-c"
+        - "/config/database.properties"
+        - "-f"
+        - "/config/schema.json"
+        - "--coordinator"
+        volumeMounts:
+        - name: schema-loading-config-volume
+          mountPath: /config
+      volumes:
+      - name: schema-loading-config-volume
+        configMap:
+          name: schema-loading-config
+      restartPolicy: Never
+  backoffLimit: 0

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -178,6 +178,7 @@ jobs:
           kubectl create -f .github/cassandra.yaml
           echo "Wait until cassandra is running" && sleep 100
           kubectl create -f .github/schema-loading.yaml
+          kubectl wait --for=condition=complete --timeout=60s job/schema-loading
           kubectl get pods,svc,endpoints,nodes -o wide
 
       - name: Run chart-testing (install)

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -177,6 +177,7 @@ jobs:
           kubectl create secret generic auditor-keys --from-file=certificate=.github/auditor-cert.pem --from-file=private-key=.github/auditor-key.pem
           kubectl create -f .github/cassandra.yaml
           echo "Wait until cassandra is running" && sleep 100
+          kubectl create -f .github/schema-loading.yaml
           kubectl get pods,svc,endpoints,nodes -o wide
 
       - name: Run chart-testing (install)

--- a/charts/scalardb-graphql/Chart.yaml
+++ b/charts/scalardb-graphql/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardb-graphql
 description: Scalar DB GraphQL server
 type: application
-version: 1.0.0
-appVersion: 3.5.0
+version: 1.1.0
+appVersion: 3.6.0
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
 - scalardb

--- a/charts/scalardb-graphql/README.md
+++ b/charts/scalardb-graphql/README.md
@@ -1,7 +1,7 @@
 # scalardb-graphql
 
 Scalar DB GraphQL server
-Current chart version is `1.0.0`
+Current chart version is `1.1.0`
 
 ## Values
 
@@ -14,7 +14,7 @@ Current chart version is `1.0.0`
 | grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | image.repository | string | `"ghcr.io/scalar-labs/scalardb-graphql"` | Docker image reposiory of Scalar DB GraphQL. |
-| image.tag | string | `"3.5.0"` | Docker tag of the image. |
+| image.tag | string | `"3.6.0"` | Docker tag of the image. |
 | imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ingress.annotations | object | `{"alb.ingress.kubernetes.io/healthcheck-path":"/graphql?query=%7B__typename%7D","alb.ingress.kubernetes.io/scheme":"internal","alb.ingress.kubernetes.io/target-group-attributes":"stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60","alb.ingress.kubernetes.io/target-type":"ip","nginx.ingress.kubernetes.io/affinity":"cookie","nginx.ingress.kubernetes.io/session-cookie-hash":"sha1","nginx.ingress.kubernetes.io/session-cookie-max-age":"300","nginx.ingress.kubernetes.io/session-cookie-name":"INGRESSCOOKIE","nginx.ingress.kubernetes.io/session-cookie-path":"/"}` | The class-specific annotations for the ingress resource. |
 | ingress.className | string | `""` | The ingress class name. Specify "alb" for AWS Application Load Balancer. |

--- a/charts/scalardb-graphql/ci/ct-values.yaml
+++ b/charts/scalardb-graphql/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+scalarDbGraphQlConfiguration:
+  namespaces: ct

--- a/charts/scalardb-graphql/templates/scalardb-graphql/deployment.yaml
+++ b/charts/scalardb-graphql/templates/scalardb-graphql/deployment.yaml
@@ -83,13 +83,11 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:
-            httpGet:
-              path: "{{ .Values.scalarDbGraphQlConfiguration.path }}?query=%7B__typename%7D"
+            tcpSocket:
               port: 8080
             initialDelaySeconds: 60
           readinessProbe:
-            httpGet:
-              path: "{{ .Values.scalarDbGraphQlConfiguration.path }}?query=%7B__typename%7D"
+            tcpSocket:
               port: 8080
             initialDelaySeconds: 60
       {{- with .Values.nodeSelector }}

--- a/charts/scalardb-graphql/templates/scalardb-graphql/deployment.yaml
+++ b/charts/scalardb-graphql/templates/scalardb-graphql/deployment.yaml
@@ -82,14 +82,17 @@ spec:
               value: "{{ .Values.scalarDbGraphQlConfiguration.logLevel }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          startupProbe:
+            tcpSocket:
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
             tcpSocket:
               port: 8080
-            initialDelaySeconds: 60
           readinessProbe:
             tcpSocket:
               port: 8080
-            initialDelaySeconds: 60
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/scalardb-graphql/templates/scalardb-graphql/deployment.yaml
+++ b/charts/scalardb-graphql/templates/scalardb-graphql/deployment.yaml
@@ -86,10 +86,12 @@ spec:
             httpGet:
               path: "{{ .Values.scalarDbGraphQlConfiguration.path }}?query=%7B__typename%7D"
               port: 8080
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: "{{ .Values.scalarDbGraphQlConfiguration.path }}?query=%7B__typename%7D"
               port: 8080
+            initialDelaySeconds: 60
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/scalardb-graphql/values.yaml
+++ b/charts/scalardb-graphql/values.yaml
@@ -39,7 +39,7 @@ image:
   # -- Specify a image pulling policy.
   pullPolicy: IfNotPresent
   # -- Docker tag of the image.
-  tag: 3.5.0
+  tag: 3.6.0
 
 # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
 imagePullSecrets: [name: reg-docker-secrets]


### PR DESCRIPTION
This PR updates the version of Scalar DB GraphQL to 3.6.0.

The following changes have also been made in this PR to make the probes work well and for the CI to pass.

1. liveness/readiness probes

    `initialDelaySeconds` was added to liveness/readiness probes to avoid restarting pods in the initial startup.
    The probe method was also changed from `httpGet` to `tcpSocket` since Scalar DB GraphQL 3.6.0 always starts (or continues) a transaction when it receives a GraphQL query and it triggers database access. The liveness/readiness probe should not affect the database.

1. schema-loading job in CI

    In order for the `ct install` command to install the scalardb-graphql chart in CI, it is necessary to load a database schema into the Cassandra database since Scalar DB GraphQL requires at least one table to generate a GraphQL schema. (The GraphQL spec doesn't allow leaving the `Query` root type empty. This is why Scalar DB GraphQL can't start without tables.)
    This PR adds a simple schema loading job.