### PR TITLE
Update chart version to keep main branch latest (Ledger)

### DIFF
--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl
 description: Scalar DL is a tamper-evident and scalable distributed database.
 type: application
-version: 4.5.0
-appVersion: 3.7.0
+version: 4.5.1
+appVersion: 3.7.1
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,7 +1,7 @@
 # scalardl
 
 Scalar DL is a tamper-evident and scalable distributed database.
-Current chart version is `4.5.0`
+Current chart version is `4.5.1`
 
 ## Requirements
 
@@ -34,7 +34,7 @@ Current chart version is `4.5.0`
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
-| ledger.image.version | string | `"3.7.0"` | Docker tag |
+| ledger.image.version | string | `"3.7.1"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.ledgerProperties | string | The default minimum necessary values of ledger.properties are set. You can overwrite it with your own ledger.properties. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -110,7 +110,7 @@ ledger:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger
     # -- Docker tag
-    version: 3.7.0
+    version: 3.7.1
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
A new patch version of ScalarDL Ledger Helm Charts has been released.
This PR updates the version of the ScalarDL Ledger chart to keep the main branch latest.
(This release flow will be fixed in the future.)

This PR applies the same update as the following commit.
https://github.com/scalar-labs/helm-charts/commit/f848661e3dcfc5908709bbed23e7d4bfb8578cd8

Please take a look!