### PR TITLE
Update chart version to keep main branch latest (ScalarDB GraphQL v3.7.3)

### DIFF
--- a/charts/scalardb-graphql/Chart.yaml
+++ b/charts/scalardb-graphql/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardb-graphql
 description: Scalar DB GraphQL server
 type: application
-version: 1.2.2
-appVersion: 3.7.2
+version: 1.2.3
+appVersion: 3.7.3
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
 - scalardb

--- a/charts/scalardb-graphql/README.md
+++ b/charts/scalardb-graphql/README.md
@@ -1,7 +1,7 @@
 # scalardb-graphql
 
 Scalar DB GraphQL server
-Current chart version is `1.2.2`
+Current chart version is `1.2.3`
 
 ## Values
 
@@ -14,7 +14,7 @@ Current chart version is `1.2.2`
 | grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | image.repository | string | `"ghcr.io/scalar-labs/scalardb-graphql"` | Docker image reposiory of Scalar DB GraphQL. |
-| image.tag | string | `"3.7.2"` | Docker tag of the image. |
+| image.tag | string | `"3.7.3"` | Docker tag of the image. |
 | imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ingress.annotations | object | `{"alb.ingress.kubernetes.io/healthcheck-path":"/graphql?query=%7B__typename%7D","alb.ingress.kubernetes.io/scheme":"internal","alb.ingress.kubernetes.io/target-group-attributes":"stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60","alb.ingress.kubernetes.io/target-type":"ip","nginx.ingress.kubernetes.io/affinity":"cookie","nginx.ingress.kubernetes.io/session-cookie-hash":"sha1","nginx.ingress.kubernetes.io/session-cookie-max-age":"300","nginx.ingress.kubernetes.io/session-cookie-name":"INGRESSCOOKIE","nginx.ingress.kubernetes.io/session-cookie-path":"/"}` | The class-specific annotations for the ingress resource. |
 | ingress.className | string | `""` | The ingress class name. Specify "alb" for AWS Application Load Balancer. |

--- a/charts/scalardb-graphql/values.yaml
+++ b/charts/scalardb-graphql/values.yaml
@@ -39,7 +39,7 @@ image:
   # -- Specify a image pulling policy.
   pullPolicy: IfNotPresent
   # -- Docker tag of the image.
-  tag: 3.7.2
+  tag: 3.7.3
 
 # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
 imagePullSecrets: [name: reg-docker-secrets]


### PR DESCRIPTION
A new patch version of ScalarDB GraphQL Helm Charts has been released.
This PR updates the version of the ScalarDB GraphQL chart to keep the main branch latest.
(This release flow will be fixed in the future.)

This PR applies the same update as the following commit.
https://github.com/scalar-labs/helm-charts/commit/9d4f4521e0c7d08edecd010e121082f47a2d8eee

Please take a look!