### PR TITLE
Add Loki data source config in custom values file

### DIFF
--- a/docs/conf/scalar-prometheus-custom-values.yaml
+++ b/docs/conf/scalar-prometheus-custom-values.yaml
@@ -17,6 +17,11 @@ grafana:
   defaultDashboardsEnabled: false
 
   sidecar:
+    datasources:
+      enabled: true
+      defaultDatasourceEnabled: false
+      label: grafana_datasource
+      labelValue: "1"
     dashboards:
       enabled: true
       label: grafana_dashboard
@@ -33,6 +38,25 @@ grafana:
       # -- If you use Scalar Manager, you need to set allow_embedding to true.
       # -- https://grafana.com/docs/grafana/latest/administration/configuration/#allow_embedding
       allow_embedding: false
+
+  # -- Additional data source configurations
+  additionalDataSources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://scalar-monitoring-kube-pro-prometheus.monitoring.svc.cluster.local:9090/
+    access: proxy
+    editable: false
+    isDefault: false
+    jsonData:
+      timeInterval: 30s
+  # - name: Loki
+  #   type: loki
+  #   uid: loki
+  #   url: http://scalar-logging-loki.monitoring.svc.cluster.local:3100/
+  #   access: proxy
+  #   editable: false
+  #   isDefault: false
 
 kubeApiServer:
   # -- Scraping kube-apiserver is disabled

--- a/docs/conf/scalar-prometheus-custom-values.yaml
+++ b/docs/conf/scalar-prometheus-custom-values.yaml
@@ -44,7 +44,7 @@ grafana:
   - name: Prometheus
     type: prometheus
     uid: prometheus
-    url: http://scalar-monitoring-kube-pro-prometheus.monitoring.svc.cluster.local:9090/
+    url: http://scalar-monitoring-kube-pro-prometheus:9090/
     access: proxy
     editable: false
     isDefault: false
@@ -53,7 +53,7 @@ grafana:
   # - name: Loki
   #   type: loki
   #   uid: loki
-  #   url: http://scalar-logging-loki.monitoring.svc.cluster.local:3100/
+  #   url: http://scalar-logging-loki:3100/
   #   access: proxy
   #   editable: false
   #   isDefault: false

--- a/docs/getting-started-logging.md
+++ b/docs/getting-started-logging.md
@@ -56,19 +56,34 @@ We will deploy the following components on a Kubernetes cluster as follows.
    helm install scalar-logging-loki grafana/loki-stack -n monitoring -f scalar-loki-stack-custom-values.yaml
    ```
 
-## Step 3. Access the Grafana dashboard
+## Step 3. Add a Loki data source in the Grafana configuration
+
+1. Add a configuration of the Loki data source in the `scalar-prometheus-custom-values.yaml` file.
+   ```yaml
+   grafana:
+     additionalDataSources:
+     - name: Loki
+       type: loki
+       uid: loki
+       url: http://scalar-logging-loki.monitoring.svc.cluster.local:3100/
+       access: proxy
+       editable: false
+       isDefault: false
+   ```
+
+1. Apply the configuration (upgrade the deployment of `kube-prometheus-stack`).
+   ```console
+   helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
+   ```
+
+## Step 4. Access the Grafana dashboard
 
 1. Add Loki as a data source
    - Go to Grafana http://localhost:3000 (If you use minikube)
-      - If you use a Kubernetes cluster other than minikube, you need to access the LoadBalancer service according to the manner of each Kubernetes cluster.
-   - Move to `Configuration` and choose `Data Sources`
-   - Click `Add data source`
-   - Select `Loki`
-   - Input `http://scalar-logging-loki:3100` to URL
-   - Click `Save and test`
    - Go to `Explore` to find the added Loki
+   - You can see the collected logs in the `Explore` page
 
-## Step 4. Delete the `loki-stack` helm chart
+## Step 5. Delete the `loki-stack` helm chart
 
 1. Uninstall `loki-stack`.
    ```console

--- a/docs/getting-started-logging.md
+++ b/docs/getting-started-logging.md
@@ -65,7 +65,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
      - name: Loki
        type: loki
        uid: loki
-       url: http://scalar-logging-loki.monitoring.svc.cluster.local:3100/
+       url: http://scalar-logging-loki:3100/
        access: proxy
        editable: false
        isDefault: false


### PR DESCRIPTION
This PR updates the getting started with Loki and sample configuration for kube-prometheus-stack.

In the current getting started, we set Loki data source configuration from Web UI.
However, that configurations are not persisted anywhere.
So, if the Grafana container is restarted, that configuration is removed.

Also, in the getting started with Scalar Manager, we update the configuration of Grafana and apply it.
When this configuration applying, the Grafana pods is restarted.
So, the data source configuration of Loki that is configured from the Web UI is removed.

To avoid the above issue, I added the Loki data source configuration in the custom values file.
In this way, the data source configuration is persisted.
So, even if the Grafana pod is restarted, we can use Loki data sources without re-configure it.
Please refer to [this research](https://gist.github.com/superbrothers/528d227c2fa28df3ece99a241adab510) for more details on how to configure data sources in the custom values file.

Please take a look!