### PR TITLE
Update deprecated feature `set-output` in workflow

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -166,7 +166,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config .github/ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Create kind ${{ matrix.k8s }} cluster


### PR DESCRIPTION
This PR updates the deprecated feature `set-output` in the GitHub Actions.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Please take a look!