### PR TITLE
Allow specifying any serviceaccounts in Auditor chart

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -58,6 +58,8 @@ Current chart version is `2.5.1`
 | auditor.service.ports.scalardl-auditor.protocol | string | `"TCP"` | scalardl protocol |
 | auditor.service.ports.scalardl-auditor.targetPort | int | `40051` | scalardl k8s internal name |
 | auditor.service.type | string | `"ClusterIP"` | service types in kubernetes |
+| auditor.serviceAccount.automountServiceAccountToken | bool | `false` |  |
+| auditor.serviceAccount.serviceAccountName | string | `""` |  |
 | auditor.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | auditor.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
 | auditor.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -58,8 +58,8 @@ Current chart version is `2.5.1`
 | auditor.service.ports.scalardl-auditor.protocol | string | `"TCP"` | scalardl protocol |
 | auditor.service.ports.scalardl-auditor.targetPort | int | `40051` | scalardl k8s internal name |
 | auditor.service.type | string | `"ClusterIP"` | service types in kubernetes |
-| auditor.serviceAccount.automountServiceAccountToken | bool | `false` |  |
-| auditor.serviceAccount.serviceAccountName | string | `""` |  |
+| auditor.serviceAccount.automountServiceAccountToken | bool | `false` | Specify to mount secret or not |
+| auditor.serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource |
 | auditor.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | auditor.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
 | auditor.serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -58,7 +58,7 @@ Current chart version is `2.5.1`
 | auditor.service.ports.scalardl-auditor.protocol | string | `"TCP"` | scalardl protocol |
 | auditor.service.ports.scalardl-auditor.targetPort | int | `40051` | scalardl k8s internal name |
 | auditor.service.type | string | `"ClusterIP"` | service types in kubernetes |
-| auditor.serviceAccount.automountServiceAccountToken | bool | `false` | Specify to mount secret or not |
+| auditor.serviceAccount.automountServiceAccountToken | bool | `false` | Specify to mount a service account token or not |
 | auditor.serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource |
 | auditor.serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | auditor.serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -23,7 +23,10 @@ spec:
         {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Always
-      automountServiceAccountToken: false
+      {{- if .Values.auditor.serviceAccount.serviceAccountName }}
+      serviceAccountName: {{ .Values.auditor.serviceAccount.serviceAccountName }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.auditor.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: 60
     {{- with .Values.auditor.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -222,6 +222,17 @@
                         }
                     }
                 },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "automountServiceAccountToken": {
+                            "type": "boolean"
+                        },
+                        "serviceAccountName": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "serviceMonitor": {
                     "type": "object",
                     "properties": {

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -264,5 +264,5 @@ auditor:
   serviceAccount:
     # -- Name of the existing service account resource
     serviceAccountName: ""
-    # -- Specify to mount secret or not
+    # -- Specify to mount a service account token or not
     automountServiceAccountToken: false

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -260,3 +260,7 @@ auditor:
 
   # -- Name of existing secret to use for storing database username and password
   existingSecret: ""
+
+  serviceAccount:
+    serviceAccountName: ""
+    automountServiceAccountToken: false

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -262,5 +262,7 @@ auditor:
   existingSecret: ""
 
   serviceAccount:
+    # -- Name of the existing service account resource
     serviceAccountName: ""
+    # -- Specify to mount secret or not
     automountServiceAccountToken: false


### PR DESCRIPTION
This PR adds a new feature that can set an arbitrary Service Account to the ScalarDL Auditor pods.

For example, if we use a pay-as-you-go container in an EKS cluster, we need to create Service Account to grant permission to run the `AWS Marketplace Metering Service API` and specify it to `auditor.serviceAccount.serviceAccountName` in this chart. It uses the [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) feature of AWS.

Please take a look!

---

For your reference, you can create the Service Account to allow running `AWS Marketplace Metering Service API` as follows.
```console
eksctl create iamserviceaccount \
    --name <SERVICE_ACCOUNT_NAME> \
    --namespace <NAMESPACE> \
    --cluster <ENTER_YOUR_CLUSTER_NAME_HERE> \
    --attach-policy-arn arn:aws:iam::aws:policy/AWSMarketplaceMeteringFullAccess \
    --attach-policy-arn arn:aws:iam::aws:policy/AWSMarketplaceMeteringRegisterUsage \
    --attach-policy-arn arn:aws:iam::aws:policy/service-role/AWSLicenseManagerConsumptionPolicy \
    --approve \
    --override-existing-serviceaccounts
```

And, you can specify the above Service Account name as follows in this chart.
```yaml
auditor:
  serviceAccount:
    serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
    automountServiceAccountToken: true
```
