### PR TITLE
Add docs for ScalarDB Cluster chart

### DIFF
--- a/docs/configure-custom-values-file.md
+++ b/docs/configure-custom-values-file.md
@@ -4,6 +4,7 @@ When you deploy Scalar products using Scalar Helm Charts, you must prepare your 
 
 * [ScalarDB Server](./configure-custom-values-scalardb.md)
 * [ScalarDB GraphQL](./configure-custom-values-scalardb-graphql.md)
+* [ScalarDB Cluster](./configure-custom-values-scalardb-cluster.md)
 * [ScalarDL Ledger](./configure-custom-values-scalardl-ledger.md)
 * [ScalarDL Auditor](./configure-custom-values-scalardl-auditor.md)
 * [ScalarDL Schema Loader](./configure-custom-values-scalardl-schema-loader.md)

--- a/docs/configure-custom-values-scalardb-cluster.md
+++ b/docs/configure-custom-values-scalardb-cluster.md
@@ -6,7 +6,7 @@ This document explains how to create your custom values file for the ScalarDB Cl
 
 ### Image configurations
 
-You must set `scalardbCluster.image.repository` and `scalardbCluster.image.tag`. Please specify the container repository information that you pull the ScalarDB Cluster container image.
+You must set `scalardbCluster.image.repository` and `scalardbCluster.image.tag`. Please specify the container repository information that you will pull the ScalarDB Cluster container image from.
 
 ```yaml
 scalardbCluster:
@@ -124,7 +124,7 @@ scalardbCluster:
 
 ### Prometheus and Grafana configurations  (recommended in production environments)
 
-If you want to monitor ScalarDB Cluster pods using [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack), you can deploy a ConfigMap, a ServiceMonitor, and a PrometheusRule resource for kube-prometheus-stack using `scalardbCluster.grafanaDashboard.enabled`, `scalardbCluster.serviceMonitor.enabled`, and `scalardbCluster.prometheusRule.enabled`.
+To monitor ScalarDB Cluster pods by using [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack), you can set `scalardbCluster.grafanaDashboard.enabled`, `scalardbCluster.serviceMonitor.enabled`, and `scalardbCluster.prometheusRule.enabled` to `true`. When you set these configurations to `true`, the chart deploys the necessary resources and kube-prometheus-stack starts monitoring automatically.
 
 ```yaml
 scalardbCluster:

--- a/docs/configure-custom-values-scalardb-cluster.md
+++ b/docs/configure-custom-values-scalardb-cluster.md
@@ -26,8 +26,8 @@ scalardbCluster:
     scalar.db.cluster.membership.kubernetes.endpoint.namespace_name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAMESPACE_NAME}
     scalar.db.cluster.membership.kubernetes.endpoint.name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME}
     scalar.db.contact_points=localhost
-    scalar.db.username=cassandra
-    scalar.db.password=cassandra
+    scalar.db.username=${env:SCALAR_DB_USERNAME}
+    scalar.db.password=${env:SCALAR_DB_PASSWORD}
     scalar.db.storage=cassandra
 ```
 

--- a/docs/configure-custom-values-scalardb-cluster.md
+++ b/docs/configure-custom-values-scalardb-cluster.md
@@ -1,6 +1,6 @@
 # Configure a custom values file for ScalarDB Cluster
 
-This document explains how to create your custom values file for the ScalarDB Cluster chart. For more details on the parameters, see [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardb-cluster/README.md) of the ScalarDB Cluster chart.
+This document explains how to create your custom values file for the ScalarDB Cluster chart. For details on the parameters, see the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardb-cluster/README.md) of the ScalarDB Cluster chart.
 
 ## Required configurations
 
@@ -11,13 +11,13 @@ You must set `scalardbCluster.image.repository` and `scalardbCluster.image.tag`.
 ```yaml
 scalardbCluster:
   image:
-    repository: <Container image of ScalarDB Cluster>
-    tag: <Tag of image>
+    repository: <SCALARDB_CLUSTER_CONTAINER_IMAGE>
+    tag: <IMAGE_TAG>
 ```
 
 ### Database configurations
 
-You must set `scalardbCluster.scalardbClusterNodeProperties`. Please set your `scalardb-cluster-node.properties` to this parameter. For more details on the configurations of ScalarDB Cluster, see [ScalarDB Cluster document](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/index.md#configurations).
+You must set `scalardbCluster.scalardbClusterNodeProperties`. Please set `scalardb-cluster-node.properties` to this parameter. For more details on the configurations of ScalarDB Cluster, see [Configurations](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/index.md#configurations).
 
 ```yaml
 scalardbCluster:
@@ -31,7 +31,7 @@ scalardbCluster:
     scalar.db.storage=cassandra
 ```
 
-Note that you must always set the following three properties when you deploy ScalarDB Cluster on the Kubernetes environment using Scalar Helm Chart. These are the fixed value. They don't depend on each environment. So, you can set the same values by **copy and paste** in your `scalardbCluster.scalardbClusterNodeProperties`.
+Note that you must always set the following three properties if you deploy ScalarDB Cluster in a Kubernetes environment by using Scalar Helm Chart. These properties are fixed values. Since the properties don't depend on individual environments, you can set the same values by copying the following values and pasting them in `scalardbCluster.scalardbClusterNodeProperties`.
 
 ```yaml
 scalardbCluster:
