### PR TITLE
Add SQL configurations to scalardbClusterNodeProperties

### DIFF
--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -145,6 +145,19 @@ scalardbCluster:
     # The interval at which GraphQL server will rebuild the GraphQL schema if any change is detected in the ScalarDB schema. The default interval value is 30000 (30 seconds).
     scalar.db.graphql.schema_checking_interval_millis=${env:SCALAR_DB_GRAPHQL_SCHEMA_CHECKING_INTERVAL_MILLIS}
 
+    #
+    # For SQL configurations
+    #
+
+    # Whether SQL is enabled. The default is false.
+    scalar.db.sql.enabled=${env:SCALAR_DB_SQL_ENABLED}
+
+    # Whether the statement cache is enabled. The default is false.
+    scalar.db.sql.statement_cache.enabled=${env:SCALAR_DB_SQL_STATEMENT_CACHE_ENABLED}
+
+    # The size of the statement cache. The default is 100.
+    scalar.db.sql.statement_cache.size=${env:SCALAR_DB_SQL_STATEMENT_CACHE_SIZE}
+
   # -- Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom.
   secretName: ""
 


### PR DESCRIPTION
This PR adds the default configurations of the SQL feature to `scalardbCluster.scalardbClusterNodeProperties` in the `values.yaml` file.
Please take a look!