### PR TITLE
Make namespace configurable in helm template (ScalarDB)

### DIFF
--- a/charts/scalardb/templates/scalardb/service.yaml
+++ b/charts/scalardb/templates/scalardb/service.yaml
@@ -23,6 +23,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "scalardb.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardb.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
This PR adds `namespace: {{ .Release.Namespace }}` configuration in the `service.yaml` file. This update make the `helm template` command with `--namespace` flag works properly.
Probably, we overlooked this point in the following PR. This PR fixes it.
https://github.com/scalar-labs/helm-charts/pull/82

Please take a look!