### PR TITLE
Support extra volume mount in ScalarDB Server chart

### DIFF
--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -27,6 +27,8 @@ Current chart version is `2.5.0`
 | scalardb.affinity | object | `{}` | The affinity/anti-affinity feature, greatly expands the types of constraints you can express. |
 | scalardb.databaseProperties | string | The minimum template of database.properties is set by default. | The database.properties is created based on the values of scalardb.storageConfiguration by default. If you want to customize database.properties, you can override this value with your database.properties. |
 | scalardb.existingSecret | string | `""` | Name of existing secret to use for storing database username and password. |
+| scalardb.extraVolumeMounts | list | `[]` | Defines additional volume mounts. If you want to get a heap dump of the ScalarDB Cluster node, you need to mount a volume to make the dump file persistent. |
+| scalardb.extraVolumes | list | `[]` | Defines additional volumes. If you want to get a heap dump of the ScalarDB Cluster node, you need to mount a volume to make the dump file persistent. |
 | scalardb.grafanaDashboard.enabled | bool | `false` | Enable grafana dashboard. |
 | scalardb.grafanaDashboard.namespace | string | `"monitoring"` | Which namespace grafana dashboard is located. by default monitoring. |
 | scalardb.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -94,10 +94,16 @@ spec:
             - name: scalardb-database-properties-volume
               mountPath: /scalardb/server/database.properties.tmpl
               subPath: database.properties.tmpl
+          {{- with .Values.scalardb.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: scalardb-database-properties-volume
           configMap:
             name: {{ include "scalardb.fullname" . }}-database-properties
+      {{- with .Values.scalardb.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.scalardb.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/scalardb/values.schema.json
+++ b/charts/scalardb/values.schema.json
@@ -77,6 +77,12 @@
                 "existingSecret": {
                     "type": "string"
                 },
+                "extraVolumeMounts": {
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "type": "array"
+                },
                 "grafanaDashboard": {
                     "type": "object",
                     "properties": {

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -183,3 +183,15 @@ scalardb:
 
   # -- Name of existing secret to use for storing database username and password.
   existingSecret: ""
+
+  # -- Defines additional volumes.
+  # If you want to get a heap dump of the ScalarDB Cluster node, you need to mount a volume to make the dump file persistent.
+  extraVolumes: []
+  # - name: heap-dump
+  #   emptyDir: {}
+
+  # -- Defines additional volume mounts.
+  # If you want to get a heap dump of the ScalarDB Cluster node, you need to mount a volume to make the dump file persistent.
+  extraVolumeMounts: []
+  # - name: heap-dump
+  #   mountPath: /dump


### PR DESCRIPTION
This PR adds a new feature that can mount any extra volumes on the ScalarDB Server pods.

For example, we can use this feature to get a heap dump file of the ScalarDB Server.
Sometimes we need to get a heap dump of JVM to investigate the ScalarDB Server issues (e.g., OOM error).
However, we cannot get the heap dump file at this time since the heap dump file is not persisted in the container.
To make the heap dump file persistent, we need to mount some volumes.

---

For your reference, we can mount `/dump` directory using this new feature in the ScalarDB Server pod as follows.

```yaml
$ cat extra-volume-scalardb-server.yaml
scalardb:

  replicaCount: 1

  (snip)

  extraVolumes:
    - name: heap-dump
      emptyDir: {}

  extraVolumeMounts:
    - name: heap-dump
      mountPath: /dump
```
```shell
helm install scalardb ~/github.com/scalar-labs/helm-charts/charts/scalardb/ -f ./extra-volume-scalardb-server.yaml
```
```shell
$ kubectl get pod
NAME                             READY   STATUS    RESTARTS   AGE
postgresql-scalardb-0            1/1     Running   0          5h32m
scalardb-7df4447998-p559z        1/1     Running   0          2s
scalardb-envoy-6497cf5f6-54j29   1/1     Running   0          2s
```
```json
$ kubectl get deployment scalardb -o jsonpath='{.spec.template.spec.volumes}' | jq .[1]
{
  "emptyDir": {},
  "name": "heap-dump"
}
```
```json
$ kubectl get deployment scalardb -o jsonpath='{.spec.template.spec.containers[].volumeMounts}' | jq .[1]
{
  "mountPath": "/dump",
  "name": "heap-dump"
}
```
```shell
$ kubectl exec -it scalardb-7df4447998-p559z -- ls -ld /dump
drwxrwxrwx 2 root root 4096 Feb  6 07:43 /dump
```
