### PR TITLE
[scalardl-audit] Rename properties file to run without dockerize

### DIFF
--- a/charts/scalardl-audit/templates/auditor/configmap.yaml
+++ b/charts/scalardl-audit/templates/auditor/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   # Create a auditor.properties file which is config file of ScalarDL Auditor.
-  auditor.properties.tmpl:
+  auditor.properties:
     {{- toYaml .Values.auditor.auditorProperties | nindent 4 }}
 ---
 {{- if .Values.auditor.grafanaDashboard.enabled }}

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -59,8 +59,8 @@ spec:
               readOnly: true
           {{- end }}
             - name: scalardl-auditor-properties-volume
-              mountPath: /scalar/auditor/auditor.properties.tmpl
-              subPath: auditor.properties.tmpl
+              mountPath: /scalar/auditor/auditor.properties
+              subPath: auditor.properties
           {{- with .Values.auditor.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
This PR renames the properties file name.
Note: This PR depends on #215.

Since we removed the `dockerize` command from the container image in the following PR, we need to update the properties file from `*.properties.tmpl` to `*.properties`.
https://github.com/scalar-labs/scalar/pull/942

Please take a look!