### PR TITLE
[schema-loading] Rename properties file to run without dockerize

### DIFF
--- a/charts/schema-loading/templates/batchjob-schema-loading.yaml
+++ b/charts/schema-loading/templates/batchjob-schema-loading.yaml
@@ -97,8 +97,8 @@ spec:
       {{- if .Values.schemaLoading.databaseProperties }}
         volumeMounts:
           - name: scalardb-database-properties-volume
-            mountPath: /scalardl-schema-loader/database.properties.tmpl
-            subPath: database.properties.tmpl
+            mountPath: /scalardl-schema-loader/database.properties
+            subPath: database.properties
       volumes:
         - name: scalardb-database-properties-volume
           configMap:

--- a/charts/schema-loading/templates/configmap.yaml
+++ b/charts/schema-loading/templates/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   # Create a database.properties file which is config file of Schema Loader.
-  database.properties.tmpl:
+  database.properties:
     {{- toYaml .Values.schemaLoading.databaseProperties | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
This PR renames the properties file name.
Note: This PR depends on #215.

Since we removed the `dockerize` command from the container image in the following PR, we need to update the properties file from `*.properties.tmpl` to `*.properties`.
https://github.com/scalar-labs/scalar/pull/947

Please take a look!