### PR TITLE
Use SNAPSHOT versions in main branch

### DIFF
--- a/charts/envoy/Chart.yaml
+++ b/charts/envoy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: envoy
 description: Envoy Proxy for Scalar applications
 type: application
-version: 2.2.0
-appVersion: 1.3.0
+version: 3.0.0-SNAPSHOT
+appVersion: 2.0.0-SNAPSHOT
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -1,9 +1,9 @@
 # envoy
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 3.0.0-SNAPSHOT](https://img.shields.io/badge/Version-3.0.0--SNAPSHOT-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 2.0.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-2.0.0--SNAPSHOT-informational?style=flat-square)
 
 Envoy Proxy for Scalar applications
-Current chart version is `2.2.0`
+Current chart version is `3.0.0-SNAPSHOT`
 
 **Homepage:** <https://scalar-labs.com/>
 
@@ -18,7 +18,7 @@ Current chart version is `2.2.0`
 | grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | image.repository | string | `"ghcr.io/scalar-labs/scalar-envoy"` | Docker image |
-| image.version | string | `"1.3.0"` |  |
+| image.version | string | `"2.0.0-SNAPSHOT"` |  |
 | imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | podAnnotations | object | `{}` | Pod annotations for the envoy Deployment |

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -11,7 +11,7 @@ image:
   # image.repository -- Docker image
   repository: ghcr.io/scalar-labs/scalar-envoy
   # image.tag -- Docker tag
-  version: 1.3.0
+  version: 2.0.0-SNAPSHOT
   # image.pullPolicy -- Specify a imagePullPolicy
   pullPolicy: IfNotPresent
 

--- a/charts/scalar-manager/Chart.yaml
+++ b/charts/scalar-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalar-manager
 description: Scalar Manager
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 2.0.0-SNAPSHOT
+appVersion: 2.0.0-SNAPSHOT
 deprecated: false
 keywords:
 - scalardb

--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -1,9 +1,9 @@
 # scalar-manager
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.0.0-SNAPSHOT](https://img.shields.io/badge/Version-2.0.0--SNAPSHOT-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 2.0.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-2.0.0--SNAPSHOT-informational?style=flat-square)
 
 Scalar Manager
-Current chart version is `1.0.0`
+Current chart version is `2.0.0-SNAPSHOT`
 
 **Homepage:** <https://scalar-labs.com/>
 

--- a/charts/scalardb-graphql/Chart.yaml
+++ b/charts/scalardb-graphql/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardb-graphql
 description: ScalarDB GraphQL server
 type: application
-version: 1.3.0
-appVersion: 3.8.0
+version: 2.0.0-SNAPSHOT
+appVersion: 4.0.0-SNAPSHOT
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
 - scalardb

--- a/charts/scalardb-graphql/README.md
+++ b/charts/scalardb-graphql/README.md
@@ -1,7 +1,7 @@
 # scalardb-graphql
 
 ScalarDB GraphQL server
-Current chart version is `1.3.0`
+Current chart version is `2.0.0-SNAPSHOT`
 
 ## Values
 
@@ -14,7 +14,7 @@ Current chart version is `1.3.0`
 | grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | image.repository | string | `"ghcr.io/scalar-labs/scalardb-graphql"` | Docker image reposiory of ScalarDB GraphQL. |
-| image.tag | string | `"3.8.0"` | Docker tag of the image. |
+| image.tag | string | `"4.0.0-SNAPSHOT"` | Docker tag of the image. |
 | imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ingress.annotations | object | `{"alb.ingress.kubernetes.io/healthcheck-path":"/graphql?query=%7B__typename%7D","alb.ingress.kubernetes.io/scheme":"internal","alb.ingress.kubernetes.io/target-group-attributes":"stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60","alb.ingress.kubernetes.io/target-type":"ip","nginx.ingress.kubernetes.io/affinity":"cookie","nginx.ingress.kubernetes.io/session-cookie-hash":"sha1","nginx.ingress.kubernetes.io/session-cookie-max-age":"300","nginx.ingress.kubernetes.io/session-cookie-name":"INGRESSCOOKIE","nginx.ingress.kubernetes.io/session-cookie-path":"/"}` | The class-specific annotations for the ingress resource. |
 | ingress.className | string | `""` | The ingress class name. Specify "alb" for AWS Application Load Balancer. |

--- a/charts/scalardb-graphql/values.yaml
+++ b/charts/scalardb-graphql/values.yaml
@@ -39,7 +39,7 @@ image:
   # -- Specify a image pulling policy.
   pullPolicy: IfNotPresent
   # -- Docker tag of the image.
-  tag: 3.8.0
+  tag: 4.0.0-SNAPSHOT
 
 # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
 imagePullSecrets: [name: reg-docker-secrets]

--- a/charts/scalardb/Chart.lock
+++ b/charts/scalardb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
-  repository: https://scalar-labs.github.io/helm-charts
-  version: 2.2.0
-digest: sha256:2400613e162d0acb575e173d8623a67281e131d0e00b0da7925177e793c13643
-generated: "2022-09-14T12:34:38.629511121+09:00"
+  repository: file://../envoy/
+  version: 3.0.0-SNAPSHOT
+digest: sha256:7f522dc715c13c57b8c9d9fc494ce5928a76a44839c26a9d62d8728927e6547e
+generated: "2023-05-15T14:07:41.699260149+09:00"

--- a/charts/scalardb/Chart.yaml
+++ b/charts/scalardb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardb
 description: ScalarDB server
 type: application
-version: 2.5.0
-appVersion: 3.8.0
+version: 3.0.0-SNAPSHOT
+appVersion: 4.0.0-SNAPSHOT
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,8 +16,8 @@ sources:
   - https://github.com/scalar-labs/scalardb
 dependencies:
 - name: envoy
-  version: ~2.2.0
-  repository: https://scalar-labs.github.io/helm-charts
+  version: ~3.0.0-SNAPSHOT
+  repository: file://../envoy/
   condition: envoy.enabled
 maintainers:
   - name: Takanori Yokoyama

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -1,13 +1,13 @@
 # scalardb
 
 ScalarDB server
-Current chart version is `2.5.0`
+Current chart version is `3.0.0-SNAPSHOT`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.2.0 |
+| file://envoy/ | envoy | ~3.0.0-SNAPSHOT |
 
 ## Values
 
@@ -15,7 +15,7 @@ Current chart version is `2.5.0`
 |-----|------|---------|-------------|
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardb-service:60051"` | list of service name and port |
-| envoy.image.version | string | `"1.3.0"` | Docker tag |
+| envoy.image.version | string | `"2.0.0-SNAPSHOT"` | Docker tag |
 | envoy.nameOverride | string | `"scalardb"` | String to partially override envoy.fullname template |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy.port | int | `60051` | envoy public port |
@@ -33,7 +33,7 @@ Current chart version is `2.5.0`
 | scalardb.grafanaDashboard.namespace | string | `"monitoring"` | Which namespace grafana dashboard is located. by default monitoring. |
 | scalardb.image.pullPolicy | string | `"IfNotPresent"` | Specify a image pulling policy. |
 | scalardb.image.repository | string | `"ghcr.io/scalar-labs/scalardb-server"` | Docker image reposiory of ScalarDB server. |
-| scalardb.image.tag | string | `"3.8.0"` | Docker tag of the image. |
+| scalardb.image.tag | string | `"4.0.0-SNAPSHOT"` | Docker tag of the image. |
 | scalardb.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalardb.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalardb.podAnnotations | object | `{}` | Pod annotations for the scalardb deployment |

--- a/charts/scalardb/README.md
+++ b/charts/scalardb/README.md
@@ -7,7 +7,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://envoy/ | envoy | ~3.0.0-SNAPSHOT |
+| file://../envoy/ | envoy | ~3.0.0-SNAPSHOT |
 
 ## Values
 

--- a/charts/scalardb/values.yaml
+++ b/charts/scalardb/values.yaml
@@ -19,7 +19,7 @@ envoy:
 
   image:
     # -- Docker tag
-    version: 1.3.0
+    version: 2.0.0-SNAPSHOT
 
   service:
     # -- service types in kubernetes
@@ -83,7 +83,7 @@ scalardb:
     # -- Specify a image pulling policy.
     pullPolicy: IfNotPresent
     # -- Docker tag of the image.
-    tag: 3.8.0
+    tag: 4.0.0-SNAPSHOT
 
   # -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: []

--- a/charts/scalardl-audit/Chart.lock
+++ b/charts/scalardl-audit/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
-  repository: https://scalar-labs.github.io/helm-charts
-  version: 2.2.0
-digest: sha256:2400613e162d0acb575e173d8623a67281e131d0e00b0da7925177e793c13643
-generated: "2022-08-04T12:28:27.876461314+09:00"
+  repository: file://../envoy/
+  version: 3.0.0-SNAPSHOT
+digest: sha256:7f522dc715c13c57b8c9d9fc494ce5928a76a44839c26a9d62d8728927e6547e
+generated: "2023-05-15T14:08:03.290947212+09:00"

--- a/charts/scalardl-audit/Chart.yaml
+++ b/charts/scalardl-audit/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl-audit
 description: ScalarDL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
 type: application
-version: 2.5.1
-appVersion: 3.7.1
+version: 3.0.0-SNAPSHOT
+appVersion: 4.0.0-SNAPSHOT
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,8 +16,8 @@ sources:
   - https://github.com/scalar-labs/scalardl
 dependencies:
 - name: envoy
-  version: ~2.2.0
-  repository: https://scalar-labs.github.io/helm-charts
+  version: ~3.0.0-SNAPSHOT
+  repository: file://../envoy/
   condition: envoy.enabled
 maintainers:
   - name: Takanori Yokoyama

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -1,13 +1,13 @@
 # scalardl-audit
 
 ScalarDL is a tamper-evident and scalable distributed database. This chart adds an auditing capability to Ledger (scalardl chart).
-Current chart version is `2.5.1`
+Current chart version is `3.0.0-SNAPSHOT`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.2.0 |
+| file://../envoy/ | envoy | ~3.0.0-SNAPSHOT |
 
 ## Values
 
@@ -22,7 +22,7 @@ Current chart version is `2.5.1`
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | auditor.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | auditor.image.repository | string | `"ghcr.io/scalar-labs/scalar-auditor"` | Docker image |
-| auditor.image.version | string | `"3.7.1"` | Docker tag |
+| auditor.image.version | string | `"4.0.0-SNAPSHOT"` | Docker tag |
 | auditor.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | auditor.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | auditor.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings |
@@ -69,7 +69,7 @@ Current chart version is `2.5.1`
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardl-audit-service:40051,scalardl-audit-privileged:40052"` | list of service name and port |
-| envoy.image.version | string | `"1.3.0"` | Docker tag |
+| envoy.image.version | string | `"2.0.0-SNAPSHOT"` | Docker tag |
 | envoy.nameOverride | string | `"scalardl-audit"` | String to partially override envoy.fullname template |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy-priv.port | int | `40052` | envoy public port |

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -20,7 +20,7 @@ envoy:
 
   image:
     # -- Docker tag
-    version: 1.3.0
+    version: 2.0.0-SNAPSHOT
 
   service:
     # -- service types in kubernetes
@@ -142,7 +142,7 @@ auditor:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-auditor
     # -- Docker tag
-    version: 3.7.1
+    version: 4.0.0-SNAPSHOT
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 

--- a/charts/scalardl/Chart.lock
+++ b/charts/scalardl/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
-  repository: https://scalar-labs.github.io/helm-charts
-  version: 2.2.0
-digest: sha256:2400613e162d0acb575e173d8623a67281e131d0e00b0da7925177e793c13643
-generated: "2022-08-04T12:11:51.570434124+09:00"
+  repository: file://../envoy/
+  version: 3.0.0-SNAPSHOT
+digest: sha256:7f522dc715c13c57b8c9d9fc494ce5928a76a44839c26a9d62d8728927e6547e
+generated: "2023-05-15T14:07:56.66768947+09:00"

--- a/charts/scalardl/Chart.yaml
+++ b/charts/scalardl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalardl
 description: ScalarDL is a tamper-evident and scalable distributed database.
 type: application
-version: 4.5.1
-appVersion: 3.7.1
+version: 5.0.0-SNAPSHOT
+appVersion: 4.0.0-SNAPSHOT
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:
@@ -16,8 +16,8 @@ sources:
   - https://github.com/scalar-labs/scalardl
 dependencies:
 - name: envoy
-  version: ~2.2.0
-  repository: https://scalar-labs.github.io/helm-charts
+  version: ~3.0.0-SNAPSHOT
+  repository: file://../envoy/
   condition: envoy.enabled
 maintainers:
   - name: Takanori Yokoyama

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -1,13 +1,13 @@
 # scalardl
 
 ScalarDL is a tamper-evident and scalable distributed database.
-Current chart version is `4.5.1`
+Current chart version is `5.0.0-SNAPSHOT`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.2.0 |
+| file://../envoy/ | envoy | ~3.0.0-SNAPSHOT |
 
 ## Values
 
@@ -15,7 +15,7 @@ Current chart version is `4.5.1`
 |-----|------|---------|-------------|
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardl-service:50051,scalardl-privileged:50052"` | list of service name and port |
-| envoy.image.version | string | `"1.3.0"` | Docker tag |
+| envoy.image.version | string | `"2.0.0-SNAPSHOT"` | Docker tag |
 | envoy.nameOverride | string | `"scalardl"` | String to partially override envoy.fullname template |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy-priv.port | int | `50052` | nvoy public port |
@@ -34,7 +34,7 @@ Current chart version is `4.5.1`
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
-| ledger.image.version | string | `"3.7.1"` | Docker tag |
+| ledger.image.version | string | `"4.0.0-SNAPSHOT"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.ledgerProperties | string | The default minimum necessary values of ledger.properties are set. You can overwrite it with your own ledger.properties. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -20,7 +20,7 @@ envoy:
 
   image:
     # -- Docker tag
-    version: 1.3.0
+    version: 2.0.0-SNAPSHOT
 
   service:
     # -- service types in kubernetes
@@ -110,7 +110,7 @@ ledger:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger
     # -- Docker tag
-    version: 3.7.1
+    version: 4.0.0-SNAPSHOT
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 

--- a/charts/schema-loading/Chart.yaml
+++ b/charts/schema-loading/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: schema-loading
 description: A schema loading tool for ScalarDL.
 type: application
-version: 2.8.0
-appVersion: 3.7.0
+version: 3.0.0-SNAPSHOT
+appVersion: 4.0.0-SNAPSHOT
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/schema-loading/README.md
+++ b/charts/schema-loading/README.md
@@ -1,7 +1,7 @@
 # schema-loading
 
 A schema loading tool for ScalarDL.
-Current chart version is `2.8.0`
+Current chart version is `3.0.0-SNAPSHOT`
 
 ## Values
 
@@ -19,7 +19,7 @@ Current chart version is `2.8.0`
 | schemaLoading.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | schemaLoading.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | schemaLoading.image.repository | string | `"ghcr.io/scalar-labs/scalardl-schema-loader"` | Docker image |
-| schemaLoading.image.version | string | `"3.7.0"` | Docker tag |
+| schemaLoading.image.version | string | `"4.0.0-SNAPSHOT"` | Docker tag |
 | schemaLoading.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | schemaLoading.password | string | `"cassandra"` | The password of the database. For Cosmos DB, please specify a key here. |
 | schemaLoading.schemaType | string | `"ledger"` | Type of schema to apply (ledger or auditor). |

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -53,7 +53,7 @@ schemaLoading:
     # -- Docker image
     repository: ghcr.io/scalar-labs/scalardl-schema-loader
     # -- Docker tag
-    version: 3.7.0
+    version: 4.0.0-SNAPSHOT
     # -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This PR updates all charts to use SNAPSHOT version container images in the `main` branch (i.e., we will use SNAPSHOT versions container images for development and CI).

Note: The CI will be failed since several charts don't support the following updates yet.
* https://github.com/scalar-labs/scalardb/pull/780
* https://github.com/scalar-labs/scalar/pull/942
* https://github.com/scalar-labs/scalar/pull/947

I will update it in another PR.

Please take a look!