### PR TITLE
Add further reading part in getting started guide

### DIFF
--- a/docs/getting-started-scalardb.md
+++ b/docs/getting-started-scalardb.md
@@ -354,3 +354,11 @@ After completing the ScalarDB Server tests on the Kubernetes cluster, remove all
    ```
    kubectl delete pod scalardb-client --force --grace-period 0
    ```
+
+## Further reading
+
+You can see how to get started with monitoring or logging for Scalar products in the following documents.
+
+* [Getting Started with Helm Charts (Monitoring using Prometheus Operator)](./getting-started-monitoring.md)
+* [Getting Started with Helm Charts (Logging using Loki Stack)](./getting-started-logging.md)
+* [Getting Started with Helm Charts (Scalar Manager)](./getting-started-scalar-manager.md)

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -882,3 +882,10 @@ After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all
    rm -rf ~/scalardl-test/
    ```
 
+## Further reading
+
+You can see how to get started with monitoring or logging for Scalar products in the following documents.
+
+* [Getting Started with Helm Charts (Monitoring using Prometheus Operator)](./getting-started-monitoring.md)
+* [Getting Started with Helm Charts (Logging using Loki Stack)](./getting-started-logging.md)
+* [Getting Started with Helm Charts (Scalar Manager)](./getting-started-scalar-manager.md)

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -592,3 +592,11 @@ After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all
    ```console
    rm -rf ~/scalardl-test/
    ```
+
+## Further reading
+
+You can see how to get started with monitoring or logging for Scalar products in the following documents.
+
+* [Getting Started with Helm Charts (Monitoring using Prometheus Operator)](./getting-started-monitoring.md)
+* [Getting Started with Helm Charts (Logging using Loki Stack)](./getting-started-logging.md)
+* [Getting Started with Helm Charts (Scalar Manager)](./getting-started-scalar-manager.md)


### PR DESCRIPTION
This PR adds the links to some guides for monitoring/logging to the getting started guide of ScalarDB/ScalarDL.

From the perspective of our documentation site, we want to list only necessary documents in the left pane of the documentation site. This is because, listing all documents is a bit confusing since there are a lot of product's documents.

To achieve this, we decided to list only three documents as root documents of Scalar Helm Chart.
* Getting Started with Helm Charts (ScalarDB Server)
* Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)
* Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)

However, there is no information about monitoring/logging in the above documents. So, I added links to those documents to lead users to the monitoring/logging documents.

Please take a look!
