### PR TITLE
Update CI to run all charts testing manually

### DIFF
--- a/.github/ct-all.yaml
+++ b/.github/ct-all.yaml
@@ -1,0 +1,11 @@
+# consider helm install to be failed after 10 minutes
+helm-extra-args: --timeout 300s
+check-version-increment: false
+debug: true
+chart-dirs:
+  - charts
+validate-maintainers: false
+namespace: default
+release-label: test
+target-branch: main
+all: true

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -9,6 +9,7 @@ on:
       - main
     paths:
       - "charts/**"
+  workflow_dispatch:
 
 env:
   HELM_VERSION: v3.5.2
@@ -169,7 +170,7 @@ jobs:
         with:
           config: .github/kind-cluster.yaml
           node_image: kindest/node:${{ matrix.k8s }}
-        if: steps.list-changed.outputs.changed == 'true'
+        if: ${{ steps.list-changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch' }}
 
       - name: Setup kubernetes (Kind) with registry, cassandra and schema
         run: |
@@ -183,8 +184,13 @@ jobs:
           kubectl wait --for=condition=complete --timeout=60s job/schema-loading
           kubectl get pods,svc,endpoints,nodes -o wide
 
-      - name: Run chart-testing (install)
+      - name: Run chart-testing (updated chart)
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: ct install --config .github/ct.yaml
+
+      - name: Run chart-testing (all charts)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: ct install --config .github/ct-all.yaml
 
   verify-chart-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the CI to run the all charts testing.
In the current CI, it only checks the updated charts only.
In other words, if there is no updated chart, CI doesn't run chart testing (ct command).
So, we cannot test if we add new Kubernetes version since it only update Kubernetes version and any charts are not updated.

To run the all charts testing even if there is no updated chart, I add the `workflow_dispatch` condition.
We can run the all charts testing manually in any time.
So, we will able to test Scalar Helm Chart when the new Kubernetes version is added.

Please take a look!