### PR TITLE
Update CI for ScalarDB Cluster chart to use PostgreSQL

### DIFF
--- a/charts/scalardb-cluster/ci/scalardb-cluster-ct-values.yaml
+++ b/charts/scalardb-cluster/ci/scalardb-cluster-ct-values.yaml
@@ -1,0 +1,9 @@
+scalardbCluster:
+  scalardbClusterNodeProperties: |
+    scalar.db.cluster.membership.type=KUBERNETES
+    scalar.db.cluster.membership.kubernetes.endpoint.namespace_name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAMESPACE_NAME}
+    scalar.db.cluster.membership.kubernetes.endpoint.name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME}
+    scalar.db.storage=jdbc
+    scalar.db.contact_points=jdbc:postgresql://postgresql.default.svc.cluster.local:5432/postgres
+    scalar.db.username=postgres
+    scalar.db.password=postgres


### PR DESCRIPTION
This PR updates CI for the ScalarDB Cluster chart to use PostgreSQL instead of Cassandra. This PR is based on #212.

Please take a look!

---

For your reference, I was able to run the `ct` command in my local environment as follows.

```shell
$ ct install --config .github/ct.yaml
Installing charts...
>>> helm version --short
>>> git rev-parse --is-inside-work-tree
>>> git merge-base origin/main HEAD
>>> git diff --find-renames --name-only 8d60921da13d070125616acfe6d06a8c09778103 -- charts

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 scalardb-cluster => (version: "1.0.0-SNAPSHOT", path: "charts/scalardb-cluster")
------------------------------------------------------------------------------------------------------------------------

(snip)

------------------------------------------------------------------------------------------------------------------------
 ✔︎ scalardb-cluster => (version: "1.0.0-SNAPSHOT", path: "charts/scalardb-cluster")
------------------------------------------------------------------------------------------------------------------------
All charts installed successfully
```


