### PR TITLE
Update CI for ScalarDB Cluster

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           # TODO If more charts are supported by kubeaudit, they should be added.
           # Change to `ls charts` when all charts are supported.
-          chart_dirs=(envoy scalardb scalardl scalardl-audit)
+          chart_dirs=(envoy scalardb scalardl scalardl-audit scalardb-cluster)
           for chart_dir in ${chart_dirs[@]}; do
             echo "helm dependency build charts/${chart_dir} chart..."
             helm dependency build charts/${chart_dir}


### PR DESCRIPTION
This PR updates the CI for ScalarDB Cluster.

The `ct` and `kubeval` commands get all chart names (directories) automatically in the current CI. So, we don't need to update their workflow.

However, we specify the list of chart (directory) names for the `kubeaudit` testing. So, I added the chart name `scalardb-cluster` to the list.

Please take a look!