### PR TITLE
[scalardl] Add readiness and startup probe

### DIFF
--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -109,13 +109,28 @@ spec:
           - secretRef:
               name: "{{ .Values.ledger.secretName }}"
           {{- end }}
+          startupProbe:
+            exec:
+              command:
+              - /usr/local/bin/grpc_health_probe
+              - -addr=:50051
+            failureThreshold: 60
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /usr/local/bin/grpc_health_probe
+              - -addr=:50051
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           livenessProbe:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
               - -addr=:50051
             failureThreshold: 3
-            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -116,15 +116,6 @@ spec:
               - -addr=:50051
             failureThreshold: 60
             periodSeconds: 5
-          readinessProbe:
-            exec:
-              command:
-              - /usr/local/bin/grpc_health_probe
-              - -addr=:50051
-            failureThreshold: 3
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
This PR adds `Readiness Probe` and `Startup Probe` in the ScalarDL Ledger chart.

At this time (no readiness probe), there is a possibility that the CI succeeded even if there are some problems. The `ct` command checks whether the pod status is `Ready`, and if the status is `Ready` it returns `success` in the CI. However, in the current charts, there is no `Readiness Probe` configuration. So, the pod will be the `Ready` status temporarily when the container starts even if the Java process will failed in the container.

As this above, There is a possibility that the `ct` command detects this temporary `Ready` state and returns `success`. To fix this issue, I added `Readiness Probe`. After this update, the pod status will be `Ready` only after ScalarDL Ledger returns `SERVING` in the gRPC health check. So, the `ct` command can check the status of the Java process in the container properly in the CI.

Also, I added `Startup Probe` instead of `initialDelaySeconds` of `Readiness/Liveness Probe`. This is a better way in the Kubernetes environment.
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

On the other hand, from the perspective of users, this update can increase the reliability of the deployment of Scalar products since Kubernetes runs the health check better way.

Please take a look!
