### PR TITLE
Use SNAPSHOT version in latest ScalarDB Cluster chart

### DIFF
--- a/charts/scalardb-cluster/Chart.yaml
+++ b/charts/scalardb-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: scalardb-cluster
 description: ScalarDB Cluster
 type: application
 version: 1.0.0-SNAPSHOT
-appVersion: 3.8.0
+appVersion: 4.0.0-SNAPSHOT
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:


### PR DESCRIPTION
This PR updates the `.Chart.AppVersion` of the ScalarDB Cluster chart.

Now, ScalarDB Cluster provides SNAPSHOT version container images. So, I use these SNAPSHOT version images in the `main` branch for using/testing the latest version features in the ScalarDB Cluster chart.

https://github.com/scalar-labs/scalardb-cluster/pull/65
https://github.com/orgs/scalar-labs/packages/container/scalardb-cluster-node/84646269?tag=4.0.0-SNAPSHOT

Please take a look!