### PR TITLE
Add kubectl wait for waiting for starup of Cassandra in CI

### DIFF
--- a/.github/cassandra.yaml
+++ b/.github/cassandra.yaml
@@ -21,6 +21,9 @@ spec:
           env:
             - name: CASSANDRA_SEEDS
               value: "cassandra-0.cassandra-headless.default.svc.cluster.local"
+          readinessProbe:
+            exec:
+              command: ["cqlsh", "-e", "SELECT now() FROM system.local;"]
 ---
 apiVersion: v1
 kind: Service

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -176,7 +176,7 @@ jobs:
           kubectl create secret generic ledger-keys --from-file=private-key=.github/ledger-key.pem
           kubectl create secret generic auditor-keys --from-file=certificate=.github/auditor-cert.pem --from-file=private-key=.github/auditor-key.pem
           kubectl create -f .github/cassandra.yaml
-          echo "Wait until cassandra is running" && sleep 100
+          kubectl wait --for=condition=Ready pod/cassandra-0
           kubectl create -f .github/schema-loading.yaml
           kubectl wait --for=condition=complete --timeout=60s job/schema-loading
           kubectl get pods,svc,endpoints,nodes -o wide


### PR DESCRIPTION
This PR adds the `kubectl wait` command for waiting for the startup of Cassandra in the CI.
This is related to the following comment in another PR.
https://github.com/scalar-labs/helm-charts/pull/132#discussion_r954454757