### PR TITLE
Update product name in ScalarDB GraphQL chart

### DIFF
--- a/charts/scalardb-graphql/Chart.yaml
+++ b/charts/scalardb-graphql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: scalardb-graphql
-description: Scalar DB GraphQL server
+description: ScalarDB GraphQL server
 type: application
 version: 1.3.0
 appVersion: 3.8.0

--- a/charts/scalardb-graphql/README.md
+++ b/charts/scalardb-graphql/README.md
@@ -1,6 +1,6 @@
 # scalardb-graphql
 
-Scalar DB GraphQL server
+ScalarDB GraphQL server
 Current chart version is `1.3.0`
 
 ## Values
@@ -13,7 +13,7 @@ Current chart version is `1.3.0`
 | grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
-| image.repository | string | `"ghcr.io/scalar-labs/scalardb-graphql"` | Docker image reposiory of Scalar DB GraphQL. |
+| image.repository | string | `"ghcr.io/scalar-labs/scalardb-graphql"` | Docker image reposiory of ScalarDB GraphQL. |
 | image.tag | string | `"3.8.0"` | Docker tag of the image. |
 | imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ingress.annotations | object | `{"alb.ingress.kubernetes.io/healthcheck-path":"/graphql?query=%7B__typename%7D","alb.ingress.kubernetes.io/scheme":"internal","alb.ingress.kubernetes.io/target-group-attributes":"stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60","alb.ingress.kubernetes.io/target-type":"ip","nginx.ingress.kubernetes.io/affinity":"cookie","nginx.ingress.kubernetes.io/session-cookie-hash":"sha1","nginx.ingress.kubernetes.io/session-cookie-max-age":"300","nginx.ingress.kubernetes.io/session-cookie-name":"INGRESSCOOKIE","nginx.ingress.kubernetes.io/session-cookie-path":"/"}` | The class-specific annotations for the ingress resource. |
@@ -33,7 +33,7 @@ Current chart version is `1.3.0`
 | scalarDbGraphQlConfiguration.contactPoints | string | `"cassandra"` | The database contact point such as a hostname of Cassandra or a URL of Cosmos DB account. |
 | scalarDbGraphQlConfiguration.contactPort | int | `9042` | The database port number. |
 | scalarDbGraphQlConfiguration.graphiql | string | `"true"` | Whether the GraphQL server serves GraphiQL IDE. The default is true. |
-| scalarDbGraphQlConfiguration.logLevel | string | `"INFO"` | The log level of Scalar DB GraphQL |
+| scalarDbGraphQlConfiguration.logLevel | string | `"INFO"` | The log level of ScalarDB GraphQL |
 | scalarDbGraphQlConfiguration.namespaces | string | `""` | Comma-separated list of namespaces of tables for which the GraphQL server generates a schema. |
 | scalarDbGraphQlConfiguration.password | string | `"cassandra"` | The password of the database. For Cosmos DB, Dynamo DB please specify a secret key here. |
 | scalarDbGraphQlConfiguration.path | string | `"/graphql"` | Path component of the URL of the GraphQL endpoint. The default is /graphql. |
@@ -42,7 +42,7 @@ Current chart version is `1.3.0`
 | scalarDbGraphQlConfiguration.username | string | `"cassandra"` | The username of the database. For Cosmos DB please leave blank. For Dynamo DB please specify key id here. |
 | securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod. |
 | service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
-| service.port | int | `8080` | Scalar DB GraphQL server port. |
+| service.port | int | `8080` | ScalarDB GraphQL server port. |
 | service.type | string | `"ClusterIP"` | service types in kubernetes. |
 | serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |

--- a/charts/scalardb-graphql/files/grafana/scalardb_graphql_grafana_dashboard.json
+++ b/charts/scalardb-graphql/files/grafana/scalardb_graphql_grafana_dashboard.json
@@ -593,7 +593,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Scalar DB GraphQL / Overview",
+  "title": "ScalarDB GraphQL / Overview",
   "uid": "wFGSrHjnz",
   "version": 3,
   "weekStart": ""

--- a/charts/scalardb-graphql/templates/scalardb-graphql/prometheusrules.yaml
+++ b/charts/scalardb-graphql/templates/scalardb-graphql/prometheusrules.yaml
@@ -20,8 +20,8 @@ spec:
         severity: critical
         app: ScalarDbGraphQl
       annotations:
-        summary: 'Scalar DB GraphQL cluster is down'
-        description: 'Scalar DB GraphQL cluster is down, no resquest can be process'
+        summary: 'ScalarDB GraphQL cluster is down'
+        description: 'ScalarDB GraphQL cluster is down, no resquest can be process'
 
     - alert: ScalarDbGraphQlClusterDegraded
       expr: kube_deployment_status_replicas_unavailable{namespace="{{ .Release.Namespace }}", deployment="{{ include "scalardb-graphql.fullname" . }}"} >= 1
@@ -30,8 +30,8 @@ spec:
         severity: warning
         app: ScalarDbGraphQl
       annotations:
-        summary: 'Scalar DB GraphQL cluster is running in a degraded mode'
-        description: 'Scalar DB GraphQL cluster is running in a degraded mode, some of the Scalar DB GraphQL pods are not healthy'
+        summary: 'ScalarDB GraphQL cluster is running in a degraded mode'
+        description: 'ScalarDB GraphQL cluster is running in a degraded mode, some of the ScalarDB GraphQL pods are not healthy'
 
     - alert: ScalarDbGraphQlPodsPending
       expr: kube_pod_status_phase{namespace="{{ .Release.Namespace }}", pod=~"^{{ include "scalardb-graphql.fullname" . }}-.*", phase="Pending"} > 0

--- a/charts/scalardb-graphql/values.yaml
+++ b/charts/scalardb-graphql/values.yaml
@@ -30,11 +30,11 @@ scalarDbGraphQlConfiguration:
   namespaces: ""
   # -- Whether the GraphQL server serves GraphiQL IDE. The default is true.
   graphiql: "true"
-  # -- The log level of Scalar DB GraphQL
+  # -- The log level of ScalarDB GraphQL
   logLevel: INFO
 
 image:
-  # -- Docker image reposiory of Scalar DB GraphQL.
+  # -- Docker image reposiory of ScalarDB GraphQL.
   repository: ghcr.io/scalar-labs/scalardb-graphql
   # -- Specify a image pulling policy.
   pullPolicy: IfNotPresent
@@ -56,7 +56,7 @@ strategy:
 service:
   # -- service types in kubernetes.
   type: ClusterIP
-  # -- Scalar DB GraphQL server port.
+  # -- ScalarDB GraphQL server port.
   port: 8080
   # -- Service annotations, e.g: prometheus, etc.
   annotations: {}


### PR DESCRIPTION
This PR updates the product name from `Scalar DB GraphQL` to `ScalarDB GraphQL` in the ScalarDB GraphQL chart directory.
All updates are on the descriptions or code comments. So, there are no updated features/functions.

Since we need to apply the updates of the product name to each branch/tag (e.g., scalardb-x.x.x, scalardl-x.x.x, and scalardl-audit-x.x.x), I separated PRs based on each chart.

Please take a look!