@@ -43,13 +43,13 @@ scalardbCluster:
 
 ## Optional configurations
 
-### Resource configurations (Recommended in the production environment)
+### Resource configurations (recommended in production environments)
 
-If you want to control pod resources using the requests and limits of Kubernetes, you can use `scalardbCluster.resources`.
+To control pod resources by using requests and limits in Kubernetes, you can use `scalardbCluster.resources`.
 
-Note that the resources for one pod of Scalar products are limited to 2vCPU / 4GB memory from the perspective of the commercial license. Also, when you get the pay-as-you-go containers provided from AWS Marketplace, you cannot run those containers with more than 2vCPU / 4GB memory configuration in the `resources.limits`. When you exceed this limitation, pods are automatically stopped.
+Note that, for commercial licenses, the resources for each pod of Scalar products are limited to 2vCPU / 4GB memory. Also, if you use the pay-as-you-go containers that the AWS Marketplace provides, you will not be able to run any containers that exceed the 2vCPU / 4GB memory configuration in `resources.limits`. If you exceed this resource limitation, the pods will automatically stop.
 
-You can configure them using the same syntax as the requests and limits of Kubernetes. For more details on the requests and limits of Kubernetes, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+You can configure requests and limits by using the same syntax as requests and limits in Kubernetes. For more details on requests and limits in Kubernetes, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 
 ```yaml
 scalardbCluster:
@@ -62,24 +62,24 @@ scalardbCluster:
       memory: 4Gi
 ```
 
-### Secret configurations (Recommended in the production environment)
+### Secret configurations (recommended in production environments)
 
-If you want to use environment variables to set some properties (e.g., credentials) in the `scalardbCluster.scalardbClusterNodeProperties`, you can use `scalardbCluster.secretName` to specify the Secret resource that includes some credentials.
+To use environment variables to set some properties (e.g., credentials) in `scalardbCluster.scalardbClusterNodeProperties`, you can use `scalardbCluster.secretName` to specify the Secret resource that includes some credentials.
 
-For example, you can set credentials for a backend database (`scalar.db.username` and `scalar.db.password`) using environment variables, which makes your pods more secure.
+For example, you can set credentials for a backend database (`scalar.db.username` and `scalar.db.password`) by using environment variables, which makes your pods more secure.
 
-For more details on how to use a Secret resource,see [How to use Secret resources to pass the credentials as the environment variables into the properties file](./use-secret-for-credentilas.md).
+For more details on how to use a Secret resource, see [How to use Secret resources to pass the credentials as the environment variables into the properties file](./use-secret-for-credentilas.md).
 
 ```yaml
 scalardbCluster:
   secretName: "scalardb-cluster-credentials-secret"
 ```
 
-### Affinity configurations (Recommended in the production environment)
+### Affinity configurations (recommended in production environments)
 
-If you want to control pod deployment using the affinity and anti-affinity of Kubernetes, you can use `scalardbCluster.affinity`.
+To control pod deployment by using affinity and anti-affinity in Kubernetes, you can use `scalardbCluster.affinity`.
 
-You can configure them using the same syntax as the affinity of Kubernetes. For more details on the affinity configuration of Kubernetes, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+You can configure affinity and anti-affinity by using the same syntax for affinity and anti-affinity in Kubernetes. For more details on configuring affinity in Kubernetes, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
 
 ```yaml
 scalardbCluster:
@@ -107,11 +107,11 @@ scalardbCluster:
           topologyKey: kubernetes.io/hostname
 ```
 
-### Taints/Tolerations configurations (Recommended in the production environment)
+### Taints and tolerations configurations (recommended in production environments)
 
-If you want to control pod deployment using the taints and tolerations of Kubernetes, you can use `scalardbCluster.tolerations`.
+To control pod deployment by using taints and tolerations in Kubernetes, you can use `scalardbCluster.tolerations`.
 
