### PR TITLE
Add supported k8s version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ This directory contains the following helm charts.
 
 ## Supported Kubernetes versions
 
-* Kubernetes 1.25
-* Kubernetes 1.24
-* Kubernetes 1.23
-* Kubernetes 1.22
-* Kubernetes 1.21
+* 1.25.x, 1.24.x, 1.23.x, 1.22.x, 1.21.x
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,15 @@ This directory contains the following helm charts.
 
 ## Prerequisites
 
-* Kubernetes 1.19+
 * Helm 3.5+
+
+## Supported Kubernetes version
+
+* Kubernetes 1.25
+* Kubernetes 1.24
+* Kubernetes 1.23
+* Kubernetes 1.22
+* Kubernetes 1.21
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This directory contains the following helm charts.
 
 * Helm 3.5+
 
-## Supported Kubernetes version
+## Supported Kubernetes versions
 
 * Kubernetes 1.25
 * Kubernetes 1.24


### PR DESCRIPTION
This PR adds the description of the supported Kubernetes version.
It is decided according to the test result in the following PR.
https://github.com/scalar-labs/helm-charts/pull/155

Please take a look!