### PR TITLE
Update getting started guide to work on any Kubernetes cluster

### DIFF
--- a/docs/getting-started-logging.md
+++ b/docs/getting-started-logging.md
@@ -4,9 +4,9 @@ This document explains how to get started with log aggregation for Scalar produc
 
 We assume that you have already read the [getting-started with monitoring](./getting-started-monitoring.md) for Scalar products and installed kube-prometheus-stack.
 
-## Environment
+## What we create
 
-We will create the `loki-stack` component in the following diagram.
+We will deploy the following components on a Kubernetes cluster as follows.
 
 ```
 +--------------------------------------------------------------------------------------------------+

--- a/docs/getting-started-logging.md
+++ b/docs/getting-started-logging.md
@@ -16,11 +16,11 @@ We will create the `loki-stack` component in the following diagram.
 | | +--------------+  +--------------+ | <-----------------(Log)-------------- | Scalar Products | |
 | | |     Loki     |  |   Promtail   | |                                       |                 | |
 | | +--------------+  +--------------+ |                                       |  +-----------+  | |
-| +------------------------------------+                                       |  | Scalar DB |  | |
+| +------------------------------------+                                       |  | ScalarDB  |  | |
 |                                                                              |  +-----------+  | |
 | +------------------------------------------------------+                     |                 | |
 | |                kube-prometheus-stack                 |                     |  +-----------+  | |
-| |                                                      |                     |  | Scalar DL |  | |
+| |                                                      |                     |  | ScalarDL  |  | |
 | | +--------------+  +--------------+  +--------------+ | -----(Monitor)----> |  +-----------+  | |
 | | |  Prometheus  |  | Alertmanager |  |   Grafana    | |                     +-----------------+ |
 | | +-------+------+  +------+-------+  +------+-------+ |                                         |
@@ -29,9 +29,9 @@ We will create the `loki-stack` component in the following diagram.
 | |                          |                           |                                         |
 | +--------------------------+---------------------------+                                         |
 |                            |                                                                     |
-|                            |         Kubernetes (minikube)                                       |
+|                            |         Kubernetes                                                  |
 +----------------------------+---------------------------------------------------------------------+
-                             | <- expose to localhost (127.0.0.1)
+                             | <- expose to localhost (127.0.0.1) or use load balancer etc to access
                              |
               (Access Dashboard through HTTP)
                              |
@@ -59,7 +59,8 @@ We will create the `loki-stack` component in the following diagram.
 ## Step 3. Access the Grafana dashboard
 
 1. Add Loki as a data source
-   - Go to Grafana http://localhost:3000
+   - Go to Grafana http://localhost:3000 (If you use minikube)
+      - If you use a Kubernetes cluster other than minikube, you need to access the LoadBalancer service according to the manner of each Kubernetes cluster.
    - Move to `Configuration` and choose `Data Sources`
    - Click `Add data source`
    - Select `Loki`
@@ -69,7 +70,7 @@ We will create the `loki-stack` component in the following diagram.
 
 ## Step 4. Delete the `loki-stack` helm chart
 
-1. Uninstall `loki-stack` from minikube.
+1. Uninstall `loki-stack`.
    ```console
    helm uninstall scalar-logging-loki -n monitoring
    ```

--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -1,10 +1,10 @@
 # Getting Started with Helm Charts (Monitoring using Prometheus Operator)
 
-This document explains how to get started with Scalar products monitoring on Kubernetes using Prometheus Operator (kube-prometheus-stack). Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
+This document explains how to get started with Scalar products monitoring on Kubernetes using Prometheus Operator (kube-prometheus-stack). Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.
 
-## Environment
+## What we create
 
-We will create the following environment on a Kubernetes cluster.
+We will deploy the following components on a Kubernetes cluster as follows.
 
 ```
 +--------------------------------------------------------------------------------------------------+

--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -1,10 +1,10 @@
 # Getting Started with Helm Charts (Monitoring using Prometheus Operator)
 
-This document explains how to get started with Scalar products monitoring on Kubernetes using Prometheus Operator (kube-prometheus-stack). Here, we assume that you already have a Mac or Linux environment for testing.
+This document explains how to get started with Scalar products monitoring on Kubernetes using Prometheus Operator (kube-prometheus-stack). Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
 
 ## Environment
 
-We will create the following environment in your local by using Docker and minikube.
+We will create the following environment on a Kubernetes cluster.
 
 ```
 +--------------------------------------------------------------------------------------------------+
@@ -12,16 +12,16 @@ We will create the following environment in your local by using Docker and minik
 | |                kube-prometheus-stack                 |                     | Scalar Products | |
 | |                                                      |                     |                 | |
 | | +--------------+  +--------------+  +--------------+ | -----(Monitor)----> |  +-----------+  | |
-| | |  Prometheus  |  | Alertmanager |  |   Grafana    | |                     |  | Scalar DB |  | |
+| | |  Prometheus  |  | Alertmanager |  |   Grafana    | |                     |  | ScalarDB  |  | |
 | | +-------+------+  +------+-------+  +------+-------+ |                     |  +-----------+  | |
 | |         |                |                 |         |                     |  +-----------+  | |
-| |         +----------------+-----------------+         |                     |  | Scalar DL |  | |
+| |         +----------------+-----------------+         |                     |  | ScalarDL  |  | |
 | |                          |                           |                     |  +-----------+  | |
 | +--------------------------+---------------------------+                     +-----------------+ |
 |                            |                                                                     |
-|                            |         Kubernetes (minikube)                                       |
+|                            |         Kubernetes                                                  |
 +----------------------------+---------------------------------------------------------------------+
-                             | <- expose to localhost (127.0.0.1)
+                             | <- expose to localhost (127.0.0.1) or use load balancer etc to access
                              |
               (Access Dashboard through HTTP)
                              |
@@ -30,9 +30,9 @@ We will create the following environment in your local by using Docker and minik
                         +---------+
 ```
 
-## Step 1. Start minikube
+## Step 1. Start a Kubernetes cluster
 
-First, you need to prepare a `minikube` environment according to [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md). If you have already started the `minikube`, you can skip this step.
+First, you need to prepare a Kubernetes cluster. If you use a **minikube** environment, please refer to the [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md). If you have already started a Kubernetes cluster, you can skip this step.
 
 ## Step 2. Prepare a custom values file
 
@@ -72,8 +72,6 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
 
-
-
 ## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
@@ -94,10 +92,10 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
 * Note: 
-   * The following explains the minimum steps. If you want to know more details about the deployment of Scalar DB and Scalar DL, please refer to the following documents.
-       * [Getting Started with Helm Charts (Scalar DB Server)](./getting-started-scalardb.md)
-       * [Getting Started with Helm Charts (Scalar DL Ledger)](./getting-started-scalardl-ledger.md)
-       * [Getting Started with Helm Charts (Scalar DL Auditor)](./getting-started-scalardl-auditor.md)
+   * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
+       * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
+       * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
+       * [Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)](./getting-started-scalardl-auditor.md)
 
 1. To enable Prometheus monitoring of Scalar products, set `true` to the following configurations in the custom values file.
    * Configurations
@@ -105,11 +103,9 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
        * `*.grafanaDashboard.enabled`
        * `*.serviceMonitor.enabled`
    * Sample configuration files
-       * Scalar DB (scalardb-custom-values.yaml)
+       * ScalarDB (scalardb-custom-values.yaml)
          ```yaml
          envoy:
-           service:
-             type: "NodePort"
            prometheusRule:
              enabled: true
            grafanaDashboard:
@@ -118,11 +114,6 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
              enabled: true
          
          scalardb:
-           storageConfiguration:
-             contactPoints: "cassandra-scalardb"
-             username: "cassandra"
-             password: "cassandra"
-             storage: "cassandra"
            prometheusRule:
              enabled: true
            grafanaDashboard:
@@ -130,11 +121,9 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
            serviceMonitor:
              enabled: true
          ```
-       * Scalar DL Ledger (scalardl-ledger-custom-values.yaml)
+       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
          ```yaml
          envoy:
-           service:
-             type: "NodePort"
            prometheusRule:
              enabled: true
            grafanaDashboard:
@@ -143,13 +132,6 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
              enabled: true
          
          ledger:
-           scalarLedgerConfiguration:
-             dbStorage: "cassandra"
-             dbContactPoints: "cassandra-ledger"
-             dbUsername: "cassandra"
-             dbPassword: "cassandra"
-             ledgerProofEnabled: true
-           # ledgerAuditorEnabled: true
            prometheusRule:
              enabled: true
            grafanaDashboard:
@@ -157,11 +139,9 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
            serviceMonitor:
              enabled: true
          ```
-       * Scalar DL Auditor (scalardl-auditor-custom-values.yaml)
+       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
          ```yaml
          envoy:
-           service:
-             type: "NodePort"
            prometheusRule:
              enabled: true
            grafanaDashboard:
@@ -170,12 +150,6 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
              enabled: true
          
          auditor:
-           scalarAuditorConfiguration:
-             dbStorage: "cassandra"
-             dbContactPoints: "cassandra-auditor"
-             dbUsername: "cassandra"
-             dbPassword: "cassandra"
-             auditorLedgerHost: "scalardl-ledger-envoy"
            prometheusRule:
              enabled: true
            grafanaDashboard:
@@ -186,21 +160,21 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
 
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
    * Examples
-       * Scalar DB
+       * ScalarDB
          ```console
          helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
          ```console
          helm upgrade scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
-       * Scalar DL Ledger
+       * ScalarDL Ledger
          ```console
          helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
          ```console
          helm upgrade scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
-       * Scalar DL Auditor
+       * ScalarDL Auditor
          ```console
          helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
@@ -209,6 +183,8 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
          ```
 
 ## Step 5. Access Dashboards
+
+### If you use minikube
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
    ```console
