### PR TITLE
Allow specifying any serviceaccounts in Scalar Manager chart

### DIFF
--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -24,5 +24,5 @@ Current chart version is `1.0.0`
 | scalarManager.targets | list | `[]` |  |
 | service.port | int | `8000` | The port that service exposes |
 | service.type | string | `"ClusterIP"` | The service type |
-| serviceAccount.automountServiceAccountToken | bool | `true` | Specify to mount secret or not |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Specify to mount a service account token or not |
 | serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource |

--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -24,5 +24,5 @@ Current chart version is `1.0.0`
 | scalarManager.targets | list | `[]` |  |
 | service.port | int | `8000` | The port that service exposes |
 | service.type | string | `"ClusterIP"` | The service type |
-| serviceAccount.create | bool | `true` | Create a service account |
-| serviceAccount.name | string | `"scalar-manager"` | Specify the name for the service account |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Specify to mount secret or not |
+| serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource |

--- a/charts/scalar-manager/templates/_helpers.tpl
+++ b/charts/scalar-manager/templates/_helpers.tpl
@@ -54,9 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "scalar-manager.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "scalar-manager.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.serviceAccountName }}
+{{- .Values.serviceAccount.serviceAccountName }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- print (include "scalar-manager.fullname" .) "-sa" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}

--- a/charts/scalar-manager/templates/deployment.yaml
+++ b/charts/scalar-manager/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "scalar-manager.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/scalar-manager/templates/role.yaml
+++ b/charts/scalar-manager/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "scalar-manager.fullname" . }}
+  name: {{ include "scalar-manager.fullname" . }}-role
 rules:
 - apiGroups: [""]
   resources: ["endpoints"]

--- a/charts/scalar-manager/templates/rolebinding.yaml
+++ b/charts/scalar-manager/templates/rolebinding.yaml
@@ -2,12 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "scalar-manager.fullname" . }}
+  name: {{ include "scalar-manager.fullname" . }}-rolebinding
 subjects:
 - kind: ServiceAccount
   name: {{ include "scalar-manager.serviceAccountName" . }}
   apiGroup: ""
 roleRef:
   kind: Role
-  name: {{ include "scalar-manager.fullname" . }}
+  name: {{ include "scalar-manager.fullname" . }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/charts/scalar-manager/templates/serviceaccount.yaml
+++ b/charts/scalar-manager/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if not .Values.serviceAccount.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/scalar-manager/values.schema.json
+++ b/charts/scalar-manager/values.schema.json
@@ -67,10 +67,10 @@
         "serviceAccount": {
             "type": "object",
             "properties": {
-                "create": {
+                "automountServiceAccountToken": {
                     "type": "boolean"
                 },
-                "name": {
+                "serviceAccountName": {
                     "type": "string"
                 }
             }

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -20,10 +20,10 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # serviceAccount.create -- Create a service account
-  create: true
-  # serviceAccount.name -- Specify the name for the service account
-  name: scalar-manager
+  # serviceAccount.serviceAccountName -- Name of the existing service account resource
+  serviceAccountName: ""
+  # serviceAccount.automountServiceAccountToken -- Specify to mount secret or not
+  automountServiceAccountToken: true
 
 service:
   # service.type -- The service type

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -22,7 +22,7 @@ fullnameOverride: ""
 serviceAccount:
   # serviceAccount.serviceAccountName -- Name of the existing service account resource
   serviceAccountName: ""
-  # serviceAccount.automountServiceAccountToken -- Specify to mount secret or not
+  # serviceAccount.automountServiceAccountToken -- Specify to mount a service account token or not
   automountServiceAccountToken: true
 
 service:


### PR DESCRIPTION
This PR adds a new feature that can set an arbitrary Service Account to the Scalar Manager pods.

For example, if we use a pay-as-you-go container in an EKS cluster, we need to create Service Account to grant permission to run the `AWS Marketplace Metering Service API` and specify it to `serviceAccount.serviceAccountName` in this chart. It uses the [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) feature of AWS.

Also, the Scalar Manager pod already uses Service Account to allow running the Kubernetes API from inside of Scalar Manager pod.
We cannot set two Service Accounts to one pod, so I adjusted `Role` and `Rolebinding` resource.
If we don't specify the existing Service Account, this chart generates Service Account automatically and grants some permissions to it.
If we specify the existing Service Account, this chart grants some permissions to the specified Service Account.

Please take a look!

---

For your reference, you can create the Service Account to allow running `AWS Marketplace Metering Service API` as follows.
```console
eksctl create iamserviceaccount \
    --name <SERVICE_ACCOUNT_NAME> \
    --namespace <NAMESPACE> \
    --cluster <ENTER_YOUR_CLUSTER_NAME_HERE> \
    --attach-policy-arn arn:aws:iam::aws:policy/AWSMarketplaceMeteringFullAccess \
    --attach-policy-arn arn:aws:iam::aws:policy/AWSMarketplaceMeteringRegisterUsage \
    --attach-policy-arn arn:aws:iam::aws:policy/service-role/AWSLicenseManagerConsumptionPolicy \
    --approve \
    --override-existing-serviceaccounts
```

And, you can specify the above Service Account name as follows in this chart.
```yaml
serviceAccount:
  serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
  automountServiceAccountToken: true
```
