### PR TITLE
Fix comment in scalardb-cluster-node.properties file

### DIFF
--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -138,7 +138,7 @@ scalardbCluster:
     # For GraphQL configurations
     #
 
-    # Whether GraphQL is enabled. The default is true.
+    # Whether GraphQL is enabled. The default is false.
     scalar.db.graphql.enabled=${env:SCALAR_DB_GRAPHQL_ENABLED}
 
     # Port number for GraphQL server. The default is 8080.


### PR DESCRIPTION
This PR fixes the comment about the default value of `scalar.db.graphql.enabled` in the `values.yaml` file of the ScalarDB Cluster chart.

We set `scalar.db.graphql.enabled` to `false` by default in the following commit of ScalarDB Cluster.
https://github.com/scalar-labs/scalardb-cluster/commit/e35e616ae79cb082314d6c88ef662138dd6001f4

So, I fixed the comment based on the above default value.

Please take a look!