### PR TITLE
Add sleep command before kubectl wait in the CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -183,6 +183,7 @@ jobs:
           kubectl create secret generic ledger-keys --from-file=private-key=.github/ledger-key.pem
           kubectl create secret generic auditor-keys --from-file=certificate=.github/auditor-cert.pem --from-file=private-key=.github/auditor-key.pem
           kubectl create -f .github/cassandra.yaml
+          sleep 1 # Waiting for the StatefulSet creates a cassandra pod.
           kubectl wait --for=condition=Ready --timeout=120s pod/cassandra-0
           kubectl create -f .github/schema-loading.yaml
           kubectl wait --for=condition=complete --timeout=60s job/schema-loading


### PR DESCRIPTION
This PR adds the `sleep 1` command before `kubectl wait` in the CI.

The CI sometimes fails with the following error.

```shell
$ kubectl wait --for=condition=Ready --timeout=120s pod/cassandra-0
Error from server (NotFound): pods "cassandra-0" not found
```

For example, you can see it in the following action.
https://github.com/scalar-labs/helm-charts/actions/runs/3945941786/jobs/6753281153

I guess, there is a time lag between the `StatefulSet` creation and the `Pod` creation by the StatefulSet.

Also, I investigated the `kubectl wait` command. However, it seems that there is no way to handle (re-try) the `not found` error.
https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#wait

So, I added the `sleep` command before the `kubectl wait` command for waiting for the pod creation.

Please take a look!
