### PR TITLE
Add requirement in getting started scalar manager

### DIFF
--- a/docs/getting-started-scalar-manager.md
+++ b/docs/getting-started-scalar-manager.md
@@ -111,6 +111,11 @@ We will deploy the following components on a Kubernetes cluster as follows.
 
 ## Step 3. Deploy `scalar-manager`
 
+1. Create a secret resource `reg-docker-secrets` to pull the Scalar Manager container image from GitHub Packages.
+   ```console
+   kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
+   ```
+
 1. Deploy the `scalar-manager` Helm Chart.
    ```console
    helm install scalar-manager scalar-labs/scalar-manager -f scalar-manager-custom-values.yaml

--- a/docs/getting-started-scalar-manager.md
+++ b/docs/getting-started-scalar-manager.md
@@ -11,6 +11,11 @@ Scalar Manager also embeds Grafana explorers by which the users can review the m
 This guide assumes that the users are aware of how to deploy Scalar products with the monitoring and logging tools to a Kubernetes cluster.
 If not, please start with [Getting Started with Scalar Helm Charts](./getting-started-scalar-helm-charts.md) before this guide.
 
+## Requirement
+
+* You need the privileges to pull the Scalar Manager container (`scalar-manager`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).
+* You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above container.
+
 ## What we create
 
 We will deploy the following components on a Kubernetes cluster as follows.

--- a/docs/getting-started-scalar-manager.md
+++ b/docs/getting-started-scalar-manager.md
@@ -13,7 +13,7 @@ If not, please start with [Getting Started with Scalar Helm Charts](./getting-st
 
 ## Requirement
 
-* You need the privileges to pull the Scalar Manager container (`scalar-manager`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).
+* You need privileges to pull the Scalar Manager container (`scalar-manager`) from [GitHub Packages](https://github.com/orgs/scalar-labs/packages).
 * You must create a Github Personal Access Token (PAT) with `read:packages` scope according to the [GitHub document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to pull the above container.
 
 ## What we create


### PR DESCRIPTION
This PR adds a requirement section in the Scalar Manager getting started guide.

Before, we pulled all images from GitHub Packages in all getting started guides. And, we created a secret resource that includes GitHub Personal Access Token (PAT) in the getting started guide of ScalarDB or ScalarDL.
So, we could pull the Scalar Manager container image using this PAT.

However, I updated the getting started guide of ScalarDB and ScalarDL in PR #147.
After that update, we pull ScalarDB/ScalarDL container images from AWS/Azure Marketplace.
So, we don't create a secret resource that includes PAT of GitHub.

In other words, there are no steps to create a secret resource that includes PAT to pull the Scalar Manager container image.
As a result, we will face the `Error: ErrImagePull` error when we deploy Scalar Manager according to the getting started.

So, I added a requirement section that describes how to create PAT to pull the Scalar Manager container image.
(We can remove this section after we start providing Scalar Manager in each Marketplace.)

Please take a look!
