### PR TITLE
Increase timeout configuration for Cassandra in the CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -178,7 +178,7 @@ jobs:
           kubectl create secret generic ledger-keys --from-file=private-key=.github/ledger-key.pem
           kubectl create secret generic auditor-keys --from-file=certificate=.github/auditor-cert.pem --from-file=private-key=.github/auditor-key.pem
           kubectl create -f .github/cassandra.yaml
-          kubectl wait --for=condition=Ready --timeout=60s pod/cassandra-0
+          kubectl wait --for=condition=Ready --timeout=120s pod/cassandra-0
           kubectl create -f .github/schema-loading.yaml
           kubectl wait --for=condition=complete --timeout=60s job/schema-loading
           kubectl get pods,svc,endpoints,nodes -o wide


### PR DESCRIPTION
In the following PR, the CI failed several times with the timeout error in the step of waiting for Cassandra starts.
https://github.com/scalar-labs/helm-charts/pull/142

I re-run it several times and finally it succeeded, but I think it is better to increase the timeout configuration.
So, I updated the timeout configuration from `60s` to `120s`.

Please take a look!