### PR TITLE
Support GraphQL feature in ScalarDB Cluster chart

### DIFF
--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -30,6 +30,12 @@ Current chart version is `1.0.0-SNAPSHOT`
 | scalardbCluster.extraVolumes | list | `[]` | Defines additional volumes. If you want to get a heap dump of the ScalarDB Cluster node, you need to mount a volume to make the dump file persistent. |
 | scalardbCluster.grafanaDashboard.enabled | bool | `false` | Enable grafana dashboard. |
 | scalardbCluster.grafanaDashboard.namespace | string | `"monitoring"` | Which namespace grafana dashboard is located. by default monitoring. |
+| scalardbCluster.graphql.enabled | bool | `false` | enable graphql |
+| scalardbCluster.graphql.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
+| scalardbCluster.graphql.service.ports.graphql.port | int | `8080` | graphql public port |
+| scalardbCluster.graphql.service.ports.graphql.protocol | string | `"TCP"` | graphql protocol |
+| scalardbCluster.graphql.service.ports.graphql.targetPort | int | `8080` | graphql k8s internal port |
+| scalardbCluster.graphql.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | scalardbCluster.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | scalardbCluster.image.repository | string | `"ghcr.io/scalar-labs/scalardb-cluster-node"` | Docker image reposiory of ScalarDB Cluster. |
 | scalardbCluster.image.tag | string | `""` | Override the image tag whose default is the chart appVersion |

--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -44,6 +44,7 @@ spec:
           ports:
             - containerPort: 60053
             - containerPort: 8080
+            - containerPort: 9080
           env:
           - name: SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAMESPACE_NAME
             value: {{ .Release.Namespace }}

--- a/charts/scalardb-cluster/templates/scalardb-cluster/service.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/service.yaml
@@ -23,14 +23,36 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "scalardb-cluster.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardb-cluster.labels" . | nindent 4 }}
 spec:
   ports:
   - name: scalardb-cluster-prometheus
-    port: 8080
-    targetPort: 8080
+    port: 9080
+    targetPort: 9080
     protocol: TCP
   selector:
     {{- include "scalardb-cluster.selectorLabels" . | nindent 4 }}
   type: ClusterIP
+---
+{{- if .Values.scalardbCluster.graphql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scalardb-cluster.fullname" . }}-graphql
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardb-cluster.labels" . | nindent 4 }}
+  annotations:
+{{ toYaml .Values.scalardbCluster.graphql.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.scalardbCluster.graphql.service.type }}
+  ports:
+  {{- range $key, $value := .Values.scalardbCluster.graphql.service.ports }}
+    - name: {{ $key }}
+{{ toYaml $value | indent 6 }}
+  {{- end }}
+  selector:
+    {{- include "scalardb-cluster.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/scalardb-cluster/values.schema.json
+++ b/charts/scalardb-cluster/values.schema.json
@@ -91,6 +91,44 @@
                         }
                     }
                 },
+                "graphql": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "graphql": {
+                                            "type": "object",
+                                            "properties": {
+                                                "port": {
+                                                    "type": "integer"
+                                                },
+                                                "protocol": {
+                                                    "type": "string"
+                                                },
+                                                "targetPort": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -53,6 +53,24 @@ scalardbCluster:
     # -- The log level of ScalarDB Cluster
     dbLogLevel: INFO
 
+  graphql:
+    # -- enable graphql
+    enabled: false
+
+    service:
+      # -- service types in kubernetes
+      type: ClusterIP
+      # -- Service annotations, e.g: prometheus, etc.
+      annotations: {}
+      ports:
+        graphql:
+          # -- graphql public port
+          port: 8080
+          # -- graphql k8s internal port
+          targetPort: 8080
+          # -- graphql protocol
+          protocol: TCP
+
   # -- The database.properties is created based on the values of scalardb-cluster.storageConfiguration by default. If you want to customize database.properties, you can override this value with your database.properties.
   # @default -- The minimum template of database.properties is set by default.
   scalardbClusterNodeProperties: |
@@ -115,6 +133,28 @@ scalardbCluster:
 
     # Whether or not the commit phase is executed asynchronously.
     scalar.db.consensus_commit.async_commit.enabled=${env:SCALAR_DB_CONSENSUS_COMMIT_ASYNC_COMMIT_ENABLED}
+
+    #
+    # For GraphQL configurations
+    #
+
+    # Whether GraphQL is enabled. The default is true.
+    scalar.db.graphql.enabled=${env:SCALAR_DB_GRAPHQL_ENABLED}
+
+    # Port number for GraphQL server. The default is 8080.
+    scalar.db.graphql.port=${env:SCALAR_DB_GRAPHQL_PORT}
+
+    # Path component of the URL of the GraphQL endpoint. The default is /graphql.
+    scalar.db.graphql.path=${env:SCALAR_DB_GRAPHQL_PATH}
+
+    # Comma-separated list of namespaces of tables for which the GraphQL server generates a schema.
+    scalar.db.graphql.namespaces=${env:SCALAR_DB_GRAPHQL_NAMESPACES}
+
+    # Whether the GraphQL server serves GraphiQL IDE. The default is true.
+    scalar.db.graphql.graphiql=${env:SCALAR_DB_GRAPHQL_GRAPHIQL}
+
+    # The interval at which GraphQL server will rebuild the GraphQL schema if any change is detected in the ScalarDB schema. The default interval value is 30000 (30 seconds).
+    scalar.db.graphql.schema_checking_interval_millis=${env:SCALAR_DB_GRAPHQL_SCHEMA_CHECKING_INTERVAL_MILLIS}
 
   # -- Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom.
   secretName: ""


### PR DESCRIPTION
This PR adds the GraphQL feature support to the ScalarDB Cluster chart.
Some default values are based on the current ScalarDB Cluster default configurations, but we can update some default configurations in the future based on the ScalarDB Cluster's feature updates.

Please take a look!