### PR TITLE
Make namespace configurable in helm template (Scalar Envoy)

### DIFF
--- a/charts/envoy/templates/service.yaml
+++ b/charts/envoy/templates/service.yaml
@@ -21,6 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "envoy.fullname" . }}-envoy-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "envoy.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
This PR adds `namespace: {{ .Release.Namespace }}` configuration in the `service.yaml` file. This update make the `helm template` command with `--namespace` flag works properly.
Probably, we overlooked this point in the following PR. This PR fixes it.
https://github.com/scalar-labs/helm-charts/pull/82

Please take a look!