### PR TITLE
[WIP] [schema-loading] Add helm test resources for CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -139,6 +139,7 @@ jobs:
       DOCKER_REGISTRY_PASSWORD: ${{ secrets.CR_PAT }}
       DOCKER_REGISTRY_USERNAME: scalar-git
       DOCKER_REGISTRY_SERVER: ghcr.io
+      KUBERNETES_VERSION: ${{ matrix.k8s }}
     strategy:
       matrix:
         k8s:
@@ -191,11 +192,11 @@ jobs:
 
       - name: Run chart-testing (updated chart)
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        run: ct install --config .github/ct.yaml
+        run: ct install --config .github/ct.yaml --helm-extra-set-args "--set=test.kubectlImageTag=${KUBERNETES_VERSION#v}"
 
       - name: Run chart-testing (all charts)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: ct install --config .github/ct-all.yaml
+        run: ct install --config .github/ct-all.yaml --helm-extra-set-args "--set=test.kubectlImageTag=${KUBERNETES_VERSION#v}"
 
   verify-chart-docs:
     runs-on: ubuntu-latest

--- a/charts/schema-loading/README.md
+++ b/charts/schema-loading/README.md
@@ -25,3 +25,5 @@ Current chart version is `3.0.0-SNAPSHOT`
 | schemaLoading.schemaType | string | `"ledger"` | Type of schema to apply (ledger or auditor). |
 | schemaLoading.secretName | string | `""` | Secret name that includes sensitive data such as credentials. Each secret key is passed to Pod as environment variables using envFrom. |
 | schemaLoading.username | string | `"cassandra"` | The username of the database. (Ignored if the database is `cosmos`.) |
+| test | object | `{"kubectlImageTag":"latest"}` | Testing parameters. Users don't need to set these values. |
+| test.kubectlImageTag | string | `"latest"` | Version of the kubectl command that we use in the helm test. |

--- a/charts/schema-loading/templates/tests/pod.yaml
+++ b/charts/schema-loading/templates/tests/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: "{{ include "schema-loading.fullname" . }}-test-kubectl"
+  labels:
+    {{- include "schema-loading.selectorLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  serviceAccountName: {{ include "schema-loading.fullname" . }}-test-kubectl-sa
+  automountServiceAccountToken: true
+  containers:
+    - name: kubectl
+      image: bitnami/kubectl:{{ .Values.test.kubectlImageTag }}
+      command: ['kubectl']
+      args: ['wait', '--for=condition=complete', '--timeout=60s', 'jobs/{{ include "schema-loading.fullname" . }}']
+  restartPolicy: Never

--- a/charts/schema-loading/templates/tests/role.yaml
+++ b/charts/schema-loading/templates/tests/role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "schema-loading.fullname" . }}-test-kubectl-role
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]

--- a/charts/schema-loading/templates/tests/rolebinding.yaml
+++ b/charts/schema-loading/templates/tests/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "schema-loading.fullname" . }}-test-kubectl-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: {{ include "schema-loading.fullname" . }}-test-kubectl-sa
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ include "schema-loading.fullname" . }}-test-kubectl-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/schema-loading/templates/tests/serviceaccount.yaml
+++ b/charts/schema-loading/templates/tests/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "schema-loading.fullname" . }}-test-kubectl-sa
+  labels:
+    {{- include "schema-loading.labels" . | nindent 4 }}

--- a/charts/schema-loading/values.schema.json
+++ b/charts/schema-loading/values.schema.json
@@ -73,6 +73,14 @@
                     "type": "string"
                 }
             }
+        },
+        "test": {
+            "type": "object",
+            "properties": {
+                "kubectlImageTag": {
+                    "type": "string"
+                }
+            }
         }
     }
 }

--- a/charts/schema-loading/values.yaml
+++ b/charts/schema-loading/values.yaml
@@ -65,3 +65,8 @@ schemaLoading:
 
   # schemaLoading.schemaType -- Type of schema to apply (ledger or auditor).
   schemaType: ledger
+
+# -- Testing parameters. Users don't need to set these values.
+test:
+  # -- Version of the kubectl command that we use in the helm test.
+  kubectlImageTag: latest


### PR DESCRIPTION
This PR adds some resources for the `helm test` command that we run via the `ct` command in the CI.

In the current CI, a test of the ScalarDL Schema Loader chart returns `success` as a result of the test even if the pod returns an error.

1. Run the `helm install` with the `--wait` flag.
1. The job resource is created.
1. The pod of ScalarDL Schema Loader is created via the job resource.
1. The status of the pod temporarily becomes `Ready` for a moment (but not completed yet) after pod creation.
1. The `helm install` command detects this temporary `Ready` of the pod and returns `success`.
1. After the `helm install` command finished with `success`, the pod executes Schema Loader inside of it.
1. If the Schema Loader failed, the pod status moves to `Error`.

Like this, the test of the ScalarDL Schema Loader chart always returns `success` even if the pod will be `Error`. In other words, we should use the `--wait-for-jobs` flag for the test of the ScalarDL Schema Loader chart. If we specify the `--wait-for-jobs` flag to the `helm install` command, it waits for the pod will be `Complete`. So, we can do the test properly if we use the `--wait-for-jobs` flag.
https://helm.sh/docs/helm/helm_install/#options

However, it seems that there is no way to specify the `--wait-for-jobs` in the `ct install` command at this time.
https://github.com/helm/chart-testing/blob/v3.8.0/doc/ct_install.md

Also, there is a `--helm-extra-args` flag that can specify the additional flags in the `ct install` command. However, if we set `--helm-extra-args --wait-for-jobs`, the extra flag also is applied to the `helm test` and `helm uninstall` command as follows.

```shell
>>> helm test schema-loading-5zkxs0fsq3 --namespace default --wait-for-jobs
Error: unknown flag: --wait-for-jobs

>>> helm uninstall schema-loading-5zkxs0fsq3 --namespace default --wait-for-jobs
Error: unknown flag: --wait-for-jobs
```

So, in this case, the test (`ct install`) failed unfortunately. We cannot use this flag.
FYI: This issue is reported in https://github.com/helm/chart-testing/issues/540 .

To resolve this CI issue, I added the test resources for the `helm test` command. This new test runs another pod and run the `kubectl wait --for=condition=complete job/{jobName}` command. By using this way, we can check if the ScalarDL Schema Loader pod is `Complete` or not.

The `ct install` command that runs in the CI processes three steps `helm install --wait` -> `helm test` -> `helm uninstall`. So, the `ct install` command runs the above test process (`helm test`) for the ScalarDL Schema Loader pod in the CI. So, we can do the test properly via the `ct` command in our CI.

Please take a look!

---

FYI: It seems that the `--wait` flag is hardcoded in the following code. So, I think it might be able to create PR to add the `--wait-for-jobs` flag here. But, I think we have to fix this (our) CI issue first.
https://github.com/helm/chart-testing/blob/v3.8.0/pkg/tool/helm.go#L64-L65