-You can configure them using the same syntax as the tolerations of Kubernetes. For more details on the tolerations configuration of Kubernetes, see [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+You can configure taints and tolerations by using the same syntax as taints and tolerations in Kubernetes. For more details on the taints and tolerations configuration in Kubernetes, see [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
 ```yaml
 scalardbCluster:
@@ -122,7 +122,7 @@ scalardbCluster:
       value: scalardb-cluster
 ```
 
-### Prometheus/Grafana configurations  (Recommended in the production environment)
+### Prometheus and Grafana configurations  (recommended in production environments)
 
 If you want to monitor ScalarDB Cluster pods using [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack), you can deploy a ConfigMap, a ServiceMonitor, and a PrometheusRule resource for kube-prometheus-stack using `scalardbCluster.grafanaDashboard.enabled`, `scalardbCluster.serviceMonitor.enabled`, and `scalardbCluster.prometheusRule.enabled`.
 
@@ -140,11 +140,11 @@ scalardbCluster:
     namespace: monitoring
 ```
 
-### SecurityContext configurations (Default value is recommended)
+### SecurityContext configurations (default value is recommended)
 
-If you want to set SecurityContext and PodSecurityContext for ScalarDB Cluster pods, you can use `scalardbCluster.securityContext` and `scalardbCluster.podSecurityContext`.
+To set SecurityContext and PodSecurityContext for ScalarDB Cluster pods, you can use `scalardbCluster.securityContext` and `scalardbCluster.podSecurityContext`.
 
-You can configure them using the same syntax as SecurityContext and PodSecurityContext of Kubernetes. For more details on the SecurityContext and PodSecurityContext configurations of Kubernetes, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+You can configure SecurityContext and PodSecurityContext by using the same syntax as SecurityContext and PodSecurityContext in Kubernetes. For more details on the SecurityContext and PodSecurityContext configurations in Kubernetes, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
 ```yaml
 scalardbCluster:
@@ -159,27 +159,27 @@ scalardbCluster:
     allowPrivilegeEscalation: false
 ```
 
-### Replica configurations (Optional based on your environment)
+### Replica configurations (optional based on your environment)
 
-You can specify the number of replicas (pods) of ScalarDB Cluster using `scalardbCluster.replicaCount`.
+You can specify the number of ScalarDB Cluster replicas (pods) by using `scalardbCluster.replicaCount`.
 
 ```yaml
 scalardbCluster:
   replicaCount: 3
 ```
 
-### Logging configurations (Optional based on your environment)
+### Logging configurations (optional based on your environment)
 
-If you want to change the log level of ScalarDB Cluster, you can use `scalardbCluster.logLevel`.
+To change the ScalarDB Cluster log level, you can use `scalardbCluster.logLevel`.
 
 ```yaml
 scalardbCluster:
   logLevel: INFO
 ```
 
-### GraphQL configurations (Optional based on your environment)
+### GraphQL configurations (optional based on your environment)
 
-If you want to use the GraphQL feature of ScalarDB Cluster, you can set `true` to `scalardbCluster.graphql.enabled` to deploy some resources for the GraphQL feature. Note that you also need to set `scalar.db.graphql.enabled=true` in `scalardbCluster.scalardbClusterNodeProperties` when you use the GraphQL feature.
+To use the GraphQL feature in ScalarDB Cluster, you can set `scalardbCluster.graphql.enabled` to `true` to deploy some resources for the GraphQL feature. Note that you also need to set `scalar.db.graphql.enabled=true` in `scalardbCluster.scalardbClusterNodeProperties` when using the GraphQL feature.
 
 ```yaml
 scalardbCluster:
@@ -202,22 +202,22 @@ scalardbCluster:
           protocol: TCP
 ```
 
-### SQL configurations (Optional based on your environment)
+### SQL configurations (optional based on your environment)
 
-If you want to use the SQL feature of ScalarDB Cluster, there is no configuration for custom values files. You can use it by setting `scalar.db.sql.enabled=true` in `scalardbCluster.scalardbClusterNodeProperties`.
+To use the SQL feature in ScalarDB Cluster, there is no configuration necessary for custom values files. You can use the feature by setting `scalar.db.sql.enabled=true` in `scalardbCluster.scalardbClusterNodeProperties`.
 
-### Scalar Envoy configurations (Optional based on your environment)
+### Scalar Envoy configurations (optional based on your environment)
 
-If you want to use ScalarDB Cluster with `indirect` mode, you must enable Envoy as follows.
+To use ScalarDB Cluster with `indirect` mode, you must enable Envoy as follows.
 
 ```yaml
 envoy:
   enabled: true
 ```
 
-Also, you must set the Scalar Envoy configurations in the custom values file for ScalarDB Cluster. This is because clients need to send requests to ScalarDB Cluster via Scalar Envoy as the load balancer of gRPC requests if you deploy ScalarDB Cluster on a Kubernetes environment with `indirect` mode.
+Also, you must set the Scalar Envoy configurations in the custom values file for ScalarDB Cluster. This is because clients need to send requests to ScalarDB Cluster via Scalar Envoy as the load balancer of gRPC requests if you deploy ScalarDB Cluster in a Kubernetes environment with `indirect` mode.
 
-For more details on the Scalar Envoy configurations, see [Configure a custom values file for Scalar Envoy](configure-custom-values-envoy.md).
+For more details on Scalar Envoy configurations, see [Configure a custom values file for Scalar Envoy](configure-custom-values-envoy.md).
 
 ```yaml
 envoy:

--- a/docs/configure-custom-values-scalardb-cluster.md
+++ b/docs/configure-custom-values-scalardb-cluster.md
@@ -1,0 +1,230 @@
+# Configure a custom values file for ScalarDB Cluster
+
+This document explains how to create your custom values file for the ScalarDB Cluster chart. For more details on the parameters, see [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardb-cluster/README.md) of the ScalarDB Cluster chart.
+
+## Required configurations
+
+### Image configurations
+
+You must set `scalardbCluster.image.repository` and `scalardbCluster.image.tag`. Please specify the container repository information that you pull the ScalarDB Cluster container image.
+
+```yaml
+scalardbCluster:
+  image:
+    repository: <Container image of ScalarDB Cluster>
+    tag: <Tag of image>
+```
+
+### Database configurations
+
+You must set `scalardbCluster.scalardbClusterNodeProperties`. Please set your `scalardb-cluster-node.properties` to this parameter. For more details on the configurations of ScalarDB Cluster, see [ScalarDB Cluster document](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/index.md#configurations).
+
+```yaml
+scalardbCluster:
+  scalardbClusterNodeProperties: |
+    scalar.db.cluster.membership.type=KUBERNETES
+    scalar.db.cluster.membership.kubernetes.endpoint.namespace_name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAMESPACE_NAME}
+    scalar.db.cluster.membership.kubernetes.endpoint.name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME}
+    scalar.db.contact_points=localhost
+    scalar.db.username=cassandra
+    scalar.db.password=cassandra
+    scalar.db.storage=cassandra
+```
+
+Note that you must always set the following three properties when you deploy ScalarDB Cluster on the Kubernetes environment using Scalar Helm Chart. These are the fixed value. They don't depend on each environment. So, you can set the same values by **copy and paste** in your `scalardbCluster.scalardbClusterNodeProperties`.
+
+```yaml
+scalardbCluster:
+  scalardbClusterNodeProperties: |
+    scalar.db.cluster.membership.type=KUBERNETES
+    scalar.db.cluster.membership.kubernetes.endpoint.namespace_name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAMESPACE_NAME}
+    scalar.db.cluster.membership.kubernetes.endpoint.name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME}
+```
+
+## Optional configurations
+
+### Resource configurations (Recommended in the production environment)
+
+If you want to control pod resources using the requests and limits of Kubernetes, you can use `scalardbCluster.resources`.
+
+Note that the resources for one pod of Scalar products are limited to 2vCPU / 4GB memory from the perspective of the commercial license. Also, when you get the pay-as-you-go containers provided from AWS Marketplace, you cannot run those containers with more than 2vCPU / 4GB memory configuration in the `resources.limits`. When you exceed this limitation, pods are automatically stopped.
+
+You can configure them using the same syntax as the requests and limits of Kubernetes. For more details on the requests and limits of Kubernetes, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+
+```yaml
+scalardbCluster:
+  resources:
+    requests:
+      cpu: 2000m
+      memory: 4Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+```
+
+### Secret configurations (Recommended in the production environment)
+
+If you want to use environment variables to set some properties (e.g., credentials) in the `scalardbCluster.scalardbClusterNodeProperties`, you can use `scalardbCluster.secretName` to specify the Secret resource that includes some credentials.
+
+For example, you can set credentials for a backend database (`scalar.db.username` and `scalar.db.password`) using environment variables, which makes your pods more secure.
+
+For more details on how to use a Secret resource,see [How to use Secret resources to pass the credentials as the environment variables into the properties file](./use-secret-for-credentilas.md).
+
+```yaml
+scalardbCluster:
+  secretName: "scalardb-cluster-credentials-secret"
+```
+
+### Affinity configurations (Recommended in the production environment)
+
+If you want to control pod deployment using the affinity and anti-affinity of Kubernetes, you can use `scalardbCluster.affinity`.
+
+You can configure them using the same syntax as the affinity of Kubernetes. For more details on the affinity configuration of Kubernetes, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+
+```yaml
+scalardbCluster:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: scalar-labs.com/dedicated-node
+                operator: In
+                values:
+                  - scalardb-cluster
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - scalardb-cluster
+              - key: app.kubernetes.io/app
+                operator: In
+                values:
+                  - scalardb-cluster
+          topologyKey: kubernetes.io/hostname
+```
+
+### Taints/Tolerations configurations (Recommended in the production environment)
+
+If you want to control pod deployment using the taints and tolerations of Kubernetes, you can use `scalardbCluster.tolerations`.
+
+You can configure them using the same syntax as the tolerations of Kubernetes. For more details on the tolerations configuration of Kubernetes, see [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+
+```yaml
+scalardbCluster:
+  tolerations:
+    - effect: NoSchedule
+      key: scalar-labs.com/dedicated-node
+      operator: Equal
+      value: scalardb-cluster
+```
+
+### Prometheus/Grafana configurations  (Recommended in the production environment)
+
+If you want to monitor ScalarDB Cluster pods using [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack), you can deploy a ConfigMap, a ServiceMonitor, and a PrometheusRule resource for kube-prometheus-stack using `scalardbCluster.grafanaDashboard.enabled`, `scalardbCluster.serviceMonitor.enabled`, and `scalardbCluster.prometheusRule.enabled`.
+
+```yaml
+scalardbCluster:
+  grafanaDashboard:
+    enabled: true
+    namespace: monitoring
+  serviceMonitor:
+    enabled: true
+    namespace: monitoring
+    interval: 15s
+  prometheusRule:
+    enabled: true
+    namespace: monitoring
+```
+
+### SecurityContext configurations (Default value is recommended)
+
+If you want to set SecurityContext and PodSecurityContext for ScalarDB Cluster pods, you can use `scalardbCluster.securityContext` and `scalardbCluster.podSecurityContext`.
+
+You can configure them using the same syntax as SecurityContext and PodSecurityContext of Kubernetes. For more details on the SecurityContext and PodSecurityContext configurations of Kubernetes, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
+```yaml
+scalardbCluster:
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+```
+
+### Replica configurations (Optional based on your environment)
+
+You can specify the number of replicas (pods) of ScalarDB Cluster using `scalardbCluster.replicaCount`.
+
+```yaml
+scalardbCluster:
+  replicaCount: 3
+```
+
+### Logging configurations (Optional based on your environment)
+
+If you want to change the log level of ScalarDB Cluster, you can use `scalardbCluster.logLevel`.
+
+```yaml
+scalardbCluster:
+  logLevel: INFO
+```
+
+### GraphQL configurations (Optional based on your environment)
+
+If you want to use the GraphQL feature of ScalarDB Cluster, you can set `true` to `scalardbCluster.graphql.enabled` to deploy some resources for the GraphQL feature. Note that you also need to set `scalar.db.graphql.enabled=true` in `scalardbCluster.scalardbClusterNodeProperties` when you use the GraphQL feature.
+
+```yaml
+scalardbCluster:
+  graphql:
+    enabled: true
+```
+
+Also, you can configure the `Service` resource that accepts GraphQL requests from clients.
+
+```yaml
+scalardbCluster:
+  graphql:
+    service:
+      type: ClusterIP
+      annotations: {}
+      ports:
+        graphql:
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+```
+
+### SQL configurations (Optional based on your environment)
+
+If you want to use the SQL feature of ScalarDB Cluster, there is no configuration for custom values files. You can use it by setting `scalar.db.sql.enabled=true` in `scalardbCluster.scalardbClusterNodeProperties`.
+
+### Scalar Envoy configurations (Optional based on your environment)
+
+If you want to use ScalarDB Cluster with `indirect` mode, you must enable Envoy as follows.
+
+```yaml
+envoy:
+  enabled: true
+```
+
+Also, you must set the Scalar Envoy configurations in the custom values file for ScalarDB Cluster. This is because clients need to send requests to ScalarDB Cluster via Scalar Envoy as the load balancer of gRPC requests if you deploy ScalarDB Cluster on a Kubernetes environment with `indirect` mode.
+
+For more details on the Scalar Envoy configurations, see [Configure a custom values file for Scalar Envoy](configure-custom-values-envoy.md).
+
+```yaml
+envoy:
+  configurationsForScalarEnvoy: 
+    ...
+
+scalardbCluster:
+  configurationsForScalarDbCluster: 
+    ...
+```

--- a/docs/configure-custom-values-scalardl-auditor.md
+++ b/docs/configure-custom-values-scalardl-auditor.md
@@ -58,7 +58,7 @@ You must set a private key file to `scalar.dl.auditor.private_key_path` and a ce
 
 You must also mount the private key file and the certificate file on the ScalarDL Auditor pod.
 
-For more details on how to mount the private key file and the certificate file, refer to [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts).
+For more details on how to mount the private key file and the certificate file, refer to [Mount key and certificate files on a pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-key-and-certificate-files-on-a-pod-in-scalardl-helm-charts).
 
 ## Optional configurations
 

--- a/docs/configure-custom-values-scalardl-auditor.md
+++ b/docs/configure-custom-values-scalardl-auditor.md
@@ -58,7 +58,7 @@ You must set a private key file to `scalar.dl.auditor.private_key_path` and a ce
 
 You must also mount the private key file and the certificate file on the ScalarDL Auditor pod.
 
-Please refer to the document [Mount key/certificate files to the pod in ScalarDL Helm Charts](mount-key-and-cert-for-scalardl.md) for more details on how to mount the private key file and the certificate file.
+Please refer to the document [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts) for more details on how to mount the private key file and the certificate file.
 
 ## Optional configurations
 

--- a/docs/configure-custom-values-scalardl-auditor.md
+++ b/docs/configure-custom-values-scalardl-auditor.md
@@ -58,7 +58,7 @@ You must set a private key file to `scalar.dl.auditor.private_key_path` and a ce
 
 You must also mount the private key file and the certificate file on the ScalarDL Auditor pod.
 
-Please refer to the document [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts) for more details on how to mount the private key file and the certificate file.
+For more details on how to mount the private key file and the certificate file, refer to [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts).
 
 ## Optional configurations
 

--- a/docs/configure-custom-values-scalardl-ledger.md
+++ b/docs/configure-custom-values-scalardl-ledger.md
@@ -58,7 +58,7 @@ If you set `scalar.dl.ledger.proof.enabled` to `true` (this configuration is req
 
 In this case, you must mount the private key file on the ScalarDL Ledger pod.
 
-For more details on how to mount the private key file, refer to [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts).
+For more details on how to mount the private key file, refer to [Mount key and certificate files on a pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-key-and-certificate-files-on-a-pod-in-scalardl-helm-charts).
 
 ## Optional configurations
 

--- a/docs/configure-custom-values-scalardl-ledger.md
+++ b/docs/configure-custom-values-scalardl-ledger.md
@@ -58,7 +58,7 @@ If you set `scalar.dl.ledger.proof.enabled` to `true` (this configuration is req
 
 In this case, you must mount the private key file on the ScalarDL Ledger pod.
 
-Please refer to the document [Mount key/certificate files to the pod in ScalarDL Helm Charts](mount-key-and-cert-for-scalardl.md) for more details on how to mount the private key file.
+Please refer to the document [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts) for more details on how to mount the private key file.
 
 ## Optional configurations
 

--- a/docs/configure-custom-values-scalardl-ledger.md
+++ b/docs/configure-custom-values-scalardl-ledger.md
@@ -58,7 +58,7 @@ If you set `scalar.dl.ledger.proof.enabled` to `true` (this configuration is req
 
 In this case, you must mount the private key file on the ScalarDL Ledger pod.
 
-Please refer to the document [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts) for more details on how to mount the private key file.
+For more details on how to mount the private key file, refer to [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts).
 
 ## Optional configurations
 

--- a/docs/how-to-deploy-scalar-products.md
+++ b/docs/how-to-deploy-scalar-products.md
@@ -50,6 +50,7 @@ Please refer to the following documents for more details on how to deploy each p
 
 * [ScalarDB Server](./how-to-deploy-scalardb.md)
 * [ScalarDB GraphQL](./how-to-deploy-scalardb-graphql.md)
+* [ScalarDB Cluster](./how-to-deploy-scalardb-cluster.md)
 * [ScalarDL Ledger](./how-to-deploy-scalardl-ledger.md)
 * [ScalarDL Auditor](./how-to-deploy-scalardl-auditor.md)
 * [Scalar Manager](./how-to-deploy-scalar-manager.md)

--- a/docs/how-to-deploy-scalardb-cluster.md
+++ b/docs/how-to-deploy-scalardb-cluster.md
@@ -1,6 +1,6 @@
 # How to deploy ScalarDB Cluster
 
-This document explains how to deploy ScalarDB Cluster using Scalar Helm Charts. For more details on the custom values file for ScalarDB Cluster, see [Configure a custom values file for ScalarDB Cluster](./configure-custom-values-scalardb-cluster.md).
+This document explains how to deploy ScalarDB Cluster by using Scalar Helm Charts. For details on the custom values file for ScalarDB Cluster, see [Configure a custom values file for ScalarDB Cluster](./configure-custom-values-scalardb-cluster.md).
 
 ## Deploy ScalarDB Cluster
 
@@ -8,13 +8,13 @@ This document explains how to deploy ScalarDB Cluster using Scalar Helm Charts. 
 helm install <release name> scalar-labs/scalardb-cluster -n <namespace> -f /path/to/<your custom values file for ScalarDB Cluster>
 ```
 
-## Upgrade the deployment of ScalarDB Cluster
+## Upgrade a ScalarDB Cluster deployment
 
 ```console
 helm upgrade <release name> scalar-labs/scalardb-cluster -n <namespace> -f /path/to/<your custom values file for ScalarDB Cluster>
 ```
 
-## Delete the deployment of ScalarDB Cluster
+## Delete a ScalarDB Cluster deployment
 
 ```console
 helm uninstall <release name> -n <namespace>
@@ -22,13 +22,13 @@ helm uninstall <release name> -n <namespace>
 
 ## Deploy your client application on Kubernetes with `direct-kubernetes` mode
 
-If you use ScalarDB Cluster with `direct-kubernetes` mode, you have to:
+If you use ScalarDB Cluster with `direct-kubernetes` mode, you must:
 
-* Deploy your application pods on the same Kubernetes cluster as ScalarDB Cluster.
-* Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`).
-* Mount the `ServiceAccount` on your application pods.
+1. Deploy your application pods on the same Kubernetes cluster as ScalarDB Cluster.
+2. Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`).
+3. Mount the `ServiceAccount` on your application pods.
 
-This is because the ScalarDB Cluster client library with `direct-kubernetes` mode runs Kubernetes API from inside of your application pods to get the information of ScalarDB Cluster pods.
+This method is necessary because the ScalarDB Cluster client library with `direct-kubernetes` mode runs the Kubernetes API from inside of your application pods to get information about the ScalarDB Cluster pods.
 
 * Role
   ```yaml

--- a/docs/how-to-deploy-scalardb-cluster.md
+++ b/docs/how-to-deploy-scalardb-cluster.md
@@ -1,0 +1,67 @@
+# How to deploy ScalarDB Cluster
+
+This document explains how to deploy ScalarDB Cluster using Scalar Helm Charts. For more details on the custom values file for ScalarDB Cluster, see [Configure a custom values file for ScalarDB Cluster](./configure-custom-values-scalardb-cluster.md).
+
+## Deploy ScalarDB Cluster
+
+```console
+helm install <release name> scalar-labs/scalardb-cluster -n <namespace> -f /path/to/<your custom values file for ScalarDB Cluster>
+```
+
+## Upgrade the deployment of ScalarDB Cluster
+
+```console
+helm upgrade <release name> scalar-labs/scalardb-cluster -n <namespace> -f /path/to/<your custom values file for ScalarDB Cluster>
+```
+
+## Delete the deployment of ScalarDB Cluster
+
+```console
+helm uninstall <release name> -n <namespace>
+```
+
+## Deploy your client application on Kubernetes with `direct-kubernetes` mode
+
+If you use ScalarDB Cluster with `direct-kubernetes` mode, you have to:
+
+* Deploy your application pods on the same Kubernetes cluster as ScalarDB Cluster.
+* Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`).
+* Mount the `ServiceAccount` on your application pods.
+
+This is because the ScalarDB Cluster client library with `direct-kubernetes` mode runs Kubernetes API from inside of your application pods to get the information of ScalarDB Cluster pods.
+
+* Role
+  ```yaml
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: scalardb-cluster-client-role
+    namespace: <your namespace>
+  rules:
+    - apiGroups: [""]
+      resources: ["endpoints"]
+      verbs: ["get", "watch", "list"]
+  ```
+* RoleBinding
+  ```yaml
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: scalardb-cluster-client-rolebinding
+    namespace: <your namespace>
+  subjects:
+    - kind: ServiceAccount
+      name: scalardb-cluster-client-sa
+  roleRef:
+    kind: Role
+    name: scalardb-cluster-role
+    apiGroup: rbac.authorization.k8s.io
+  ```
+* ServiceAccount
+  ```yaml
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: scalardb-cluster-client-sa
+    namespace: <your namespace>
+  ```

--- a/docs/how-to-deploy-scalardl-auditor.md
+++ b/docs/how-to-deploy-scalardl-auditor.md
@@ -11,7 +11,7 @@ When you deploy ScalarDL Auditor, you must create a Secrete resource to mount th
 
 Please refer to the following document for more details on how to mount the key/certificate files on the ScalarDL pods.
 
-* [Mount key/certificate files to the pod in ScalarDL Helm Charts](./mount-key-and-cert-for-scalardl.md)
+* [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts)
 
 ## Create schemas for ScalarDL Auditor (Deploy ScalarDL Schema Loader)
 

--- a/docs/how-to-deploy-scalardl-auditor.md
+++ b/docs/how-to-deploy-scalardl-auditor.md
@@ -9,9 +9,7 @@ This document explains how to deploy ScalarDL Auditor using Scalar Helm Charts. 
 
 When you deploy ScalarDL Auditor, you must create a Secrete resource to mount the private key file and the certificate file on the ScalarDL Auditor pods.
 
-Please refer to the following document for more details on how to mount the key/certificate files on the ScalarDL pods.
-
-* [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts)
+For more details on how to mount the key and certificate files on the ScalarDL pods, refer to [Mount key and certificate files on a pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-key-and-certificate-files-on-a-pod-in-scalardl-helm-charts).
 
 ## Create schemas for ScalarDL Auditor (Deploy ScalarDL Schema Loader)
 

--- a/docs/how-to-deploy-scalardl-ledger.md
+++ b/docs/how-to-deploy-scalardl-ledger.md
@@ -11,7 +11,7 @@ If you use the [asset proofs](https://github.com/scalar-labs/scalardl/blob/maste
 
 Please refer to the following document for more details on how to mount the key/certificate files on the ScalarDL pods.
 
-* [Mount key/certificate files to the pod in ScalarDL Helm Charts](./mount-key-and-cert-for-scalardl.md)
+* [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts)
 
 ## Create schemas for ScalarDL Ledger (Deploy ScalarDL Schema Loader)
 

--- a/docs/how-to-deploy-scalardl-ledger.md
+++ b/docs/how-to-deploy-scalardl-ledger.md
@@ -11,7 +11,7 @@ If you use the [asset proofs](https://github.com/scalar-labs/scalardl/blob/maste
 
 Please refer to the following document for more details on how to mount the key/certificate files on the ScalarDL pods.
 
-* [Mount key/certificate files on the pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-keycertificate-files-on-the-pod-in-scalardl-helm-charts)
+* [Mount key and certificate files on a pod in ScalarDL Helm Charts](./mount-files-or-volumes-on-scalar-pods.md#mount-key-and-certificate-files-on-a-pod-in-scalardl-helm-charts)
 
 ## Create schemas for ScalarDL Ledger (Deploy ScalarDL Schema Loader)
 

--- a/docs/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/mount-files-or-volumes-on-scalar-pods.md
@@ -1,10 +1,10 @@
 # Mount any files or volumes on Scalar product pods
 
-You can mount any files or volumes on the Scalar product pods when you use the ScalarDB Server, ScalarDB Cluster, or ScalarDL Helm Charts (ScalarDL Ledger and ScalarDL Auditor).
+You can mount any files or volumes on Scalar product pods when you use ScalarDB Server, ScalarDB Cluster, or ScalarDL Helm Charts (ScalarDL Ledger and ScalarDL Auditor).
 
-## Mount key/certificate files on the pod in ScalarDL Helm Charts
+## Mount key and certificate files on a pod in ScalarDL Helm Charts
 
-You must mount the key and certificate files to run the ScalarDL Auditor.
+You must mount the key and certificate files to run ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
@@ -92,7 +92,7 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
 ## Mount emptyDir to get a heap dump file
 
-You can mount emptyDir to Scalar product pods using the following keys in your custom values file. For example, you can use this volume to get the heap dump of Scalar products.
+You can mount emptyDir to Scalar product pods by using the following keys in your custom values file. For example, you can use this volume to get a heap dump of Scalar products.
 
 * Keys
   * `scalardb.extraVolumes` / `scalardb.extraVolumeMounts` (ScalarDB Server)

--- a/docs/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/mount-files-or-volumes-on-scalar-pods.md
@@ -1,6 +1,10 @@
-# Mount key/certificate files to the pod in ScalarDL Helm Charts
+# Mount any files or volumes on Scalar product pods
 
-You can mount any files to the pod when you use the ScalarDL Helm Charts (ScalarDL Ledger and ScalarDL Auditor). For example, you must mount the key and certificate files to run the ScalarDL Auditor.
+You can mount any files or volumes on the Scalar product pods when you use the ScalarDB Server, ScalarDB Cluster, or ScalarDL Helm Charts (ScalarDL Ledger and ScalarDL Auditor).
+
+## Mount key/certificate files on the pod in ScalarDL Helm Charts
+
+You must mount the key and certificate files to run the ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
@@ -85,3 +89,31 @@ In this example, you need to mount a **private-key** and a **certificate** file 
          lrwxrwxrwx 1 root root 18 Jun 27 03:16 certificate -> ..data/certificate
          lrwxrwxrwx 1 root root 18 Jun 27 03:16 private-key -> ..data/private-key
          ```
+
+## Mount emptyDir to get a heap dump file
+
+You can mount emptyDir to Scalar product pods using the following keys in your custom values file. For example, you can use this volume to get the heap dump of Scalar products.
+
+* Keys
+  * `scalardb.extraVolumes` / `scalardb.extraVolumeMounts` (ScalarDB Server)
+  * `scalardbCluster.extraVolumes` / `scalardbCluster.extraVolumeMounts` (ScalarDB Cluster)
+  * `ledger.extraVolumes` / `ledger.extraVolumeMounts` (ScalarDL Ledger)
+  * `auditor.extraVolumes` / `auditor.extraVolumeMounts` (ScalarDL Auditor)
+
+* Example (ScalarDB Server)
+  ```yaml
+  scalardb:
+    extraVolumes:
+      - name: heap-dump
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: heap-dump
+        mountPath: /dump
+  ```
+
+In this example, you can see the mounted volume in the ScalarDB Server pod as follows.
+
+```console
+$ ls -ld /dump
+drwxrwxrwx 2 root root 4096 Feb  6 07:43 /dump
+```

--- a/docs/use-secret-for-credentilas.md
+++ b/docs/use-secret-for-credentilas.md
@@ -1,6 +1,6 @@
-# How to use Secret resources to pass the credentials as the environment variables into the properties file
+# How to use Secret resources to pass credentials as environment variables into the properties file
 
-You can pass the credentials like **username** or **password** as the environment variables via a `Secret` resource of Kubernetes. The docker images of old version Scalar products use the `dockerize` command for templating properties files. The docker images of new version Scalar products directly get values from environment variables.
+You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
 ```console
@@ -150,4 +150,4 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
          scalar.db.storage=jdbc
          ```
 
-   If you use Apache Commons Text syntax, Scalar products directly get values from environment variables.
+   If you use Apache Commons Text syntax, Scalar products get values directly from environment variables.

--- a/docs/use-secret-for-credentilas.md
+++ b/docs/use-secret-for-credentilas.md
@@ -1,6 +1,6 @@
 # How to use Secret resources to pass the credentials as the environment variables into the properties file
 
-You can pass the credentials like **username** or **password** as the environment variables via a `Secret` resource of Kubernetes. The docker images of Scalar products use the `dockerize` command for templating properties files.  
+You can pass the credentials like **username** or **password** as the environment variables via a `Secret` resource of Kubernetes. The docker images of old version Scalar products use the `dockerize` command for templating properties files. The docker images of new version Scalar products directly get values from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
 ```console
@@ -23,12 +23,14 @@ HELM_SCALAR_DL_AUDITOR_PRIVATE_KEY_PATH
 SCALAR_DB_LOG_LEVEL
 SCALAR_DL_LEDGER_LOG_LEVEL
 SCALAR_DL_AUDITOR_LOG_LEVEL
+SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAMESPACE_NAME
+SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 ```
 
 1. Set environment variable name to the properties configuration in the custom values file.
    * Example
-       * ScalarDB 
-           * ScalarDB 3.7 or earlier (Go template syntax)
+       * ScalarDB Server
+           * ScalarDB Server 3.7 or earlier (Go template syntax)
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -37,7 +39,7 @@ SCALAR_DL_AUDITOR_LOG_LEVEL
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
-           * ScalarDB 3.8 or later (Apache Commons Text syntax)
+           * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -46,6 +48,15 @@ SCALAR_DL_AUDITOR_LOG_LEVEL
                   scalar.db.password=${env:SCALAR_DB_PASSWORD}
                   ...
              ```
+       * ScalarDB Cluster
+         ```yaml
+         scalardbCluster:
+           scalardbClusterNodeProperties: |
+             ...
+             scalar.db.username=${env:SCALAR_DB_USERNAME}
+             scalar.db.password=${env:SCALAR_DB_PASSWORD}
+             ...
+         ```
        * ScalarDL Ledger (Go template syntax)
           ```yaml
           ledger:
@@ -85,15 +96,21 @@ SCALAR_DL_AUDITOR_LOG_LEVEL
 
 1. Set the `Secret` name to the following keys in the custom values file.  
    * Keys
-     * `scalardb.secretName` (ScalarDB)
+     * `scalardb.secretName` (ScalarDB Server)
+     * `scalardbCluster.secretName` (ScalarDB Cluster)
      * `ledger.secretName` (ScalarDL Ledger)
      * `auditor.secretName` (ScalarDL Auditor)
      * `schemaLoading.secretName` (ScalarDL Schema Loader)
    * Example
-     * ScalarDB
+     * ScalarDB Server
        ```yaml
        scalardb:
          secretName: "scalardb-credentials-secret"
+       ```
+     * ScalarDB Cluster
+       ```yaml
+       scalardbCluster:
+         secretName: "scalardb-cluster-credentials-secret"
        ```
      * ScalarDL Ledger
        ```yaml
@@ -133,4 +150,4 @@ SCALAR_DL_AUDITOR_LOG_LEVEL
          scalar.db.storage=jdbc
          ```
 
-   If you use Apache Commons Text syntax with ScalarDB 3.8 or later, ScalarDB directly gets values from environment variables.
+   If you use Apache Commons Text syntax, Scalar products directly get values from environment variables.


### PR DESCRIPTION
This PR updates several documents to add descriptions for ScalarDB Cluster chart.
Please take a look!

Note: At this time, we don't provide ScalarDB Cluster in AWS/Azure Marketplace. So, I don't create `Getting Started with Helm Charts (ScalarDB Cluster)` now. I would like to discuss this in the next week.