### PR TITLE
Disable Pod Security Policy by default in Scalar DB chart

### DIFF
--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -36,7 +36,7 @@ Current chart version is `2.3.0`
 | scalardb.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalardb.podAnnotations | object | `{}` | Pod annotations for the scalardb deployment |
 | scalardb.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings. |
-| scalardb.podSecurityPolicy.enabled | bool | `true` | Enable pod security policy |
+| scalardb.podSecurityPolicy.enabled | bool | `false` | Enable pod security policy |
 | scalardb.prometheusRule.enabled | bool | `false` | Enable rules for prometheus. |
 | scalardb.prometheusRule.namespace | string | `"monitoring"` | Which namespace prometheus is located. by default monitoring. |
 | scalardb.rbac.create | bool | `true` | If true, create and use RBAC resources |

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -117,7 +117,7 @@ scalardb:
 
   podSecurityPolicy:
     # -- Enable pod security policy
-    enabled: true
+    enabled: false
 
   serviceMonitor:
     # -- Enable metrics collect with prometheus.


### PR DESCRIPTION
This PR disables Pod Security Policy by default since this feature is removed in the latest Kubernetes release v1.25.
https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/#pod-security-changes

Also, we have already disabled Pod Security Policy by default in the Envoy chart in the following PR.
https://github.com/scalar-labs/helm-charts/pull/120

Please take a look!