@@ -251,23 +227,27 @@ First, you need to prepare a `minikube` environment according to [Getting Starte
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
 
+### If you use other Kubernetes than minikube
+
+If you use a Kubernetes cluster other than minikube, you need to access the LoadBalancer service according to the manner of each Kubernetes cluster. For example, using a Load Balancer provided by cloud service or the `kubectl port-forward` command.
+
 ## Step 6. Delete all resources
 
-After completing the Monitoring tests on minikube, remove all resources.
+After completing the Monitoring tests on the Kubernetes cluster, remove all resources.
 
-1. Terminate the `minikube tunnel` command.
+1. Terminate the `minikube tunnel` command. (If you use minikube)
    ```console
    Ctrl + C
    ```
 
-1. Uninstall `kube-prometheus-stack` from minikube.
+1. Uninstall `kube-prometheus-stack`.
    ```console
    helm uninstall scalar-monitoring -n monitoring
    ```
 
-1. (Optional) Delete minikube.
+1. Delete minikube. (Optional / If you use minikube)
    ```console
    minikube delete --all
    ```
    * Note:
-       * If you deploy the Scalar DB or Scalar DL, you need to remove them before deleting minikube.
+       * If you deploy the ScalarDB or ScalarDL, you need to remove them before deleting minikube.

--- a/docs/getting-started-scalar-helm-charts.md
+++ b/docs/getting-started-scalar-helm-charts.md
@@ -1,13 +1,12 @@
 # Getting Started with Scalar Helm Charts
 
-This document explains how to get started with Scalar Helm Chart in your test environment using `Minikube`. Here, we assume that you already have a Mac or Linux environment for testing.  
+This document explains how to get started with Scalar Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
 
 ## Tools
 
 We will use the following tools for testing.  
 
-1. Docker
-1. minikube
+1. minikube (If you use other Kubernetes distributions, minikube is not necessary.)
 1. kubectl
 1. Helm
 1. cfssl / cfssljson
@@ -15,8 +14,6 @@ We will use the following tools for testing.
 ## Step 1. Install tools
 
 First, you need to install the following tools used in this guide.
-
-1. Install the Docker according to the [Docker document](https://docs.docker.com/engine/install/)  
 
 1. Install the minikube according to the [minikube document](https://minikube.sigs.k8s.io/docs/start/)  
 
@@ -26,13 +23,13 @@ First, you need to install the following tools used in this guide.
 
 1. Install the cfssl and cfssljson according to the [CFSSL document](https://github.com/cloudflare/cfssl)
    * Note:
-        * You need the cfssl and cfssljson when you try Scalar DL. If you try Scalar Helm Charts other than Scalar DL (e.g., Scalar DB, Monitoring, Logging, etc...), the cfssl and cfssljson are not necessary.
+        * You need the cfssl and cfssljson when you try ScalarDL. If you try Scalar Helm Charts other than ScalarDL (e.g., ScalarDB, Monitoring, Logging, etc...), the cfssl and cfssljson are not necessary.
 
-## Step 2. Start minikube with docker driver
+## Step 2. Start minikube with docker driver (Optional / If you use minikube)
 
-1. Start minikube with docker driver.
+1. Start minikube.
    ```console
-   minikube start --driver=docker
+   minikube start
    ```
 
 1. Check the status of the minikube and pods.
@@ -50,15 +47,15 @@ First, you need to install the following tools used in this guide.
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
-   If the minikube starts properly, you can see some pods are `Running` in the kube-system namespace.
+   If the minikube starts properly, you can see some pods are **Running** in the kube-system namespace.
 
 ## Step 3. 
 
-After the minikube starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
+After the Kubernetes cluster starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
 
-* [Scalar DB Server](./getting-started-scalardb.md)
-* [Scalar DL Ledger](./getting-started-scalardl-ledger.md)
-* [Scalar DL Auditor](./getting-started-scalardl-auditor.md)
+* [ScalarDB Server](./getting-started-scalardb.md)
+* [ScalarDL Ledger (Ledger only)](./getting-started-scalardl-ledger.md)
+* [ScalarDL Ledger and Auditor (Auditor mode)](./getting-started-scalardl-auditor.md)
 * [Monitoring using Prometheus Operator](./getting-started-monitoring.md)
   * [Logging using Loki Stack](./getting-started-logging.md)
   * [Scalar Manager](./getting-started-scalar-manager.md)

--- a/docs/getting-started-scalar-helm-charts.md
+++ b/docs/getting-started-scalar-helm-charts.md
@@ -1,6 +1,6 @@
 # Getting Started with Scalar Helm Charts
 
-This document explains how to get started with Scalar Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
+This document explains how to get started with Scalar Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.
 
 ## Tools
 

--- a/docs/getting-started-scalar-manager.md
+++ b/docs/getting-started-scalar-manager.md
@@ -11,8 +11,9 @@ Scalar Manager also embeds Grafana explorers by which the users can review the m
 This guide assumes that the users are aware of how to deploy Scalar products with the monitoring and logging tools to a Kubernetes cluster.
 If not, please start with [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md) before this guide.
 
-## Environment
-In this guide, we will create the `scalar-manager` component in the following diagram.
+## What we create
+
+We will deploy the following components on a Kubernetes cluster as follows.
 
 ```
 +--------------------------------------------------------------------------------------------------+

--- a/docs/getting-started-scalar-manager.md
+++ b/docs/getting-started-scalar-manager.md
@@ -30,11 +30,11 @@ In this guide, we will create the `scalar-manager` component in the following di
 | | +--------------+  +--------------+ | <----------------(Log)--------------- | Scalar Products | |
 | | |     Loki     |  |   Promtail   | |                                       |                 | |
 | | +--------------+  +--------------+ |                                       |  +-----------+  | |
-| +------------------------------------+                                       |  | Scalar DB |  | |
+| +------------------------------------+                                       |  | ScalarDB  |  | |
 |    |                                                                         |  +-----------+  | |
 | +------------------------------------------------------+                     |                 | |
 | |                kube-prometheus-stack                 |                     |  +-----------+  | |
-| |                                                      |                     |  | Scalar DL |  | |
+| |                                                      |                     |  | ScalarDL  |  | |
 | | +--------------+  +--------------+  +--------------+ | -----(Monitor)----> |  +-----------+  | |
 | | |  Prometheus  |  | Alertmanager |  |   Grafana    | |                     +-----------------+ |
 | | +-------+------+  +------+-------+  +------+-------+ |                                         |
@@ -43,10 +43,10 @@ In this guide, we will create the `scalar-manager` component in the following di
 | |                          |                           |                                         |
 | +--------------------------+---------------------------+                                         |
 |    |                       |                                                                     |
-|    |                       |         Kubernetes (minikube)                                       |
+|    |                       |         Kubernetes                                                  |
 +----+-----------------------+---------------------------------------------------------------------+
      |                       |
-  expose to localhost (127.0.0.1)
+  expose to localhost (127.0.0.1) or use load balancer etc to access
      |                       |
   (Access Dashboard through HTTP)
      |                       |
@@ -83,8 +83,7 @@ In this guide, we will create the `scalar-manager` component in the following di
          adminSrv: _scalardl-admin._tcp.scalardl-headless.default.svc.cluster.local
          databaseType: cassandra
    ```
-
-Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
+   Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
 
 1. Set the Grafana URL. For example, if your Grafana of the `kube-prometheus-stack` is exposed in `localhost:3000`, then we can set it as follows.
    ```yaml
@@ -98,6 +97,12 @@ Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kub
      refreshInterval: 60 # one minute
    ```
 
+1. Set the service type to access Scalar Manager. The default value is `ClusterIP`, but if we access using the `minikube tunnel` command or some load balancer, we can set it as `LoadBalancer`.
+   ```yaml
+   service:
+     type: LoadBalancer
+   ```
+
 ## Step 3. Deploy `scalar-manager`
 
 1. Deploy the `scalar-manager` Helm Chart.
@@ -107,12 +112,18 @@ Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kub
 
 ## Step 4. Access Scalar Manager
 
-1. Forward Scalar Manager's port 8000 to the host's port 8000
+### If you use minikube
+
+1. To expose Scalar Manager's service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
    ```console
-   kubectl port-forward services/scalar-manager 8000
+   minikube tunnel
    ```
 
 1. Open the browser with URL `http://localhost:8000`
+
+### If you use other Kubernetes than minikube
+
+If you use a Kubernetes cluster other than minikube, you need to access the LoadBalancer service according to the manner of each Kubernetes cluster. For example, using a Load Balancer provided by cloud service or the `kubectl port-forward` command.
 
 ## Step 5. Delete Scalar Manager
 1. Uninstall `scalar-manager`

--- a/docs/getting-started-scalardb.md
+++ b/docs/getting-started-scalardb.md
@@ -1,6 +1,6 @@
 # Getting Started with Helm Charts (ScalarDB Server)
 
-This document explains how to get started with ScalarDB Server using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
+This document explains how to get started with ScalarDB Server using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.
 
 ## Requirement
 
@@ -8,9 +8,9 @@ This document explains how to get started with ScalarDB Server using Helm Chart 
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
-## Environment
+## What we create
 
-We will create the following environment on a Kubernetes cluster.
+We will deploy the following components on a Kubernetes cluster as follows.
 
 ```
 +--------------------------------------------------------------------------------------------------------------------------------------+

--- a/docs/getting-started-scalardb.md
+++ b/docs/getting-started-scalardb.md
@@ -1,198 +1,232 @@
-# Getting Started with Helm Charts (Scalar DB Server)
+# Getting Started with Helm Charts (ScalarDB Server)
 
-This document explains how to get started with Scalar DB Server using Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
+This document explains how to get started with ScalarDB Server using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
+
+## Requirement
+
+* You need to subscribe to ScalarDB in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2) or [Azure Marketplace](https://azuremarketplace.microsoft.com/en/marketplace/apps/scalarinc.scalardb) to get container images (`scalardb-server` and `scalardb-envoy`). Please refer to the following documents for more details.
+   * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
+   * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 ## Environment
 
-We will create the following environment in your local by using Docker and minikube.  
+We will create the following environment on a Kubernetes cluster.
 
 ```
-On the Docker Network (named minikube)
-
-                   +-----------------------+
-  +-----------+    | +------------------+  |    +-----------+
-  |           |    | | Scalar DB Server |  |    |           |
-  |  Client   |    | +------------------+  |    | Cassandra |
-  | Container |    |                       |    | Container |
-  |           |    | Kubernetes (minikube) |    |           |
-  +-----+-----+    +-----------+-----------+    +-----+-----+
-        |                      |                      |
-*-------+----------------------+----------------------+-------*
-             ------->                     ------->
-               gRPC                    Cassandra Driver
++--------------------------------------------------------------------------------------------------------------------------------------+
+| [Kubernetes Cluster]                                                                                                                 |
+|                                                                                                                                      |
+|    [Pod]                                [Pod]                                                  [Pod]                     [Pod]       |
+|                                                                                                                                      |
+|                                       +-------+                                         +-----------------+                          |
+|                                 +---> | Envoy | ---+                              +---> | ScalarDB Server | ---+                     |
+|                                 |     +-------+    |                              |     +-----------------+    |                     |
+|                                 |                  |                              |                            |                     |
+|  +--------+      +---------+    |     +-------+    |     +-------------------+    |     +-----------------+    |     +------------+  |
+|  | Client | ---> | Service | ---+---> | Envoy | ---+---> |      Service      | ---+---> | ScalarDB Server | ---+---> | PostgreSQL |  |
+|  +--------+      | (Envoy) |    |     +-------+    |     | (ScalarDB Server) |    |     +-----------------+    |     +------------+  |
+|                  +---------+    |                  |     +-------------------+    |                            |                     |
+|                                 |     +-------+    |                              |     +-----------------+    |                     |
+|                                 +---> | Envoy | ---+                              +---> | ScalarDB Server | ---+                     |
+|                                       +-------+                                         +-----------------+                          |
+|                                                                                                                                      |
++--------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
-## Step 1. Start minikube
+## Step 1. Start a Kubernetes cluster
 
-First, you need to prepare a `minikube` environment according to [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md). If you have already started the `minikube`, you can skip this step.
+First, you need to prepare a Kubernetes cluster. If you use a **minikube** environment, please refer to the [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md). If you have already started a Kubernetes cluster, you can skip this step.
 
-## Step 2. Start Cassandra container
+## Step 2. Start a PostgreSQL container
 
-We use Apache Cassandra as the backend storage of Scalar DB Server. We start a Cassandra container on the same network of Kubernetes (Scalar DB Server Pod on minikube) to make them communicate properly.
+ScalarDB uses some kind of database system as a backend database. In this document, we use PostgreSQL.
 
-1. Start a Cassandra container on the Docker Network `minikube`.
+You can deploy PostgreSQL on the Kubernetes cluster as follows.
+
+1. Add the Bitnami helm repository.
    ```console
-   docker run --name cassandra-scalardb --network minikube -d cassandra:3.11
+   helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
-   * Note: 
-       * The Docker Network `minikube` was created by `minikube start --driver=docker` command that we ran in Step 2.
-       * You can see the Scalar DB-supported Cassandra versions (tag) in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
-       * If you want to create a schema for Scalar DB by running Schema Loader from localhost, you need to expose the container's 9042 port as follows.
-         ```console
-         docker run --name cassandra-scalardb --network minikube -p 127.0.0.1:9042:9042 -d cassandra:3.11
-         ```
 
-1. Check if the Cassandra container is running.
+1. Deploy PostgreSQL.
    ```console
-   docker ps -f name=cassandra-scalardb
+   helm install postgresql-scalardb bitnami/postgresql \
+     --set auth.postgresPassword=postgres \
+     --set primary.persistence.enabled=false
+   ```
+
+1. Check if the PostgreSQL container is running.
+   ```console
+   kubectl get pod
    ```
    [Command execution result]
    ```console
-   CONTAINER ID   IMAGE            COMMAND                  CREATED         STATUS         PORTS                                         NAMES
-   6dceab0007c8   cassandra:3.11   "docker-entrypoint.s…"   2 minutes ago   Up 2 minutes   7000-7001/tcp, 7199/tcp, 9042/tcp, 9160/tcp   cassandra-scalardb
+   NAME                    READY   STATUS    RESTARTS   AGE
+   postgresql-scalardb-0   1/1     Running   0          2m42s
    ```
 
-1. Check the status of Cassandra.
-   ```console
-   docker exec -t cassandra-scalardb cqlsh -e "show version"
-   ```
-   [Command execution result]
-   ```console
-   [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
-   ```
-   It may take a while to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
+## Step 3. Deploy ScalarDB Server on the Kubernetes cluster using Helm Charts
 
-## Step 3. Deploy Scalar DB Server on the Kubernetes (minikube) using Helm Charts
-
-1. Add the Scalar Helm Repository.
+1. Add the Scalar helm repository.
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
-1. Create a custom value file for Scalar DB Server (scalardb-custom-values.yaml).
-   ```console
-   cat << EOF > scalardb-custom-values.yaml
-   envoy:
-     service:
-       type: "NodePort"
-   
-   scalardb:
-     storageConfiguration:
-       contactPoints: "cassandra-scalardb"
-       username: "cassandra"
-       password: "cassandra"
-       storage: "cassandra"
-   EOF
-   ```
-   * Note:
-       * If you want to access Scalar DB Server from 127.0.0.1 (your localhost), set `LoadBalancer` to `envoy.service.type` like the following.
-         ```console
-         cat << EOF > scalardb-custom-values.yaml
-         envoy:
-           service:
-             type: "LoadBalancer"
-         
-         scalardb:
-           storageConfiguration:
-             contactPoints: "cassandra-scalardb"
-             username: "cassandra"
-             password: "cassandra"
-             storage: "cassandra"
-         EOF
-         ```
+1. Create a secret resource to pull the ScalarDB container images from AWS/Azure Marketplace.
+   * AWS Marketplace
+     ```console
+     kubectl create secret docker-registry reg-ecr-mp-secrets \
+       --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
+       --docker-username=AWS \
+       --docker-password=$(aws ecr get-login-password --region us-east-1)
+     ```
+   * Azure Marketplace
+     ```console
+     kubectl create secret docker-registry reg-acr-secrets \
+       --docker-server=<your private container registry login server> \
+       --docker-username=<Service principal ID> \
+       --docker-password=<Service principal password>
+     ```
 
-1. Deploy Scalar DB Server.
+   Please refer to the following documents for more details.
+   
+   * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
+   * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
+
+1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
+   * AWS Marketplace
+     ```console
+     cat << EOF > scalardb-custom-values.yaml
+     envoy:
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-envoy"
+         version: "1.3.0"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+     
+     scalardb:
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
+         tag: "3.7.0"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+       databaseProperties: |
+         scalar.db.storage=jdbc
+         scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DB_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DB_POSTGRES_PASSWORD "" }}
+       secretName: "scalardb-credentials-secret"
+     EOF
+     ```
+   * Azure Marketplace
+     ```console
+     cat << EOF > scalardb-custom-values.yaml
+     envoy:
+       image:
+         repository: "<your private container registry>/scalarinc/scalardb-envoy"
+         version: "1.3.0"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+     
+     scalardb:
+       image:
+         repository: "<your private container registry>/scalarinc/scalardb-server"
+         tag: "3.7.0"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+       databaseProperties: |
+         scalar.db.storage=jdbc
+         scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DB_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DB_POSTGRES_PASSWORD "" }}
+       secretName: "scalardb-credentials-secret"
+        EOF
+     ```
+
+1. Create a Secret resource that includes a username and password for PostgreSQL.
+   ```console
+   kubectl create secret generic scalardb-credentials-secret \
+     --from-literal=SCALAR_DB_POSTGRES_USERNAME=postgres \
+     --from-literal=SCALAR_DB_POSTGRES_PASSWORD=postgres
+   ```
+
+1. Deploy ScalarDB Server.
    ```console
    helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
    ```
 
-1. Check if the Scalar DB Server Pods are deployed.
+1. Check if the ScalarDB Server pods are deployed.
    ```console
    kubectl get pod
    ```
    [Command execution result]
    ```console
    NAME                              READY   STATUS    RESTARTS   AGE
-   scalardb-7674f74d6b-blxnj         1/1     Running   0          19m
-   scalardb-7674f74d6b-kx5q7         1/1     Running   0          19m
-   scalardb-7674f74d6b-mzwcr         1/1     Running   0          19m
-   scalardb-envoy-5fb8f64786-5q6hn   1/1     Running   0          19m
-   scalardb-envoy-5fb8f64786-8d7k5   1/1     Running   0          19m
-   scalardb-envoy-5fb8f64786-t2xcv   1/1     Running   0          19m
+   postgresql-scalardb-0             1/1     Running   0          9m48s
+   scalardb-765598848b-75csp         1/1     Running   0          6s
+   scalardb-765598848b-w864f         1/1     Running   0          6s
+   scalardb-765598848b-x8rqj         1/1     Running   0          6s
+   scalardb-envoy-84c475f77b-kpz2p   1/1     Running   0          6s
+   scalardb-envoy-84c475f77b-n74tk   1/1     Running   0          6s
+   scalardb-envoy-84c475f77b-zbrwz   1/1     Running   0          6s
    ```
-   If the Scalar DB Server Pods are deployed properly, you can see the STATUS are `Running`.  
+   If the ScalarDB Server Pods are deployed properly, you can see the STATUS are **Running**.  
 
-1. Check if the Scalar DB Server Services are deployed.
+1. Check if the ScalarDB Server services are deployed.
    ```console
    kubectl get svc
    ```
    [Command execution result]
    ```console
-   NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
-   kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP                           163m
-   scalardb-envoy           NodePort    10.103.103.188   <none>        60051:32344/TCP,50052:30921/TCP   19m
-   scalardb-envoy-metrics   ClusterIP   10.99.184.116    <none>        9001/TCP                          19m
-   scalardb-headless        ClusterIP   None             <none>        50051/TCP                         19m
-   scalardb-metrics         ClusterIP   10.101.127.88    <none>        8080/TCP                          19m
+   NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
+   kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP     47d
+   postgresql-scalardb      ClusterIP   10.109.118.122   <none>        5432/TCP    10m
+   postgresql-scalardb-hl   ClusterIP   None             <none>        5432/TCP    10m
+   scalardb-envoy           ClusterIP   10.110.110.250   <none>        60051/TCP   41s
+   scalardb-envoy-metrics   ClusterIP   10.107.98.227    <none>        9001/TCP    41s
+   scalardb-headless        ClusterIP   None             <none>        60051/TCP   41s
+   scalardb-metrics         ClusterIP   10.108.188.10    <none>        8080/TCP    41s
    ```
-   If the Scalar DB Server Services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
+   If the ScalarDB Server services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
 
-1. (Optional) If you set `LoadBalancer` to `envoy.service.type` in the `scalardb-custom-values.yaml`, you can access Scalar DB Server from 127.0.0.1.  
-   To expose the `scalardb-envoy` service as your local `127.0.0.1:60051`, open another terminal, and run the `minikube tunnel` command.
+## Step 4. Start a Client container
+
+1. Start a Client container on the Kubernetes cluster.
    ```console
-   minikube tunnel
+   kubectl run scalardb-client --image eclipse-temurin:8 --command sleep inf
    ```
-   After running the `minikube tunnel` command, you can see the EXTERNAL-IP of the `scalardb-envoy` as `127.0.0.1`.
+
+1. Check if the Client container is running.
    ```console
-   kubectl get svc scalardb-envoy
+   kubectl get pod scalardb-client
    ```
    [Command execution result]
    ```console
-   NAME             TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
-   scalardb-envoy   LoadBalancer   10.103.103.188   127.0.0.1     60051:32344/TCP,50052:30921/TCP   13m
+   NAME              READY   STATUS    RESTARTS   AGE
+   scalardb-client   1/1     Running   0          23s
    ```
 
-## Step 4. Start Client container
+## Step 5. Run ScalarDB sample applications in the Client container
 
-
-1. Start a Client container on the `minikube` network.
-   ```console
-   docker run -d --name scalardb-client --hostname scalardb-client --network minikube --entrypoint sleep ubuntu:20.04 inf
-   ```
-
-1. Check the status of the Client container.
-   ```console
-   docker ps -f name=scalardb-client
-   ```
-   [Command execution result]
-   ```console
-   CONTAINER ID   IMAGE          COMMAND       CREATED              STATUS              PORTS     NAMES
-   a49eaf0c2442   ubuntu:20.04   "sleep inf"   About a minute ago   Up About a minute             scalardb-client
-   ```
-
-## Step 5. Run Scalar DB sample application in the Client container
-
-
-The following explains the minimum steps. If you want to know more details about Scalar DB, please refer to the [Getting Started with Scalar DB
-](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
+The following explains the minimum steps. If you want to know more details about ScalarDB, please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 
 1. Run bash in the Client container.
    ```console
-   docker exec -it scalardb-client bash
+   kubectl exec -it scalardb-client -- bash
    ```
    After this step, run each command in the Client container.  
 
-1. Install Git, OpenJDK 8, and curl in the Client container.
+1. Install the git and curl commands in the Client container.
    ```console
-   apt update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt install -y git openjdk-8-jdk curl
+   apt update && apt install -y git curl
    ```
 
-1. Clone Scalar DB git repository.
+1. Clone ScalarDB git repository.
    ```console
    git clone https://github.com/scalar-labs/scalardb.git
    ```
 
-1. Change directory to `scalardb/`.
+1. Change the directory to `scalardb/`.
    ```console
    cd scalardb/
    ```
@@ -206,7 +240,7 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Change branch to arbitrary version.
    ```console
-   git checkout -b v3.5.1 refs/tags/v3.5.1
+   git checkout -b v3.7.0 refs/tags/v3.7.0
    ```
    ```console
    git branch
@@ -214,16 +248,11 @@ The following explains the minimum steps. If you want to know more details about
    [Command execution result]
    ```console
      master
-   * v3.5.1
+   * v3.7.0
    ```
    If you want to use another version, please specify the version (tag) you want to use.
 
-1. Build Scalar DB as a library.
-   ```console
-   ./gradlew installDist
-   ```
-
-1. Change directory to `docs/getting-started/`.
+1. Change the directory to `docs/getting-started/`.
    ```console
    cd docs/getting-started/
    ```
@@ -235,34 +264,23 @@ The following explains the minimum steps. If you want to know more details about
    /scalardb/docs/getting-started
    ```
 
-1. Download Schema Loader from [Scalar DB Releases](https://github.com/scalar-labs/scalardb/releases).
+1. Download Schema Loader from [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases).
    ```console
-   curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.5.1/scalardb-schema-loader-3.5.1.jar
+   curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.7.0/scalardb-schema-loader-3.7.0.jar
    ```
-   You need to use the same version of Scalar DB and Schema Loader.
+   You need to use the same version of ScalarDB and Schema Loader.
 
-1. Create a configuration file (scalardb.properties) to access Scalar DB Server on minikube.
+1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
    ```console
    cat << EOF > scalardb.properties
-   scalar.db.contact_points=minikube
-   scalar.db.contact_port=32344
+   scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
+   scalar.db.contact_port=60051
    scalar.db.storage=grpc
    scalar.db.transaction_manager=grpc
    EOF
    ```
-   * Note:
-       * You need to specify the port number (NodePort) of `scalardb-envoy` (Kubernetes Service Resource) as a value of `scalar.db.contact_port` in the `scalardb.properties`. You can confirm the port number of `scalardb-envoy` with the `kubectl get svc scalardb-envoy` command.
-         ```console
-         kubectl get svc scalardb-envoy
-         ```
-         [Command execution result]
-         ```console
-         NAME             TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
-         scalardb-envoy   NodePort   10.103.103.188   <none>        60051:32344/TCP,50052:30921/TCP   79m
-         ```
-         In this case, you need to specify `32344` to `scalar.db.contact_port` in the `scalardb.properties` file.
 
-1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample application.
+1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
    ```console
    cat << EOF > emoney-transaction.json
    {
@@ -283,51 +301,56 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Run Schema Loader (Create sample TABLE).
    ```console
-   java -jar ./scalardb-schema-loader-3.5.1.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
+   java -jar ./scalardb-schema-loader-3.7.0.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
    ```
 
-1. Run the sample application.
-   ```console
-   ../../gradlew run --args="-mode transaction -action charge -amount 1000 -to user1"
-   ```
-   ```console
-   ../../gradlew run --args="-mode transaction -action charge -amount 0 -to merchant1"
-   ```
-   ```console
-   ../../gradlew run --args="-mode transaction -action pay -amount 100 -to merchant1 -from user1"
-   ```
+1. Run the sample applications.
+   * Charge `1000` to `user1`:
+     ```console
+     ./gradlew run --args="-action charge -amount 1000 -to user1"
+     ```
+   * Charge `0` to `merchant1` (Just create an account for `merchant1`):
+     ```console
+     ./gradlew run --args="-action charge -amount 0 -to merchant1"
+     ```
+   * Pay `100` from `user1` to `merchant1`:
+     ```console
+     ./gradlew run --args="-action pay -amount 100 -from user1 -to merchant1"
+     ```
+   * Get the balance of `user1`:
+     ```console
+     ./gradlew run --args="-action getBalance -id user1"
+     ```
+   * Get the balance of `merchant1`:
+     ```console
+     ./gradlew run --args="-action getBalance -id merchant1"
+     ```
 
-1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample application using the following command. (This command needs to run on your localhost, not on the Client container.)  
+1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample applications using the following command. (This command needs to run on your localhost, not on the Client container.)  
    ```console
-   docker exec -t cassandra-scalardb cqlsh -e "SELECT * FROM emoney.account"
+   kubectl exec -it postgresql-scalardb-0 -- bash -c 'export PGPASSWORD=postgres && psql -U postgres -d postgres -c "SELECT * FROM emoney.account"'
    ```
    [Command execution result]
-   ```console
-    id        | balance | before_balance | before_tx_committed_at | before_tx_id                         | before_tx_prepared_at | before_tx_state | before_tx_version | tx_committed_at | tx_id                                | tx_prepared_at | tx_state | tx_version
-   -----------+---------+----------------+------------------------+--------------------------------------+-----------------------+-----------------+-------------------+-----------------+--------------------------------------+----------------+----------+------------
-        user1 |     900 |           1000 |          1649830558289 | 78bdbb22-1ab4-4263-80c4-eacd9c6fbcfb |         1649830558262 |               3 |                 1 |   1649830585148 | d156b2dc-f791-4fd4-b3de-a6272eb2a680 |  1649830585119 |        3 |          2
-    merchant1 |     100 |              0 |          1649830578857 | e4028217-ab4f-4755-ab31-fcc2ed93905f |         1649830578840 |               3 |                 1 |   1649830585148 | d156b2dc-f791-4fd4-b3de-a6272eb2a680 |  1649830585119 |        3 |          2
-   
+   ```sql
+       id     | balance |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at |             before_tx_id             | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_balance
+   -----------+---------+--------------------------------------+----------+------------+----------------+-----------------+--------------------------------------+-----------------+-------------------+-----------------------+------------------------+----------------
+    merchant1 |     100 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 3633df99-a8ed-4301-a8b9-db1344807d7b |               3 |                 1 |         1667361902466 |          1667361902485 |              0
+    user1     |     900 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 5520cba4-625a-4886-b81f-6089bf846d18 |               3 |                 1 |         1667361897283 |          1667361897317 |           1000
    (2 rows)
    ```
    * Note:
-       * Usually, you need to access data (record) through Scalar DB. The above command is used to explain and confirm the working of the sample application.
+       * Usually, you need to access data (records) through ScalarDB. The above command is used to explain and confirm the working of the sample applications.
 
 ## Step 6. Delete all resources
 
-After completing the Scalar DB Server tests on minikube, remove all resources.
+After completing the ScalarDB Server tests on the Kubernetes cluster, remove all resources.
 
-1. Uninstall Scalar DB Server from minikube.
+1. Uninstall ScalarDB Server and PostgreSQL.
    ```console
-   helm uninstall scalardb
+   helm uninstall scalardb postgresql-scalardb
    ```
 
-1. Stop and remove containers (Cassandra and Client).
+1. Remove the Client container.
    ```
-   docker rm $(docker kill scalardb-client cassandra-scalardb)
-   ```
-
-1. Delete minikube.
-   ```console
-   minikube delete --all
+   kubectl delete pod scalardb-client --force --grace-period 0
    ```

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -1,87 +1,145 @@
-# Getting Started with Helm Charts (Scalar DL Auditor)
+# Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)
 
-This document explains how to get started with Scalar DL Ledger and Auditor using the Helm Chart in your test environment. Here, we assume that you already have a Mac or Linux environment for testing.  
+This document explains how to get started with ScalarDL Ledger and Auditor using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
 
 ## Requirement
 
-* You need the privileges to pull the Scalar DL containers (`scalar-ledger`, `scalar-auditor`, and `scalardl-schema-loader`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).
-* You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above containers.
+You need to subscribe to ScalarDL Ledger and ScalarDL Auditor in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2) or [Azure Marketplace](https://azuremarketplace.microsoft.com/en/marketplace/apps/scalarinc.scalardb) to get the following container images.
+   * AWS Marketplace
+      * scalar-ledger
+      * scalar-ledger-envoy
+      * scalardl-schema-loader-ledger
+      * scalar-auditor
+      * scalar-auditor-envoy
+      * scalardl-schema-loader-auditor
+   * Azure Marketplace
+      * scalar-ledger
+      * scalar-auditor
+      * scalardl-envoy
+      * scalardl-schema-loader
+
+Please refer to the following documents for more details.
+   * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
+   * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 ## Note
-To make Byzantine fault detection with auditing work properly, Ledger and Auditor should be deployed and managed in different administrative domains. However, in this guide, we will deploy Ledger and Auditor in the same Kubernetes (minikube) to make the test easier.  
+To make Byzantine fault detection with auditing work properly, Ledger and Auditor should be deployed and managed in different administrative domains. However, in this guide, we will deploy Ledger and Auditor in the same Kubernetes cluster to make the test easier.  
 
 ## Environment
 
-We will create the following environment in your local by using Docker and minikube.  
+We will create the following environment on a Kubernetes cluster.
 
 ```
-On the Docker Network (named minikube)
-
-                   +---------------------------------------------+    +-----------+    +-----------+
-  +-----------+    | +------------------+  +-------------------+ |    |           |    |           |
-  |           |    | | Scalar DL Ledger |  | Scalar DL Auditor | |    | Cassandra |    | Cassandra |
-  |  Client   |    | +------------------+  +-------------------+ |    | Container |    | Container |
-  | Container |    |                                             |    | (Ledger)  |    | (Auditor) |
-  |           |    |            Kubernetes (minikube)            |    |           |    |           |
-  +-----+-----+    +----------------------+----------------------+    +-----+-----+    +-----+-----+
-        |                                 |                                 |                |
-*-------+---------------------------------+---------------------------------+----------------+-------*
-             ------->                                           ------->
-               gRPC                                          Cassandra Driver
++-----------------------------------------------------------------------------------------------------------------------------+
+| [Kubernetes Cluster]                                                                                                        |
+|                                             [Pod]                                      [Pod]                   [Pod]        |
+|                                                                                                                             |
+|                                           +-------+                                 +---------+                             |
+|                                     +---> | Envoy | ---+                      +---> | Ledger  | ---+                        |
+|                                     |     +-------+    |                      |     +---------+    |                        |
+|                                     |                  |                      |                    |                        |
+|                      +---------+    |     +-------+    |     +-----------+    |     +---------+    |     +---------------+  |
+|                +---> | Service | ---+---> | Envoy | ---+---> |  Service  | ---+---> | Ledger  | ---+---> |  PostgreSQL   |  |
+|                |     | (Envoy) |    |     +-------+    |     | (Ledger)  |    |     +---------+    |     | (For Ledger)  |  |
+|                |     +---------+    |                  |     +-----------+    |                    |     +---------------+  |
+|                |                    |     +-------+    |                      |     +---------+    |                        |
+|                |                    +---> | Envoy | ---+                      +---> | Ledger  | ---+                        |
+|  +--------+    |                          +-------+                                 +---------+                             |
+|  | Client | ---+                                                                                                            |
+|  +--------+    |                          +-------+                                 +---------+                             |
+|                |                    +---> | Envoy | ---+                      +---> | Auditor | ---+                        |
+|                |                    |     +-------+    |                      |     +---------+    |                        |
+|                |                    |                  |                      |                    |                        |
+|                |     +---------+    |     +-------+    |     +-----------+    |     +---------+    |     +---------------+  |
+|                +---> | Service | ---+---> | Envoy | ---+---> |  Service  | ---+---> | Auditor | ---+---> |  PostgreSQL   |  |
+|                      | (Envoy) |    |     +-------+    |     | (Auditor) |    |     +---------+    |     | (For Auditor) |  |
+|                      +---------+    |                  |     +-----------+    |                    |     +---------------+  |
+|                                     |     +-------+    |                      |     +---------+    |                        |
+|                                     +---> | Envoy | ---+                      +---> | Auditor | ---+                        |
+|                                           +-------+                                 +---------+                             |
+|                                                                                                                             |
++-----------------------------------------------------------------------------------------------------------------------------+
 ```
 
-## Step 1. Create the Scalar DL Ledger environment
+## Step 1. Start a Kubernetes cluster
 
-First, you need to create a Scalar DL Ledger environment with Auditor configuration.  
-Please refer to the `Step 1` ~ `Step 7` of [Getting Started with Helm Charts (Scalar DL Ledger)](./getting-started-scalardl-ledger.md) to create a Ledger environment.  
-To enable Auditor configuration in the Scalar DL Ledger, set `true` to `ledger.scalarLedgerConfiguration.ledgerAuditorEnabled` in `Step 7` of the above guide.  
+First, you need to prepare a Kubernetes cluster. If you use a **minikube** environment, please refer to the [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md). If you have already started a Kubernetes cluster, you can skip this step.
 
-After this step, we will create (add) a Scalar DL Auditor environment into the above Scalar DL Ledger environment.  
-Also, after this step, we call `Scalar DL Ledger` as `Ledger` and `Scalar DL Auditor` as `Auditor`.  
+## Step 2. Start PostgreSQL containers
 
-## Step 2. Start Cassandra container for Auditor
+ScalarDL Ledger and Auditor use some kind of database system as a backend database. In this document, we use PostgreSQL.
 
-We use Apache Cassandra as the backend storage of the Auditor. We start a Cassandra container on the same network of Kubernetes (Auditor Pod on minikube) to make them communicate properly.
+You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
-1. Start a Cassandra container for Auditor on the Docker Network `minikube`.
+1. Add the Bitnami helm repository.
    ```console
-   docker run --name cassandra-auditor --network minikube -d cassandra:3.11
+   helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
-   * Note: 
-       * The Docker Network `minikube` was created by the `minikube start --driver=docker` command that we ran in Step 1.
-       * Scalar DL uses Scalar DB in its internal. You need to specify the Scalar DB-supported Cassandra version (tag).
-           * You can see the Scalar DB version of Scalar DL from the [build.gradle](https://github.com/scalar-labs/scalar/blob/master/build.gradle) file (see the value of `scalarDbVersion`).
-           * Also, you can see the Scalar DB-supported Cassandra versions (tag) in [this document](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
-1. Check if the Cassandra container is running.
+1. Deploy PostgreSQL for Ledger.
    ```console
-   docker ps -f name=cassandra-auditor
+   helm install postgresql-ledger bitnami/postgresql \
+     --set auth.postgresPassword=postgres \
+     --set primary.persistence.enabled=false
+   ```
+
+1. Deploy PostgreSQL for Auditor.
+   ```console
+   helm install postgresql-auditor bitnami/postgresql \
+     --set auth.postgresPassword=postgres \
+     --set primary.persistence.enabled=false
+   ```
+
+1. Check if the PostgreSQL containers are running.
+   ```console
+   kubectl get pod
    ```
    [Command execution result]
    ```console
-   CONTAINER ID   IMAGE            COMMAND                  CREATED          STATUS          PORTS                                         NAMES
-   2a1d2770bf72   cassandra:3.11   "docker-entrypoint.s…"   6 seconds ago    Up 4 seconds    7000-7001/tcp, 7199/tcp, 9042/tcp, 9160/tcp   cassandra-auditor
+   NAME                   READY   STATUS    RESTARTS   AGE
+   postgresql-auditor-0   1/1     Running   0          11s
+   postgresql-ledger-0    1/1     Running   0          16s
    ```
 
-1. Check the status of Cassandra.
+## Step 3. Create a working directory
+
+We will create some configuration files and key/certificate files locally. So, create a working directory for them.
+
+1. Create a working directory.
    ```console
-   docker exec -t cassandra-auditor cqlsh -e "show version"
+   mkdir -p ~/scalardl-test/certs/
    ```
-   [Command execution result]
-   ```console
-   [cqlsh 5.0.1 | Cassandra 3.11.11 | CQL spec 3.4.4 | Native protocol v4]
-   ```
-   It may take a while to start Cassandra in the container. So, if this command returns an error, wait a moment and then re-run it.
 
-## Step 3. Create key/certificate files for Auditor
+## Step 4. Create key/certificate files
 
-* Note: 
-    * In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
-    * We assume that you already made a working directory and create key/certificate files for Ledger and Client in the [Getting Started with Helm Charts (Scalar DL Ledger)](./getting-started-scalardl-ledger.md).
+Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
-1. Change working directory to `certs/`.
+1. Change the working directory to `~/scalardl-test/certs/` directory.
    ```console
    cd ~/scalardl-test/certs/
+   ```
+
+1. Create a JSON file that includes Ledger information.
+   ```console
+   cat << EOF > ~/scalardl-test/certs/ledger.json
+   {
+       "CN": "ledger",
+       "hosts": ["example.com","*.example.com"],
+       "key": {
+           "algo": "ecdsa",
+           "size": 256
+       },
+       "names": [
+           {
+               "O": "ledger",
+               "OU": "test team",
+               "L": "Shinjuku",
+               "ST": "Tokyo",
+               "C": "JP"
+           }
+       ]
+   }
+   EOF
    ```
 
 1. Create a JSON file that includes Auditor information.
@@ -107,9 +165,42 @@ We use Apache Cassandra as the backend storage of the Auditor. We start a Cassan
    EOF
    ```
 
+1. Create a JSON file that includes Client information.
+   ```console
+   cat << EOF > ~/scalardl-test/certs/client.json
+   {
+       "CN": "client",
+       "hosts": ["example.com","*.example.com"],
+       "key": {
+           "algo": "ecdsa",
+           "size": 256
+       },
+       "names": [
+           {
+               "O": "client",
+               "OU": "test team",
+               "L": "Shinjuku",
+               "ST": "Tokyo",
+               "C": "JP"
+           }
+       ]
+   }
+   EOF
+   ```
+
+1. Create key/certificate files for the Ledger.
+   ```console
+   cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
+   ```
+
 1. Create key/certificate files for the Auditor.
    ```console
    cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
+   ```
+
+1. Create key/certificate files for the Client.
+   ```console
+   cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
@@ -132,200 +223,466 @@ We use Apache Cassandra as the backend storage of the Auditor. We start a Cassan
    ledger.pem
    ```
 
-## Step 4. Create DB schema for Auditor by Helm Charts
+# Step 5. Create DB schemas for ScalarDL Ledger using Helm Charts
 
-We will deploy a Scalar DL Schema Loader on minikube by using Helm Charts.  
-The Scalar DL Schema Loader will create the DB schema in the Cassandra for Auditor.  
+We will deploy two ScalarDL Schema Loader pods on the Kubernetes cluster using Helm Charts.  
+The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Auditor in PostgreSQL.  
 
-1. Change working directory from `certs/`.
+1. Change the working directory to `~/scalardl-test/`.
    ```console
    cd ~/scalardl-test/
    ```
 
-1. Create a custom value file for Scalar DL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
+1. Add the Scalar helm repository.
    ```console
-   cat << EOF > schema-loader-auditor-custom-values.yaml
-   schemaLoading:
-     database: "cassandra"
-     contactPoints: "cassandra-auditor"
-     username: "cassandra"
-     password: "cassandra"
-     schemaType: "auditor"
-   EOF
+   helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
-1. Deploy the Scalar DL Schema Loader for Auditor.
+1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
+   * AWS Marketplace
+     ```console
+     kubectl create secret docker-registry reg-ecr-mp-secrets \
+       --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
+       --docker-username=AWS \
+       --docker-password=$(aws ecr get-login-password --region us-east-1)
+     ```
+   * Azure Marketplace
+     ```console
+     kubectl create secret docker-registry reg-acr-secrets \
+       --docker-server=<your private container registry login server> \
+       --docker-username=<Service principal ID> \
+       --docker-password=<Service principal password>
+     ```
+
+   Please refer to the following documents for more details.
+   
+   * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
+   * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
+
+1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
+   * AWS Marketplace
+     ```console
+     cat << EOF > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
+     schemaLoading:
+       schemaType: "ledger"
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
+         version: "3.6.0"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+       databaseProperties: |
+         scalar.db.contact_points=jdbc:postgresql://postgresql-ledger.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DL_LEDGER_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DL_LEDGER_POSTGRES_PASSWORD "" }}
+         scalar.db.storage=jdbc
+       secretName: "ledger-credentials-secret"
+     EOF
+     ```
+   * Azure Marketplace
+     ```console
+     cat << EOF > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
+     schemaLoading:
+       schemaType: "ledger"
+       image:
+         repository: "<your private container registry>/scalarinc/scalardl-schema-loader"
+         version: "3.6.0"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+       databaseProperties: |
+         scalar.db.contact_points=jdbc:postgresql://postgresql-ledger.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DL_LEDGER_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DL_LEDGER_POSTGRES_PASSWORD "" }}
+         scalar.db.storage=jdbc
+       secretName: "ledger-credentials-secret"
+     EOF
+     ```
+
+1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
+   * AWS Marketplace
+     ```console
+     cat << EOF > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
+     schemaLoading:
+       schemaType: "auditor"
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-auditor"
+         version: "3.6.0"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+       databaseProperties: |
+         scalar.db.contact_points=jdbc:postgresql://postgresql-auditor.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DL_AUDITOR_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DL_AUDITOR_POSTGRES_PASSWORD "" }}
+         scalar.db.storage=jdbc
+       secretName: "auditor-credentials-secret"
+     EOF
+     ```
+   * Azure Marketplace
+     ```console
+     cat << EOF > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
+     schemaLoading:
+       schemaType: "auditor"
+       image:
+         repository: "<your private container registry>/scalarinc/scalardl-schema-loader"
+         version: "3.6.0"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+       databaseProperties: |
+         scalar.db.contact_points=jdbc:postgresql://postgresql-auditor.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DL_AUDITOR_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DL_AUDITOR_POSTGRES_PASSWORD "" }}
+         scalar.db.storage=jdbc
+       secretName: "auditor-credentials-secret"
+     EOF
+     ```
+
+1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
+   ```console
+   kubectl create secret generic ledger-credentials-secret \
+     --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
+     --from-literal=SCALAR_DL_LEDGER_POSTGRES_PASSWORD=postgres
+   ```
+
+1. Create a secret resource that includes a username and password for PostgreSQL for Auditor.
+   ```console
+   kubectl create secret generic auditor-credentials-secret \
+     --from-literal=SCALAR_DL_AUDITOR_POSTGRES_USERNAME=postgres \
+     --from-literal=SCALAR_DL_AUDITOR_POSTGRES_PASSWORD=postgres
+   ```
+
+1. Deploy the ScalarDL Schema Loader for Ledger.
+   ```console
+   helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
+   ```
+
+1. Deploy the ScalarDL Schema Loader for Auditor.
    ```console
    helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
-1. Check if the Scalar DL Schema Loader pod is deployed and completed.
-   ```console
-   kubectl get pod | grep schema-loader-auditor
-   ```
-   [Command execution result]
-   ```console
-   schema-loader-auditor-schema-loading-9v5m7   0/1     Completed   0          10m
-   ```
-   If the Scalar DL Schema Loader pod (schema-loader-auditor-schema-loading-xxxxx) is `ContainerCreating` or `Running`, wait for the process will be completed (The STATUS will be `Completed`).
-
-## Step 5. Deploy Auditor on the Kubernetes (minikube) using Helm Charts
-
-1. Create a custom value file for Auditor (scalardl-auditor-custom-values.yaml).
-   ```console
-   cat << EOF > scalardl-auditor-custom-values.yaml
-   envoy:
-     service:
-       type: "NodePort"
-   
-   auditor:
-     scalarAuditorConfiguration:
-       dbStorage: "cassandra"
-       dbContactPoints: "cassandra-auditor"
-       dbUsername: "cassandra"
-       dbPassword: "cassandra"
-       auditorLedgerHost: "scalardl-ledger-envoy"
-   EOF
-   ```
-   * Note:
-       * If you want to access Auditor from 127.0.0.1 (your localhost), set `LoadBalancer` to `envoy.service.type` like the following.
-         ```console
-         cat << EOF > scalardl-auditor-custom-values.yaml
-         envoy:
-           service:
-             type: "LoadBalancer"
-         
-         auditor:
-           scalarAuditorConfiguration:
-             dbStorage: "cassandra"
-             dbContactPoints: "cassandra-auditor"
-             dbUsername: "cassandra"
-             dbPassword: "cassandra"
-             auditorLedgerHost: "scalardl-ledger-envoy"
-         EOF
-         ```
-
-1. Create secret resource `auditor-keys`.
-   ```console
-   kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
-   ```
-
-1. Deploy the Auditor.
-   ```console
-   helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
-   ```
-
-1. Check if the Auditor pods are deployed.
+1. Check if the ScalarDL Schema Loader pods are deployed and completed.
    ```console
    kubectl get pod
    ```
    [Command execution result]
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
-   scalardl-auditor-auditor-99b94bb75-7fjmb     1/1     Running     0          3m1s
-   scalardl-auditor-auditor-99b94bb75-jbp7c     1/1     Running     0          3m1s
-   scalardl-auditor-auditor-99b94bb75-trq66     1/1     Running     0          3m1s
-   scalardl-auditor-envoy-55bfcbb76b-4bkdp      1/1     Running     0          3m1s
-   scalardl-auditor-envoy-55bfcbb76b-552hd      1/1     Running     0          3m1s
-   scalardl-auditor-envoy-55bfcbb76b-cqx98      1/1     Running     0          3m1s
-   scalardl-ledger-envoy-84dcc85b6d-jzkjr       1/1     Running     0          18m
-   scalardl-ledger-envoy-84dcc85b6d-l4r66       1/1     Running     0          18m
-   scalardl-ledger-envoy-84dcc85b6d-nz25m       1/1     Running     0          18m
-   scalardl-ledger-ledger-6dbc56c7b5-nsmxv      1/1     Running     0          18m
-   scalardl-ledger-ledger-6dbc56c7b5-rxnjz      1/1     Running     0          18m
-   scalardl-ledger-ledger-6dbc56c7b5-szqc2      1/1     Running     0          18m
-   schema-loader-auditor-schema-loading-9v5m7   0/1     Completed   0          15m
-   schema-loader-ledger-schema-loading-dgksb    0/1     Completed   0          19m
+   postgresql-auditor-0                         1/1     Running     0          2m56s
+   postgresql-ledger-0                          1/1     Running     0          3m1s
+   schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          6s
+   schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          10s
    ```
-   If the Auditor pods are deployed properly, you can see the STATUS are `Running`.  
+   If the ScalarDL Schema Loader pods are **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
-1. Check if the Auditor Services are deployed.
+## Step 6. Deploy ScalarDL Ledger and Auditor on the Kubernetes cluster using Helm Charts
+
+1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
+   * AWS Marketplace
+     ```console
+     cat << EOF > ~/scalardl-test/scalardl-ledger-custom-values.yaml
+     envoy:
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger-envoy"
+         version: "1.3.0"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+     
+     ledger:
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
+         version: "3.6.0"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+       ledgerProperties: |
+         scalar.db.contact_points=jdbc:postgresql://postgresql-ledger.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DL_LEDGER_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DL_LEDGER_POSTGRES_PASSWORD "" }}
+         scalar.db.storage=jdbc
+         scalar.dl.ledger.proof.enabled=true
+         scalar.dl.ledger.auditor.enabled=true
+         scalar.dl.ledger.proof.private_key_path=/keys/private-key
+       secretName: "ledger-credentials-secret"
+       extraVolumes:
+         - name: "ledger-keys"
+           secret:
+             secretName: "ledger-keys"
+       extraVolumeMounts:
+         - name: "ledger-keys"
+           mountPath: "/keys"
+           readOnly: true
+     EOF
+     ```
+   * Azure Marketplace
+     ```console
+     cat << EOF > ~/scalardl-test/scalardl-ledger-custom-values.yaml
+     envoy:
+       image:
+         repository: "<your private container registry>/scalarinc/scalardl-envoy"
+         version: "1.3.0"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+     
+     ledger:
+       image:
+         repository: "<your private container registry>/scalarinc/scalar-ledger"
+         version: "3.6.0"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+       ledgerProperties: |
+         scalar.db.contact_points=jdbc:postgresql://postgresql-ledger.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DL_LEDGER_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DL_LEDGER_POSTGRES_PASSWORD "" }}
+         scalar.db.storage=jdbc
+         scalar.dl.ledger.proof.enabled=true
+         scalar.dl.ledger.proof.private_key_path=/keys/private-key
+       secretName: "ledger-credentials-secret"
+       extraVolumes:
+         - name: "ledger-keys"
+           secret:
+             secretName: "ledger-keys"
+       extraVolumeMounts:
+         - name: "ledger-keys"
+           mountPath: "/keys"
+           readOnly: true
+     EOF
+     ```
+
+1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
+   * AWS Marketplace
+     ```console
+     cat << EOF > ~/scalardl-test/scalardl-auditor-custom-values.yaml
+     envoy:
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor-envoy"
+         version: "1.3.0"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+     
+     auditor:
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
+         version: "3.6.0"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+       auditorProperties: |
+         scalar.db.contact_points=jdbc:postgresql://postgresql-auditor.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DL_AUDITOR_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DL_AUDITOR_POSTGRES_PASSWORD "" }}
+         scalar.db.storage=jdbc
+         scalar.dl.auditor.ledger.host=scalardl-ledger-envoy.default.svc.cluster.local
+         scalar.dl.auditor.cert_path=/keys/certificate
+         scalar.dl.auditor.private_key_path=/keys/private-key
+       secretName: "auditor-credentials-secret"
+       extraVolumes:
+         - name: "auditor-keys"
+           secret:
+             secretName: "auditor-keys"
+       extraVolumeMounts:
+         - name: "auditor-keys"
+           mountPath: "/keys"
+           readOnly: true
+     EOF
+     ```
+   * Azure Marketplace
+     ```console
+     cat << EOF > ~/scalardl-test/scalardl-auditor-custom-values.yaml
+     envoy:
+       image:
+         repository: "<your private container registry>/scalarinc/scalardl-envoy"
+         version: "1.3.0"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+     
+     auditor:
+       image:
+         repository: "<your private container registry>/scalarinc/scalar-auditor"
+         version: "3.6.0"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+       auditorProperties: |
+         scalar.db.contact_points=jdbc:postgresql://postgresql-auditor.default.svc.cluster.local:5432/postgres
+         scalar.db.username={{ default .Env.SCALAR_DL_AUDITOR_POSTGRES_USERNAME "" }}
+         scalar.db.password={{ default .Env.SCALAR_DL_AUDITOR_POSTGRES_PASSWORD "" }}
+         scalar.db.storage=jdbc
+         scalar.dl.auditor.ledger.host=scalardl-ledger-envoy.default.svc.cluster.local
+         scalar.dl.auditor.cert_path=/keys/certificate
+         scalar.dl.auditor.private_key_path=/keys/private-key
+       secretName: "auditor-credentials-secret"
+       extraVolumes:
+         - name: "auditor-keys"
+           secret:
+             secretName: "auditor-keys"
+       extraVolumeMounts:
+         - name: "auditor-keys"
+           mountPath: "/keys"
+           readOnly: true
+     EOF
+     ```
+
+1. Create secret resource `ledger-keys`.
+   ```console
+   kubectl create secret generic ledger-keys --from-file=certificate=./certs/ledger.pem --from-file=private-key=./certs/ledger-key.pem
+   ```
+
+1. Create secret resource `auditor-keys`.
+   ```console
+   kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
+   ```
+
+1. Deploy the ScalarDL Ledger.
+   ```console
+   helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
+   ```
+
+1. Deploy the ScalarDL Auditor.
+   ```console
+   helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
+   ```
+
+1. Check if the ScalarDL Ledger and Auditor pods are deployed.
+   ```console
+   kubectl get pod
+   ```
+   [Command execution result]
+   ```console
+   NAME                                         READY   STATUS      RESTARTS   AGE
+   postgresql-auditor-0                         1/1     Running     0          14m
+   postgresql-ledger-0                          1/1     Running     0          14m
+   scalardl-auditor-auditor-5b885ff4c8-fwkpf    1/1     Running     0          18s
+   scalardl-auditor-auditor-5b885ff4c8-g69cb    1/1     Running     0          18s
+   scalardl-auditor-auditor-5b885ff4c8-nsmnq    1/1     Running     0          18s
+   scalardl-auditor-envoy-689bcbdf65-5mn6v      1/1     Running     0          18s
+   scalardl-auditor-envoy-689bcbdf65-fpq8j      1/1     Running     0          18s
+   scalardl-auditor-envoy-689bcbdf65-lsz2t      1/1     Running     0          18s
+   scalardl-ledger-envoy-547bbf7546-n7p5x       1/1     Running     0          26s
+   scalardl-ledger-envoy-547bbf7546-p8nwp       1/1     Running     0          26s
+   scalardl-ledger-envoy-547bbf7546-pskpb       1/1     Running     0          26s
+   scalardl-ledger-ledger-6db5dc8774-5zsbj      1/1     Running     0          26s
+   scalardl-ledger-ledger-6db5dc8774-vnmrw      1/1     Running     0          26s
+   scalardl-ledger-ledger-6db5dc8774-wpjvs      1/1     Running     0          26s
+   schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          11m
+   schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          11m
+   ```
+   If the ScalarDL Ledger and Auditor pods are deployed properly, you can see the STATUS are **Running**.  
+
+1. Check if the ScalarDL Ledger and Auditor services are deployed.
    ```console
    kubectl get svc
    ```
    [Command execution result]
    ```console
-   NAME                             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
-   kubernetes                       ClusterIP   10.96.0.1       <none>        443/TCP                           25m
-   scalardl-auditor-envoy           NodePort    10.101.34.229   <none>        40051:30140/TCP,40052:30599/TCP   3m32s
-   scalardl-auditor-envoy-metrics   ClusterIP   10.97.47.11     <none>        9001/TCP                          3m32s
-   scalardl-auditor-headless        ClusterIP   None            <none>        50051/TCP,50053/TCP,50052/TCP     3m32s
-   scalardl-auditor-metrics         ClusterIP   10.103.88.93    <none>        8080/TCP                          3m32s
-   scalardl-ledger-envoy            NodePort    10.97.160.80    <none>        50051:32468/TCP,50052:30626/TCP   19m
-   scalardl-ledger-envoy-metrics    ClusterIP   10.97.83.78     <none>        9001/TCP                          19m
-   scalardl-ledger-headless         ClusterIP   None            <none>        50051/TCP,50053/TCP,50052/TCP     19m
-   scalardl-ledger-metrics          ClusterIP   10.111.170.92   <none>        8080/TCP                          19m
+   NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
+   kubernetes                       ClusterIP   10.96.0.1        <none>        443/TCP                         47d
+   postgresql-auditor               ClusterIP   10.107.9.78      <none>        5432/TCP                        15m
+   postgresql-auditor-hl            ClusterIP   None             <none>        5432/TCP                        15m
+   postgresql-ledger                ClusterIP   10.108.241.181   <none>        5432/TCP                        15m
+   postgresql-ledger-hl             ClusterIP   None             <none>        5432/TCP                        15m
+   scalardl-auditor-envoy           ClusterIP   10.100.61.202    <none>        40051/TCP,40052/TCP             55s
+   scalardl-auditor-envoy-metrics   ClusterIP   10.99.6.227      <none>        9001/TCP                        55s
+   scalardl-auditor-headless        ClusterIP   None             <none>        40051/TCP,40053/TCP,40052/TCP   55s
+   scalardl-auditor-metrics         ClusterIP   10.108.1.147     <none>        8080/TCP                        55s
+   scalardl-ledger-envoy            ClusterIP   10.101.191.116   <none>        50051/TCP,50052/TCP             61s
+   scalardl-ledger-envoy-metrics    ClusterIP   10.106.52.103    <none>        9001/TCP                        61s
+   scalardl-ledger-headless         ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   61s
+   scalardl-ledger-metrics          ClusterIP   10.99.122.106    <none>        8080/TCP                        61s
    ```
-   If the Auditor Services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-auditor-headless` has no CLUSTER-IP.)  
+   If the ScalarDL Ledger and Auditor services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` and `scalardl-auditor-headless` have no CLUSTER-IP.)  
 
-1. (Optional) If you set `LoadBalancer` to `envoy.service.type` in the `scalardl-auditor-custom-values.yaml`, you can access Auditor from 127.0.0.1.  
-   To expose the `scalardl-auditor-envoy` service as your local `127.0.0.1:40051` and `127.0.0.1:40052`, open another terminal, and run the `minikube tunnel` command.
-   ```console
-   minikube tunnel
+## Step 7. Start a Client container
+
+We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
+
+1. Create secret resource `client-keys`.
    ```
-   After running the `minikube tunnel` command, you can see the  EXTERNAL-IP of the `scalardl-auditor-envoy` as  `127.0.0.1`.
-   ```console
-   kubectl get svc scalardl-auditor-envoy
-   ```
-   [Command execution result]
-   ```console
-   NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
-   scalardl-auditor-envoy   LoadBalancer   10.101.34.229   127.0.0.1     40051:30140/TCP,40052:30599/TCP   5m28s
+   kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
-## Step 6. Start Client container
-
-We will use certificate files in the Client container. So, we mount ~/scalardl-test/certs directory to the Client container.  
-
-1. Start a Client container on the `minikube` network.
+1. Start a Client container on the Kubernetes cluster.
    ```console
-   docker run -d --name scalardl-client --hostname scalardl-client -v ~/scalardl-test/certs:/certs --network minikube --entrypoint sleep ubuntu:20.04 inf
+   cat << EOF | kubectl apply -f -
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: "scalardl-client"
+   spec:
+     containers:
+       - name: scalardl-client
+         image: eclipse-temurin:8
+         command: ['sleep']
+         args: ['inf']
+         volumeMounts:
+           - name: "ledger-keys"
+             mountPath: "/keys/ledger"
+             readOnly: true
+           - name: "auditor-keys"
+             mountPath: "/keys/auditor"
+             readOnly: true
+           - name: "client-keys"
+             mountPath: "/keys/client"
+             readOnly: true
+     volumes:
+       - name: "ledger-keys"
+         secret:
+           secretName: "ledger-keys"
+       - name: "auditor-keys"
+         secret:
+           secretName: "auditor-keys"
+       - name: "client-keys"
+         secret:
+           secretName: "client-keys"
+     restartPolicy: Never 
+   EOF
    ```
 
 1. Check if the Client container is running.
    ```console
-   docker ps -f name=scalardl-client
+   kubectl get pod scalardl-client
+   ```
+   [Command execution result]
+   ```console
+   NAME              READY   STATUS    RESTARTS   AGE
+   scalardl-client   1/1     Running   0          4s
    ```
 
-## Step 7. Run Scalar DL sample contracts in the Client container
+## Step 8. Run ScalarDL sample contracts in the Client container
 
-* Note: 
-   * When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application.  
-   * The Ledger needs to register its certificate to Auditor, and the Auditor needs to register its certificate to Ledger.
+The following explains the minimum steps. If you want to know more details about ScalarDL Ledger and Auditor, please refer to the following documents.
+   * [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md)
+   * [Getting Started with ScalarDL Auditor](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started-auditor.md)
 
-The following explains the minimum steps. If you want to know more details about Scalar DL and the contract, please refer to the [Getting Started with Scalar DL Auditor](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started-auditor.md).
+When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application. Ledger needs to register its certificate to Auditor, and Auditor needs to register its certificate to Ledger.
 
 1. Run bash in the Client container.
    ```console
-   docker exec -it scalardl-client bash
+   kubectl exec -it scalardl-client -- bash
    ```
    After this step, run each command in the Client container.  
 
-1. Install Git, OpenJDK 8, curl, and unzip in the Client container.
+1. Install the git, curl and unzip commands in the Client container.
    ```console
-   apt update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt install -y git openjdk-8-jdk curl unzip
+   apt update && apt install -y git curl unzip
    ```
 
-1. Clone Scalar DL Java Client SDK git repository.
+1. Clone ScalarDL Java Client SDK git repository.
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
-1. Change directory to `scalardl-java-client-sdk/`.
+1. Change the directory to `scalardl-java-client-sdk/`.
    ```console
-   cd scalardl-java-client-sdk/ 
+   cd scalardl-java-client-sdk/
    ```
    ```console
    pwd
    ```
    [Command execution result]
    ```console
+
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
    ```console
-   git checkout -b v3.4.0 refs/tags/v3.4.0
+   git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
    ```console
    git branch
@@ -333,250 +690,195 @@ The following explains the minimum steps. If you want to know more details about
    [Command execution result]
    ```console
      master
-   * v3.4.0
+   * v3.6.0
    ```
-   If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of Scalar DL (Ledger and Auditor) and Scalar DL Java Client SDK.
+   If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
-1. Build the sample contract.
+1. Build the sample contracts.
    ```console
    ./gradlew assemble
    ```
 
-1. Download CLI tools of Scalar DL from [Scalar DL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
    ```console
-   curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.4.0/scalardl-java-client-sdk-3.4.0.zip
+   curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
-   You need to use the same version of CLI tools and Scalar DL (Ledger and Auditor).
+   You need to use the same version of CLI tools and ScalarDL Ledger.
 
-1. Unzip the scalardl-java-client-sdk-3.4.0.zip file.
+1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
    ```console
-   unzip ./scalardl-java-client-sdk-3.4.0.zip
+   unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
    ```console
    cat << EOF > ledger.as.client.properties
    # Ledger
-   scalar.dl.client.server.host=minikube
-   scalar.dl.client.server.port=32468
-   scalar.dl.client.server.privileged_port=30626
+   scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
    
    # Auditor
    scalar.dl.client.auditor.enabled=true
-   scalar.dl.client.auditor.host=minikube
-   scalar.dl.client.auditor.port=30140
-   scalar.dl.client.auditor.privileged_port=30599
+   scalar.dl.client.auditor.host=scalardl-auditor-envoy.default.svc.cluster.local
    
    # Certificate
    scalar.dl.client.cert_holder_id=ledger
-   scalar.dl.client.cert_path=../certs/ledger.pem
-   scalar.dl.client.private_key_path=../certs/ledger-key.pem
+   scalar.dl.client.cert_path=/keys/ledger/certificate
+   scalar.dl.client.private_key_path=/keys/ledger/private-key
    EOF
    ```
-   * Note:
-       * You need to specify the port number (NodePort) of `scalardl-ledger-envoy` (Kubernetes Service Resource) as a value of `scalar.dl.client.server.port` and `scalar.dl.client.server.privileged_port` in each `*.properties`. You can confirm the port number of `scalardl-ledger-envoy` with the `kubectl get svc scalardl-ledger-envoy` command.
-         ```console
-         kubectl get svc scalardl-ledger-envoy
-         ```
-         [Command execution result]
-         ```console
-         NAME                    TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)                           AGE
-         scalardl-ledger-envoy   NodePort   10.97.160.80   <none>        50051:32468/TCP,50052:30626/TCP   30m
-         ```
-         In this case, you need to specify `32468` to `scalar.dl.client.server.port` and `30626` to `scalar.dl.client.server.privileged_port` in the `*.properties` file.
-       * Also, you need to specify the port number (NodePort) of `scalardl-auditor-envoy` (Kubernetes Service Resource) as a value of `scalar.dl.client.auditor.port` and `scalar.dl.client.auditor.privileged_port` in each `*.properties`. You can confirm the port number of `scalardl-auditor-envoy` with the `kubectl get svc scalardl-auditor-envoy` command.
-         ```console
-         kubectl get svc scalardl-auditor-envoy
-         ```
-         [Command execution result]
-         ```console
-         NAME                     TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
-         scalardl-auditor-envoy   NodePort   10.101.34.229   <none>        40051:30140/TCP,40052:30599/TCP   15m
-         ```
-         In this case, you need to specify `30140` to `scalar.dl.client.auditor.port` and `30599` to `scalar.dl.client.auditor.privileged_port` in the `*.properties` file.
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
    ```console
    cat << EOF > auditor.as.client.properties
    # Ledger
-   scalar.dl.client.server.host=minikube
-   scalar.dl.client.server.port=32468
-   scalar.dl.client.server.privileged_port=30626
+   scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
    
    # Auditor
    scalar.dl.client.auditor.enabled=true
-   scalar.dl.client.auditor.host=minikube
-   scalar.dl.client.auditor.port=30140
-   scalar.dl.client.auditor.privileged_port=30599
+   scalar.dl.client.auditor.host=scalardl-auditor-envoy.default.svc.cluster.local
    
    # Certificate
    scalar.dl.client.cert_holder_id=auditor
-   scalar.dl.client.cert_path=../certs/auditor.pem
-   scalar.dl.client.private_key_path=../certs/auditor-key.pem
+   scalar.dl.client.cert_path=/keys/auditor/certificate
+   scalar.dl.client.private_key_path=/keys/auditor/private-key
    EOF
    ```
 
-1. Create a configuration file (client.properties) to access Scalar DL (Ledger and Auditor) on minikube.
+1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
    ```console
    cat << EOF > client.properties
    # Ledger
-   scalar.dl.client.server.host=minikube
-   scalar.dl.client.server.port=32468
-   scalar.dl.client.server.privileged_port=30626
+   scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
    
    # Auditor
    scalar.dl.client.auditor.enabled=true
-   scalar.dl.client.auditor.host=minikube
-   scalar.dl.client.auditor.port=30140
-   scalar.dl.client.auditor.privileged_port=30599
+   scalar.dl.client.auditor.host=scalardl-auditor-envoy.default.svc.cluster.local
    
    # Certificate
    scalar.dl.client.cert_holder_id=client
-   scalar.dl.client.cert_path=../certs/client.pem
-   scalar.dl.client.private_key_path=../certs/client-key.pem
+   scalar.dl.client.cert_path=/keys/client/certificate
+   scalar.dl.client.private_key_path=/keys/client/private-key
    EOF
    ```
 
 1. Register the certificate file of Ledger.
    ```console
-   ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./ledger.as.client.properties
+   ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
 1. Register the certificate file of Auditor.
    ```console
-   ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./auditor.as.client.properties
+   ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
 1. Register the certificate file of client.
    ```console
-   ./scalardl-java-client-sdk-3.4.0/bin/register-cert --properties ./client.properties
+   ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
    ```console
-   ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
+   ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
    ```console
-   ./scalardl-java-client-sdk-3.4.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
+   ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
+   ```
+
+1. Register the contract `ValdateLedger` to execute a validate request.
+   ```console
+   ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file ./build/classes/java/main/com/scalar/dl/client/contract/ValidateLedger.class
    ```
 
 1. Execute the contract `StateUpdater`.
    ```console
-   ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
+   ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
    ```console
-   ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
+   ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
+   ```
+   [Command execution result]
+   ```console
+   Contract result:
+   {
+     "id" : "test_asset",
+     "age" : 0,
+     "output" : {
+       "state" : 3
+     }
+   }
+   ```
+   * Reference information
+      * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
+      * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.  
+        [Command execution result (If the asset data is tampered with)]
+        ```console
+        {
+          "status_code" : "INCONSISTENT_STATES",
+          "error_message" : "The results from Ledger and Auditor don't match"
+        }
+        ```
+          * In this way, the ScalarDL can detect data tampering.
+
+1. Execute a validation request for the asset.
+   ```console
+   ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
    [Command execution result]
    ```console
    {
-       "status_code": "OK",
-       "output": {
-           "age": 0,
-           "input": {
-           },
-           "output": {
-               "state": 3
-           },
-           "contract_id": "client/1/StateUpdater",
-           "argument": {
-               "asset_id": "test_asset",
-               "state": 3,
-               "nonce": "ef041eb4-f9c3-455a-9dab-0f081a01d13b"
-           },
-           "signature": "MEUCIEzeQzX3poEfM6dlgmaLIMlMI0efnsYTfY25nru1DSeXAiEAiszgxFIO3Gv4yxBI6Sy/zph1pnnwQJRuGifio09fQOg=",
-           "hash": "zqm/vXPC8o5mL5YUaAPOrIYK/qBd3kXVjHXUH7rdjnE=",
-           "prev_hash": ""
-       },
-       "error_message": null
+     "status_code" : "OK",
+     "Ledger" : {
+       "id" : "test_asset",
+       "age" : 0,
+       "nonce" : "3533427d-03cf-41d1-bf95-4d31eb0cb24d",
+       "hash" : "FiquvtPMKLlxKf4VGoccSAGsi9ptn4ozYVVTwdSzEQ0=",
+       "signature" : "MEYCIQDiiXqzw6K+Ml4uvn8rK43o5wHWESU3hoXnZPi6/OeKVwIhAM+tFBcapl6zg47Uq0Uc8nVNGWNHZLBDBGve3F0xkzTR"
+     },
+     "Auditor" : {
+       "id" : "test_asset",
+       "age" : 0,
+       "nonce" : "3533427d-03cf-41d1-bf95-4d31eb0cb24d",
+       "hash" : "FiquvtPMKLlxKf4VGoccSAGsi9ptn4ozYVVTwdSzEQ0=",
+       "signature" : "MEUCIQDLsfUR2PmxSvfpL3YvHJUkz00RDpjCdctkroZKXE8d5QIgH73FQH2e11jfnynD00Pp9DrIG1vYizxDsvxUsMPo9IU="
+     }
    }
    ```
    * Reference information
-       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
-       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.
-         ```console
-         ./scalardl-java-client-sdk-3.4.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
-         ```
-         [Command execution result]
-         ```console
-         {
-             "status_code": "INCONSISTENT_STATES",
-             "output": null,
-             "error_message": "The results from Ledger and Auditor don't match"
-         }
-         ```
-           * In this way, the Scalar DL can detect data tampering.
+      * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
+      * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
+        [Command execution result (If the asset data is tampered with)]
+        ```console
+        {
+          "status_code" : "INCONSISTENT_STATES",
+          "error_message" : "The results from Ledger and Auditor don't match"
+        }
+        ```
+          * In this way, the ScalarDL Ledger can detect data tampering.
 
-1. Execute a validation request of the asset.
+## Step 9. Delete all resources
+
+After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
+
+1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
    ```console
-   ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
-   ```
-   [Command execution result]
-   ```console
-   {
-       "status_code": "OK",
-       "Ledger": {
-           "id": "test_asset",
-           "age": 0,
-           "nonce": "ef041eb4-f9c3-455a-9dab-0f081a01d13b",
-           "hash": "zqm/vXPC8o5mL5YUaAPOrIYK/qBd3kXVjHXUH7rdjnE=",
-           "signature": "MEQCIB0lHtURoLYSz0vSpV4BhYmYBqzeSrYekN/GdP+quBLtAiBeQWMeLDEdxzeIoAkD/Cbi3zbIDud8CjK6gN/IpQKW0Q=="
-       },
-       "Auditor": {
-           "id": "test_asset",
-           "age": 0,
-           "nonce": "ef041eb4-f9c3-455a-9dab-0f081a01d13b",
-           "hash": "zqm/vXPC8o5mL5YUaAPOrIYK/qBd3kXVjHXUH7rdjnE=",
-           "signature": "MEQCIBP312FoK5pX/eSzNiJ+zCJA5PVjlbFVmMYujEESy978AiATC19Fo6Y/YGWIFgDKdfIZhLAcUcHeyNloU1YQqJBy3Q=="
-       },
-       "error_message": null
-   }
-   ```
-   * Reference information
-       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
-       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.
-         ```console
-         ./scalardl-java-client-sdk-3.4.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
-         ```
-         [Command execution result]
-         ```console
-         {
-             "status_code": "INVALID_OUTPUT",
-             "output": null,
-             "error_message": "Validation failed."
-         }
-         ```
-           * In this way, the Scalar DL can detect data tampering.
-
-## Step 8. Delete all resources
-
-After completing the Scalar DL Auditor tests on minikube, remove all resources.
-
-1. Uninstall Scalar DL Schema Loader, Ledger, and Auditor from minikube.
-   ```console
-   helm uninstall schema-loader-ledger schema-loader-auditor scalardl-ledger scalardl-auditor
+   helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger scalardl-auditor schema-loader-auditor postgresql-auditor
    ```
 
-1. Stop and remove containers (Cassandra and Client).
+1. Remove the Client container.
    ```
-   docker rm $(docker kill scalardl-client cassandra-ledger cassandra-auditor)
+   kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
-1. Remove working directory and sample files (configuration file, key, and certificate).
+1. Remove the working directory and sample files (configuration file, key, and certificate).
    ```console
    cd ~
    ```
    ```console
    rm -rf ~/scalardl-test/
-   ```
-
-1. Delete minikube.
-   ```console
-   minikube delete --all
    ```
 

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -1,6 +1,6 @@
 # Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)
 
-This document explains how to get started with ScalarDL Ledger and Auditor using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
+This document explains how to get started with ScalarDL Ledger and Auditor using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.
 
 ## Requirement
 
@@ -25,9 +25,9 @@ Please refer to the following documents for more details.
 ## Note
 To make Byzantine fault detection with auditing work properly, Ledger and Auditor should be deployed and managed in different administrative domains. However, in this guide, we will deploy Ledger and Auditor in the same Kubernetes cluster to make the test easier.  
 
-## Environment
+## What we create
 
-We will create the following environment on a Kubernetes cluster.
+We will deploy the following components on a Kubernetes cluster as follows.
 
 ```
 +-----------------------------------------------------------------------------------------------------------------------------+

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -1,6 +1,6 @@
 # Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)
 
-This document explains how to get started with ScalarDL Ledger using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. And, we assume that you can use any Kubernetes cluster, but we use **Minikube** in this document.
+This document explains how to get started with ScalarDL Ledger using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.
 
 ## Requirement
 
@@ -18,9 +18,9 @@ Please refer to the following documents for more details.
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
-## Environment
+## What we create
 
-We will create the following environment on a Kubernetes cluster.
+We will deploy the following components on a Kubernetes cluster as follows.
 
 ```
 +--------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This PR updates the getting started guide of Scalar Helm Chart. The summary of updates is the following.

* Can work on any Kubernetes cluster
    * In the previous document, we need to use `minikube + docker` environment. However, these new documents can work on any Kubernetes cluster since all components (Scalar products, backend DB, and client) will be deployed on the Kubernetes cluster.
* Use Marketplace instead of GitHub Packages to pull the container images.
    * I added the description to get container images from AWS Marketplace or Azure Marketplace and the configuration file for each marketplace.
* Use `eclipse-temurin:8` as a client instead of `ubuntu:20.04`
    * If we use `ubuntu:20.04` as a client container, we need to install `openjdk-8-jdk`, but it takes a long time. Now, we use `eclipse-temurin:8` that includes JDK from the beginning. It can save time and make steps easier.
* Add description to access each web console if we use other Kubernetes cluster than minikube
    * If we use other Kubernetes cluster than minikube, we cannot use the `minikube tunnel` command. So, I added the description of the examples to expose ports (using a Load Balancer provided by cloud service or the `kubectl port-forward` command).
* Update sample commands based on the latest getting started of ScalarDB
    * I updated the steps to run the sample application of ScalarDB based on the following PR.
    * https://github.com/scalar-labs/scalardb/pull/617
* Update product name
    * Scalar DB -> ScalarDB
    * Scalar DL -> ScalarDL
* Add how to deploy Ledger in the Auditor documents
    * In the previous document, we need to refer to the two documents alternately (Ledger's document and Auditor's document) if we want to deploy ScalarDL Auditor. However, it was a bit confusing since there are some different things in the configuration of Ledger (scalar.dl.ledger.auditor.enabled=true) and operation to run sample contracts (we need to register certs of Ledger and Auditor) between Ledger only deployment and Auditor mode deployment. To make this document easier, I added the description how to deploy Ledger (with configuration for Auditor) in the Auditor's document. There are some redundant things, but I think it is easier for users since the operation is completed in a single document.
* Update product version
    * I updated the version in each step based on ScalarDB v3.7.0 and ScalarDL v3.6.0.
    * Also, I updated the command outputs of sample contracts based on the above version.

Please take a look!