### PR TITLE
Update environment variable name in ScalarDL Schema Loader chart

### DIFF
--- a/charts/schema-loading/templates/batchjob-schema-loading.yaml
+++ b/charts/schema-loading/templates/batchjob-schema-loading.yaml
@@ -22,11 +22,11 @@ spec:
         args:
         {{- if not .Values.schemaLoading.databaseProperties }}
         - "-p"
-        - "$(DB_PASSWORD)"
+        - "$(HELM_SCALAR_DB_PASSWORD)"
         {{- if eq .Values.schemaLoading.database "cassandra" }}
         - "--cassandra"
         - "-u"
-        - "$(DB_USERNAME)"
+        - "$(HELM_SCALAR_DB_USERNAME)"
         - "-h"
         - "{{ .Values.schemaLoading.contactPoints }}"
         - "-P"
@@ -46,13 +46,13 @@ spec:
         - "--region"
         - "{{ .Values.schemaLoading.contactPoints }}"
         - "-u"
-        - "$(DB_USERNAME)"
+        - "$(HELM_SCALAR_DB_USERNAME)"
         - "-r"
         - "{{ .Values.schemaLoading.dynamoBaseResourceUnit }}"
         {{- else if eq .Values.schemaLoading.database "jdbc"}}
         - "--jdbc"
         - "-u"
-        - "$(DB_USERNAME)"
+        - "$(HELM_SCALAR_DB_USERNAME)"
         - "-j"
         - "{{ .Values.schemaLoading.contactPoints }}"
         {{- end }}
@@ -69,7 +69,7 @@ spec:
         {{- end }}
         {{- end }}
         env:
-        - name: DB_USERNAME
+        - name: HELM_SCALAR_DB_USERNAME
           valueFrom:
             secretKeyRef:
             {{- if .Values.schemaLoading.existingSecret }}
@@ -78,7 +78,7 @@ spec:
               name: {{ include "schema-loading.fullname" . }}
             {{- end }}
               key: db-username
-        - name: DB_PASSWORD
+        - name: HELM_SCALAR_DB_PASSWORD
           valueFrom:
             secretKeyRef:
             {{- if .Values.schemaLoading.existingSecret }}


### PR DESCRIPTION
This PR fixes the environment variable names that are used in ScalarDL Schema Loader chart internally.

In the previous chart, there is no way to pass the arbitrary environment variable from `Secret` resource.
However, in the latest chart, users can pass arbitrary environment variables to pods using `Secret` resource.
As a result, there is a possibility that the `chart internal environment variable name` and `user-defined environment variable name` will conflict.
(Note: The internally used environment variables are necessary for keeping backward compatibility.)

So, we should add prefix `HELM_SCALAR_` to the internal environment variable to make the purpose of it clear.
Also, the following document has already described that users cannot use some environment variable names (e.g., `HELM_SCALAR_XXXX`).
https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-use-customized-configuration.md

We should updated these internal environment variables name when we add the new feature `schemaLoading.databaseProperties`.
The internal environment variable name in the other charts (scalardb, scalardl, scalardl-audit) were updated when I added the new feature `xxxxxxProperties`.
However, I forgot to update it when I added the new feature `xxxxxxProperties` in the ScalarDL Schema Loader chart...

Please take a look!