### PR TITLE
Fix chart docs and values schema of ScalarDB Cluster chart

### DIFF
--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -38,7 +38,7 @@ Current chart version is `1.0.0-SNAPSHOT`
 | scalardbCluster.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | scalardbCluster.image.repository | string | `"ghcr.io/scalar-labs/scalardb-cluster-node"` | Docker image reposiory of ScalarDB Cluster. |
 | scalardbCluster.image.tag | string | `""` | Override the image tag whose default is the chart appVersion |
-| scalardbCluster.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
+| scalardbCluster.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalardbCluster.logLevel | string | `"INFO"` | The log level of ScalarDB Cluster |
 | scalardbCluster.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalardbCluster.podAnnotations | object | `{}` | Pod annotations for the scalardb-cluster deployment |

--- a/charts/scalardb-cluster/values.schema.json
+++ b/charts/scalardb-cluster/values.schema.json
@@ -141,7 +141,15 @@
                     }
                 },
                 "imagePullSecrets": {
-                    "type": "array"
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 },
                 "logLevel": {
                     "type": "string"


### PR DESCRIPTION
This PR fixes the auto generated chart docs and values schema files.

Since I forgot to update chart docs and values schema when I updated `values.yaml`, the CI failed as follows.
https://github.com/scalar-labs/helm-charts/actions/runs/4740369089/jobs/8416110130

To fix the above error, I ran the script that generates (automatically updates) chart docs and values schema.
Sorry, I overlooked it in the previous PRs.

Note: All files in this PR were generated automatically by `scripts/update-chart-docs.sh` and `scripts/update-values-schema-json.sh`.

Please take a look.