### PR TITLE
Disable envoy by default in ScalarDB Cluster chart

### DIFF
--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -13,7 +13,7 @@ Current chart version is `1.0.0-SNAPSHOT`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| envoy.enabled | bool | `true` | enable envoy |
+| envoy.enabled | bool | `false` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardb-cluster-service:60053"` | list of service name and port |
 | envoy.image.version | string | `"1.3.0"` | Docker tag |
 | envoy.nameOverride | string | `"scalardb-cluster"` | String to partially override envoy.fullname template |

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -9,7 +9,7 @@ fullnameOverride: ""
 
 envoy:
   # -- enable envoy
-  enabled: true
+  enabled: false
   # -- String to partially override envoy.fullname template
   nameOverride: scalardb-cluster
 


### PR DESCRIPTION
This PR updates the default value of `envoy.enabled`.
I disabled Envoy by default (use direct mode by default) according to the following discussion.
https://github.com/scalar-labs/misc/pull/76#issuecomment-1459667168

Please take a look!