### PR TITLE
Update chart version to keep main branch latest (Scalar DB)

### DIFF
--- a/charts/scalardb/Chart.lock
+++ b/charts/scalardb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
   repository: https://scalar-labs.github.io/helm-charts
-  version: 2.1.0
-digest: sha256:21cca64d71b44b1da064db4c42be1a19dd230415494752b58698aaa8bd9a5d77
-generated: "2022-07-11T14:16:08.15899893+09:00"
+  version: 2.2.0
+digest: sha256:2400613e162d0acb575e173d8623a67281e131d0e00b0da7925177e793c13643
+generated: "2022-09-14T12:34:38.629511121+09:00"

--- a/charts/scalardb/Chart.yaml
+++ b/charts/scalardb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardb
 description: Scalar DB server
 type: application
-version: 2.3.0
-appVersion: 3.6.0
+version: 2.4.0
+appVersion: 3.7.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,7 +16,7 @@ sources:
   - https://github.com/scalar-labs/scalardb
 dependencies:
 - name: envoy
-  version: ~2.1.0
+  version: ~2.2.0
   repository: https://scalar-labs.github.io/helm-charts
   condition: envoy.enabled
 maintainers:

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -1,13 +1,13 @@
 # scalardb
 
 Scalar DB server
-Current chart version is `2.3.0`
+Current chart version is `2.4.0`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.1.0 |
+| https://scalar-labs.github.io/helm-charts | envoy | ~2.2.0 |
 
 ## Values
 
@@ -31,7 +31,7 @@ Current chart version is `2.3.0`
 | scalardb.grafanaDashboard.namespace | string | `"monitoring"` | Which namespace grafana dashboard is located. by default monitoring. |
 | scalardb.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | scalardb.image.repository | string | `"ghcr.io/scalar-labs/scalardb-server"` | Docker image reposiory of Scalar DB server. |
-| scalardb.image.tag | string | `"3.6.0"` | Docker tag of the image. |
+| scalardb.image.tag | string | `"3.7.0"` | Docker tag of the image. |
 | scalardb.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalardb.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalardb.podAnnotations | object | `{}` | Pod annotations for the scalardb deployment |

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -83,7 +83,7 @@ scalardb:
     # -- Specify a image pulling policy.
     pullPolicy: IfNotPresent
     # -- Docker tag of the image.
-    tag: 3.6.0
+    tag: 3.7.0
 
   # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: []


### PR DESCRIPTION
A new minor version of Scalar DB Helm Charts has been released.
This PR updates version of Scalar DB chart to keep main branch latest.
(This release flow will be fixed in the future.)

This PR apply the same update as the following commit.
https://github.com/scalar-labs/helm-charts/commit/3c265f7aff8ea7319e9cdf819c3c3f935b2cb14d

Please take a look!
