### PR TITLE
Update index.yaml manually for release scalardl-audit v2.5.2

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3546,6 +3546,38 @@ entries:
     version: 1.2.3
   scalardl-audit:
   - apiVersion: v2
+    appVersion: 3.7.2
+    created: "2023-04-20T18:15:25.817201287+09:00"
+    dependencies:
+    - condition: envoy.enabled
+      name: envoy
+      repository: https://scalar-labs.github.io/helm-charts
+      version: ~2.2.0
+    description: ScalarDL is a tamper-evident and scalable distributed database. This
+      chart adds an auditing capability to Ledger (scalardl chart).
+    digest: 5528842a300a506a1d8b3664c83b961c7d35dc94c76306d91ef58d496ebcbf4c
+    home: https://scalar-labs.com/
+    icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
+    keywords:
+    - database
+    - distributed ledger
+    - scalar
+    - scalardl
+    maintainers:
+    - email: yusuke.morimoto@scalar-labs.com
+      name: Yusuke Morimoto
+    - email: kun.tei@scalar-labs.com
+      name: Kun Tei
+    - email: hiroyuki.yamada@scalar-labs.com
+      name: Hiroyuki Yamada
+    name: scalardl-audit
+    sources:
+    - https://github.com/scalar-labs/scalardl
+    type: application
+    urls:
+    - https://github.com/scalar-labs/helm-charts/releases/download/scalardl-audit-2.5.2/scalardl-audit-2.5.2.tgz
+    version: 2.5.2
+  - apiVersion: v2
     appVersion: 3.7.1
     created: "2023-01-11T02:14:01.451543779Z"
     dependencies:
@@ -5724,4 +5756,4 @@ entries:
     urls:
     - https://github.com/scalar-labs/helm-charts/releases/download/schema-loading-1.3.0/schema-loading-1.3.0.tgz
     version: 1.3.0
-generated: "2023-04-20T03:46:34.735450849Z"
+generated: "2023-04-20T09:15:25.817253304Z"


### PR DESCRIPTION
This PR adds an entry of ScalarDL Auditor v3.7.2 chart to `index.yaml` to release this chart.
The release workflow succeeded (it didn't return errors), but the `index.yaml` was not updated by the workflow for some reason...
So, I created the index entry for ScalarDL Auditor v3.7.2 chart.
Please take a look!

---

For your reference, I describe the details as follows.

Now, we are using `helm/chart-releaser-action@v1.2.1` in the [release workflow](https://github.com/scalar-labs/helm-charts/blob/main/.github/workflows/release.yml#L35).
And, according to the implementation of this action, it seems that this action runs three `cr` commands in the following order.

https://github.com/helm/chart-releaser-action/blob/v1.2.1/cr.sh

1. cr package
1. cr upload
1. cr index

And, from the log of workflow (Attempt #1), it seems that the `cr package` and `cr upload` succeeded. However, it seems that the `cr index` command didn't work properly/expectedly. It states `Index .cr-index/index.yaml did not change`...
https://github.com/scalar-labs/helm-charts/actions/runs/4750224350/jobs/8438209533

```
Looking up latest tag...
Discovering changed charts since 'scalardl-audit-2.5.1'...
Installing chart-releaser...
Adding cr directory to PATH...
Packaging chart 'charts/scalardl-audit'...
Successfully packaged chart in /home/runner/work/helm-charts/helm-charts/charts/scalardl-audit and saved it to: .cr-release-packages/scalardl-audit-2.5.2.tgz
Releasing charts...
Updating charts repo index...
Using existing index at .cr-index/index.yaml
Index .cr-index/index.yaml did not change
```

Just to be sure, I checked the `cr upload` behavior. It creates GitHub releases for the specific chart.
https://github.com/helm/chart-releaser/blob/v1.2.1/pkg/releaser/releaser.go#L300

And, it seems that the corresponding release is created in GitHub properly.
https://github.com/scalar-labs/helm-charts/releases/tag/scalardl-audit-2.5.2

So, I think only the `cr index` didn't work properly.

Accoring to the result of the above investigation, I think we can recover this issue by creating `index.yaml` manually. We can do it by running the `cr index` command. The update in this PR was created by the `cr index` command.
