### PR TITLE
Fix bug of CI related to the kubeaudit

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -78,6 +78,8 @@ jobs:
           # Change to `ls charts` when all charts are supported.
           chart_dirs=(envoy scalardb)
           for chart_dir in ${chart_dirs[@]}; do
+            echo "helm dependency build charts/${chart_dir} chart..."
+            helm dependency build charts/${chart_dir}
             echo "kubeaudit charts/${chart_dir} chart..."
             kubeaudit all -k .github/kube-audit.yaml -f <(helm template --generate-name "charts/${chart_dir}") -m error
           done


### PR DESCRIPTION
This PR fixes the bug of CI related to kubeaudit.
Now, kubeaudit does NOT check the chart of Scalar DB since it doesn't run the `helm dependency` command.

In this case (if we don't run `helm dependency`), it returns the following ERROR.
```
$ kubeaudit all -k .github/kube-audit.yaml -f <(helm template --generate-name "charts/scalardb") -m error
Error: found in Chart.yaml, but missing in charts/ directory: envoy
All checks completed. 0 high-risk vulnerabilities found
```
However kubeaudit returns `0` as an exit status despite the above error occurring.
```
$ echo $?
0
```
So, the CI is not failed even if the kubeaudit returns this error...
In other words, the CI was successful before despite the kubeaudit does NOT check the Scalar DB chart.

If the target chart has a dependency (in this case, it depends on the scalar-envoy chart), we need to run the `helm dependency` command before we check it by kubeaudit.
So, I added the `helm dependency` command before running kubeaudit.

Please take a look!

