### PR TITLE
Update chart version to keep main branch latest (Auditor)

### DIFF
--- a/charts/scalardl-audit/Chart.yaml
+++ b/charts/scalardl-audit/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl-audit
 description: Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
 type: application
-version: 2.5.0
-appVersion: 3.7.0
+version: 2.5.1
+appVersion: 3.7.1
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -1,7 +1,7 @@
 # scalardl-audit
 
 Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
-Current chart version is `2.5.0`
+Current chart version is `2.5.1`
 
 ## Requirements
 
@@ -22,7 +22,7 @@ Current chart version is `2.5.0`
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | auditor.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | auditor.image.repository | string | `"ghcr.io/scalar-labs/scalar-auditor"` | Docker image |
-| auditor.image.version | string | `"3.7.0"` | Docker tag |
+| auditor.image.version | string | `"3.7.1"` | Docker tag |
 | auditor.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | auditor.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | auditor.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -142,7 +142,7 @@ auditor:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-auditor
     # -- Docker tag
-    version: 3.7.0
+    version: 3.7.1
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
A new patch version of ScalarDL Auditor Helm Charts has been released.
This PR updates the version of the ScalarDL Auditor chart to keep the main branch latest.
(This release flow will be fixed in the future.)

This PR applies the same update as the following commit.
https://github.com/scalar-labs/helm-charts/commit/6f45f73fe45e288c4c2f2b2d64d63592985d1f8f

Please take a look!