### PR TITLE
Fix typo of Grafana custom values

### DIFF
--- a/docs/getting-started-scalar-manager.md
+++ b/docs/getting-started-scalar-manager.md
@@ -61,7 +61,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 1. Add or revise this value to the custom values file (e.g. scalar-prometheus-custom-values.yaml) of the `kube-prometheus-stack`
    ```yaml
    grafana:
-     grafana-ini:
+     grafana.ini:
        security:
          allow_embedding: true
          cookie_samesite: disabled


### PR DESCRIPTION
This PR fixes a typo in the getting started with Scalar Manager.
Regarding the key name, `grafana.ini` is correct.

https://github.com/scalar-labs/helm-charts/blob/main/docs/conf/scalar-prometheus-custom-values.yaml#L35
https://github.com/grafana/helm-charts/blob/grafana-6.50.7/charts/grafana/values.yaml#L692
