### PR TITLE
Update chart version to keep main branch latest (ScalarDB v3.7.2)

### DIFF
--- a/charts/scalardb/Chart.yaml
+++ b/charts/scalardb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardb
 description: Scalar DB server
 type: application
-version: 2.4.1
-appVersion: 3.7.1
+version: 2.4.2
+appVersion: 3.7.2
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -1,7 +1,7 @@
 # scalardb
 
 Scalar DB server
-Current chart version is `2.4.1`
+Current chart version is `2.4.2`
 
 ## Requirements
 
@@ -31,7 +31,7 @@ Current chart version is `2.4.1`
 | scalardb.grafanaDashboard.namespace | string | `"monitoring"` | Which namespace grafana dashboard is located. by default monitoring. |
 | scalardb.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | scalardb.image.repository | string | `"ghcr.io/scalar-labs/scalardb-server"` | Docker image reposiory of Scalar DB server. |
-| scalardb.image.tag | string | `"3.7.1"` | Docker tag of the image. |
+| scalardb.image.tag | string | `"3.7.2"` | Docker tag of the image. |
 | scalardb.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalardb.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalardb.podAnnotations | object | `{}` | Pod annotations for the scalardb deployment |

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -83,7 +83,7 @@ scalardb:
     # -- Specify a image pulling policy.
     pullPolicy: IfNotPresent
     # -- Docker tag of the image.
-    tag: 3.7.1
+    tag: 3.7.2
 
   # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: []


### PR DESCRIPTION
Sorry, I had a mistake in the following PR. So, the version of the ScalarDB chart in the main branch is not latest now. (The main branch includes the one previous patch version now.)
https://github.com/scalar-labs/helm-charts/pull/149

Therefore, I updated the version of the ScalarDB chart in the main branch to latest based on the following commit.
https://github.com/scalar-labs/helm-charts/commit/143003aa16f1b92bce614c6db6d81de66c07ac3d

Please take a look!