### PR TITLE
[scalar-manager] Add probes for health checking

### DIFF
--- a/charts/scalar-manager/templates/deployment.yaml
+++ b/charts/scalar-manager/templates/deployment.yaml
@@ -48,14 +48,6 @@ spec:
               port: {{ .Values.scalarManager.port }}
             failureThreshold: 60
             periodSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.scalarManager.port }}
-            failureThreshold: 3
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/scalar-manager/templates/deployment.yaml
+++ b/charts/scalar-manager/templates/deployment.yaml
@@ -42,3 +42,25 @@ spec:
               value: {{ .Values.scalarManager.grafanaUrl | default "" }}
             - name: REFRESH_INTERVAL
               value: "{{ .Values.scalarManager.refreshInterval }}"
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.scalarManager.port }}
+            failureThreshold: 60
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.scalarManager.port }}
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.scalarManager.port }}
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1

--- a/charts/scalar-manager/templates/deployment.yaml
+++ b/charts/scalar-manager/templates/deployment.yaml
@@ -44,13 +44,13 @@ spec:
               value: "{{ .Values.scalarManager.refreshInterval }}"
           startupProbe:
             httpGet:
-              path: /
+              path: /health
               port: {{ .Values.scalarManager.port }}
             failureThreshold: 60
             periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: {{ .Values.scalarManager.port }}
             failureThreshold: 3
             periodSeconds: 10
@@ -58,7 +58,7 @@ spec:
             timeoutSeconds: 1
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: {{ .Values.scalarManager.port }}
             failureThreshold: 3
             periodSeconds: 10


### PR DESCRIPTION
This PR adds `Probes` in the Scalar Manager chart.

In the current chart, there is no health checking in Scalar Manager deployment. I think this is not good for the production environment. So, I added `Probes` for the health checking of Scalar Manager.

Note: Scalar Manager doesn't have a health check endpoint like `/health`. So, I use `/` for health checking. We are planning to add `/health` endpoint in the Scalar Manager side in the future. After we implement `/health` endpoint in Scalar Manager, I will update this chart again to use that endpoint.

Please take a look!
