### PR TITLE
Make namespace configurable in helm template (ScalarDL Ledger)

### DIFF
--- a/charts/scalardl/templates/ledger/service.yaml
+++ b/charts/scalardl/templates/ledger/service.yaml
@@ -23,6 +23,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "scalardl.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalardl-ledger.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
This PR adds `namespace: {{ .Release.Namespace }}` configuration in the `service.yaml` file. This update make the `helm template` command with `--namespace` flag works properly.
Probably, we overlooked this point in the following PR. This PR fixes it.
https://github.com/scalar-labs/helm-charts/pull/82

Please take a look!