### PR TITLE
Allow specifying any serviceaccounts in Ledger chart

### DIFF
--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -66,7 +66,7 @@ Current chart version is `4.5.1`
 | ledger.service.ports.scalardl.protocol | string | `"TCP"` | scalardl protocol |
 | ledger.service.ports.scalardl.targetPort | int | `50051` | scalardl k8s internal name |
 | ledger.service.type | string | `"ClusterIP"` | service types in kubernetes |
-| ledger.serviceAccount.automountServiceAccountToken | bool | `false` | Specify to mount secret or not |
+| ledger.serviceAccount.automountServiceAccountToken | bool | `false` | Specify to mount a service account token or not |
 | ledger.serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource |
 | ledger.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | ledger.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -66,6 +66,8 @@ Current chart version is `4.5.1`
 | ledger.service.ports.scalardl.protocol | string | `"TCP"` | scalardl protocol |
 | ledger.service.ports.scalardl.targetPort | int | `50051` | scalardl k8s internal name |
 | ledger.service.type | string | `"ClusterIP"` | service types in kubernetes |
+| ledger.serviceAccount.automountServiceAccountToken | bool | `false` |  |
+| ledger.serviceAccount.serviceAccountName | string | `""` |  |
 | ledger.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | ledger.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
 | ledger.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -66,8 +66,8 @@ Current chart version is `4.5.1`
 | ledger.service.ports.scalardl.protocol | string | `"TCP"` | scalardl protocol |
 | ledger.service.ports.scalardl.targetPort | int | `50051` | scalardl k8s internal name |
 | ledger.service.type | string | `"ClusterIP"` | service types in kubernetes |
-| ledger.serviceAccount.automountServiceAccountToken | bool | `false` |  |
-| ledger.serviceAccount.serviceAccountName | string | `""` |  |
+| ledger.serviceAccount.automountServiceAccountToken | bool | `false` | Specify to mount secret or not |
+| ledger.serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource |
 | ledger.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | ledger.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
 | ledger.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -23,7 +23,10 @@ spec:
         {{- include "scalardl-ledger.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Always
-      automountServiceAccountToken: false
+      {{- if .Values.ledger.serviceAccount.serviceAccountName }}
+      serviceAccountName: {{ .Values.ledger.serviceAccount.serviceAccountName }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.ledger.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: 60
     {{- with .Values.ledger.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -281,6 +281,17 @@
                         }
                     }
                 },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "automountServiceAccountToken": {
+                            "type": "boolean"
+                        },
+                        "serviceAccountName": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "serviceMonitor": {
                     "type": "object",
                     "properties": {

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -227,3 +227,7 @@ ledger:
 
   # -- Name of existing secret to use for storing database username and password
   existingSecret: ""
+
+  serviceAccount:
+    serviceAccountName: ""
+    automountServiceAccountToken: false

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -231,5 +231,5 @@ ledger:
   serviceAccount:
     # -- Name of the existing service account resource
     serviceAccountName: ""
-    # -- Specify to mount secret or not
+    # -- Specify to mount a service account token or not
     automountServiceAccountToken: false

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -229,5 +229,7 @@ ledger:
   existingSecret: ""
 
   serviceAccount:
+    # -- Name of the existing service account resource
     serviceAccountName: ""
+    # -- Specify to mount secret or not
     automountServiceAccountToken: false


### PR DESCRIPTION
This PR adds a new feature that can set an arbitrary Service Account to the ScalarDL Ledger pods.

For example, if we use a pay-as-you-go container in an EKS cluster, we need to create Service Account to grant permission to run the `AWS Marketplace Metering Service API` and specify it to `ledger.serviceAccount.serviceAccountName` in this chart. It uses the [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) feature of AWS.

Please take a look!

---

For your reference, you can create the Service Account to allow running `AWS Marketplace Metering Service API` as follows.
```console
eksctl create iamserviceaccount \
    --name <SERVICE_ACCOUNT_NAME> \
    --namespace <NAMESPACE> \
    --cluster <ENTER_YOUR_CLUSTER_NAME_HERE> \
    --attach-policy-arn arn:aws:iam::aws:policy/AWSMarketplaceMeteringFullAccess \
    --attach-policy-arn arn:aws:iam::aws:policy/AWSMarketplaceMeteringRegisterUsage \
    --attach-policy-arn arn:aws:iam::aws:policy/service-role/AWSLicenseManagerConsumptionPolicy \
    --approve \
    --override-existing-serviceaccounts
```

And, you can specify the above Service Account name as follows in this chart.
```yaml
ledger:
  serviceAccount:
    serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
    automountServiceAccountToken: true
```
