### PR TITLE
[scalardl] Rename properties file to run without dockerize

### DIFF
--- a/charts/scalardl/templates/ledger/configmap.yaml
+++ b/charts/scalardl/templates/ledger/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   # Create a ledger.properties file which is config file of ScalarDL Ledger.
-  ledger.properties.tmpl:
+  ledger.properties:
     {{- toYaml .Values.ledger.ledgerProperties | nindent 4 }}
 ---
 {{- if .Values.ledger.grafanaDashboard.enabled }}

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -59,8 +59,8 @@ spec:
               readOnly: true
           {{- end }}
             - name: scalardl-ledger-properties-volume
-              mountPath: /scalar/ledger/ledger.properties.tmpl
-              subPath: ledger.properties.tmpl
+              mountPath: /scalar/ledger/ledger.properties
+              subPath: ledger.properties
           {{- with .Values.ledger.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
This PR renames the properties file name.
Note: This PR depends on #215.

Since we removed the `dockerize` command from the container image in the following PR, we need to update the properties file from `*.properties.tmpl` to `*.properties`.
https://github.com/scalar-labs/scalar/pull/942

Please take a look!