### PR TITLE
[scalardb] Add readiness and startup probe

### DIFF
--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -87,15 +87,6 @@ spec:
               - -addr=:60051
             failureThreshold: 60
             periodSeconds: 5
-          readinessProbe:
-            exec:
-              command:
-              - /usr/local/bin/grpc_health_probe
-              - -addr=:60051
-            failureThreshold: 3
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           livenessProbe:
             exec:
               command:

--- a/charts/scalardb/templates/scalardb/deployment.yaml
+++ b/charts/scalardb/templates/scalardb/deployment.yaml
@@ -80,13 +80,28 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.scalardb.resources | nindent 12 }}
+          startupProbe:
+            exec:
+              command:
+              - /usr/local/bin/grpc_health_probe
+              - -addr=:60051
+            failureThreshold: 60
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /usr/local/bin/grpc_health_probe
+              - -addr=:60051
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           livenessProbe:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
               - -addr=:60051
             failureThreshold: 3
-            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1


### PR DESCRIPTION
This PR adds `Readiness Probe` and `Startup Probe` in the ScalarDB Server chart.

At this time (no readiness probe), there is a possibility that the CI succeeded even if there are some problems. The `ct` command checks whether the pod status is `Ready`, and if the status is `Ready` it returns `success` in the CI. However, in the current charts, there is no `Readiness Probe` configuration. So, the pod will be the `Ready` status temporarily when the container starts even if the Java process will failed in the container.

As this above, There is a possibility that the `ct` command detects this temporary `Ready` state and returns `success`. To fix this issue, I added `Readiness Probe`. After this update, the pod status will be `Ready` only after ScalarDB Server returns `SERVING` in the gRPC health check. So, the `ct` command can check the status of the Java process in the container properly in the CI.

Also, I added `Startup Probe` instead of `initialDelaySeconds` of `Readiness/Liveness Probe`. This is a better way in the Kubernetes environment.
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

On the other hand, from the perspective of users, this update can increase the reliability of the deployment of Scalar products since Kubernetes runs the health check better way.

Please take a look!