### PR TITLE
Update product name in ScalarDL Auditor chart

### DIFF
--- a/charts/scalardl-audit/Chart.yaml
+++ b/charts/scalardl-audit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: scalardl-audit
-description: Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
+description: ScalarDL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
 type: application
 version: 2.5.1
 appVersion: 3.7.1
@@ -10,7 +10,7 @@ keywords:
 - "database"
 - "distributed ledger"
 - "scalar"
-- "scalar dl"
+- "scalardl"
 home: https://scalar-labs.com/
 sources:
   - https://github.com/scalar-labs/scalardl

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -1,6 +1,6 @@
 # scalardl-audit
 
-Scalar DL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
+ScalarDL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
 Current chart version is `2.5.1`
 
 ## Requirements

--- a/charts/scalardl-audit/files/grafana/scalardl_audit_grafana_dashboard.json
+++ b/charts/scalardl-audit/files/grafana/scalardl_audit_grafana_dashboard.json
@@ -1128,7 +1128,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Scalar DL Audit / Overview",
+  "title": "ScalarDL Auditor / Overview",
   "uid": "scalardl-audit-002",
   "version": 7
 }

--- a/charts/scalardl-audit/files/grafana/scalardl_audit_response_grafana_dashboard.json
+++ b/charts/scalardl-audit/files/grafana/scalardl_audit_response_grafana_dashboard.json
@@ -241,7 +241,7 @@
     ]
   },
   "timezone": "",
-  "title": "Scalar DL Audit / Response",
+  "title": "ScalarDL Auditor / Response",
   "uid": "scalardl-audit-003",
   "version": 28
 }

--- a/charts/scalardl-audit/templates/auditor/configmap.yaml
+++ b/charts/scalardl-audit/templates/auditor/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "scalardl-audit.fullname" . }}-auditor-properties
   namespace: {{ .Release.Namespace }}
 data:
-  # Create a auditor.properties file which is config file of Scalar DL Auditor.
+  # Create a auditor.properties file which is config file of ScalarDL Auditor.
   auditor.properties.tmpl:
     {{- toYaml .Values.auditor.auditorProperties | nindent 4 }}
 ---


### PR DESCRIPTION
This PR updates the product name from `Scalar DL` to `ScalarDL` in the ScalarDL Auditor chart directory.
All updates are on the descriptions or code comments. So, there are no updated features/functions.

Since we need to apply the updates of the product name to each branch/tag (e.g., scalardb-x.x.x, scalardl-x.x.x, and scalardl-audit-x.x.x), I separated PRs based on each chart.

Please take a look!