### PR TITLE
[scalardb] Rename properties file to run without dockerize

### DIFF
--- a/charts/scalardb/templates/scalardb/configmap.yaml
+++ b/charts/scalardb/templates/scalardb/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   # Create a database.properties file which is config file of ScalarDB server.
-  database.properties.tmpl:
+  database.properties:
     {{- toYaml .Values.scalardb.databaseProperties | nindent 4 }}
 ---
 {{- if .Values.scalardb.grafanaDashboard.enabled }}

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -92,8 +92,8 @@ spec:
             timeoutSeconds: 1
           volumeMounts:
             - name: scalardb-database-properties-volume
-              mountPath: /scalardb/server/database.properties.tmpl
-              subPath: database.properties.tmpl
+              mountPath: /scalardb/server/database.properties
+              subPath: database.properties
           {{- with .Values.scalardb.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
This PR renames the properties file name.
Note: This PR depends on #215.

Since we removed the `dockerize` command from the container image in the following PR, we need to update the properties file from `*.properties.tmpl` to `*.properties`.
https://github.com/scalar-labs/scalardb/pull/780

Please take a look!