### PR TITLE
Update chart version to keep main branch latest (Schema Loader)

### DIFF
--- a/charts/schema-loading/Chart.yaml
+++ b/charts/schema-loading/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: schema-loading
 description: A schema loading tool for Scalar DL.
 type: application
-version: 2.6.0
-appVersion: 3.5.0
+version: 2.7.0
+appVersion: 3.6.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/schema-loading/README.md
+++ b/charts/schema-loading/README.md
@@ -1,7 +1,7 @@
 # schema-loading
 
 A schema loading tool for Scalar DL.
-Current chart version is `2.6.0`
+Current chart version is `2.7.0`
 
 ## Values
 
@@ -19,7 +19,7 @@ Current chart version is `2.6.0`
 | schemaLoading.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | schemaLoading.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | schemaLoading.image.repository | string | `"ghcr.io/scalar-labs/scalardl-schema-loader"` | Docker image |
-| schemaLoading.image.version | string | `"3.5.0"` | Docker tag |
+| schemaLoading.image.version | string | `"3.6.0"` | Docker tag |
 | schemaLoading.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | schemaLoading.password | string | `"cassandra"` | The password of the database. For Cosmos DB, please specify a key here. |
 | schemaLoading.schemaType | string | `"ledger"` | Type of schema to apply (ledger or auditor). |

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -53,7 +53,7 @@ schemaLoading:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalardl-schema-loader
     # -- Docker tag
-    version: 3.5.0
+    version: 3.6.0
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
A new minor version of Scalar DL Schema Loader Helm Charts has been released.
This PR updates version of Scalar DL Schema Loader chart to keep main branch latest.
(This release flow will be fixed in the future.)

This PR apply the same update as the following commit.
https://github.com/scalar-labs/helm-charts/commit/f88cef7fa3d1ebc5dfeeb1472da048746892b9d5

Please take a look!