### PR TITLE
[scalardb-cluster] Add startup probe in ScalarDB Cluster chart

### DIFF
--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -59,13 +59,19 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.scalardbCluster.resources | nindent 12 }}
+          startupProbe:
+            exec:
+              command:
+                - /usr/local/bin/grpc_health_probe
+                - -addr=:60053
+            failureThreshold: 60
+            periodSeconds: 5
           livenessProbe:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
               - -addr=:60053
             failureThreshold: 3
-            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -75,7 +81,6 @@ spec:
                 - /usr/local/bin/grpc_health_probe
                 - -addr=:60053
             failureThreshold: 3
-            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -75,15 +75,6 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          readinessProbe:
-            exec:
-              command:
-                - /usr/local/bin/grpc_health_probe
-                - -addr=:60053
-            failureThreshold: 3
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           volumeMounts:
             - name: scalardb-cluster-database-properties-volume
               mountPath: /scalardb-cluster/node/scalardb-cluster-node.properties


### PR DESCRIPTION
This PR adds `Startup Probe` in the ScalarDB Cluster chart.

Sometimes, ScalarDB Cluster takes a bit long time to start and return `Ready` state (i.e., `SERVING` in gRPC health check). However the `initialDelaySeconds` of `Readiness/Liveness Probe` is fixed value. In other words, if it takes over 60sec to start process, the pod will be killed by Kubernetes and there is a possibility that the `CrashLoopBackOff`.

To avoid this issue, we can use `Startup Probe` instead of `initialDelaySeconds`. This is a better way in the Kubernetes environment to handle health checking when that pod starting process.
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

We can run the health check before `Readiness/Liveness Probe` starts when the pod starting process by using `Startup Probe`. After only `Startup Probe` succeeded, Kubernetes runs `Readiness/Liveness Probe`. So, we can avoid unexpected pod killing by `Liveness Probe` even if ScalarDB Cluster take a bit long time to starts (I set the timeout 300sec by default).

Please take a look!
