### PR TITLE
Add --helm-extra-set-args flag to ct command in CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -191,11 +191,11 @@ jobs:
 
       - name: Run chart-testing (updated chart)
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        run: ct install --config .github/ct.yaml
+        run: ct install --config .github/ct.yaml --helm-extra-set-args "--wait-for-jobs"
 
       - name: Run chart-testing (all charts)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: ct install --config .github/ct-all.yaml
+        run: ct install --config .github/ct-all.yaml --helm-extra-set-args "--wait-for-jobs"
 
   verify-chart-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds the `--helm-extra-set-args` flag for the `ct` command in the CI.

In the current CI, a test of the ScalarDL Schema Loader chart returns `success` as a result of the test even if the pod returns an error.

1. Run the `helm install` with the `--wait` flag.
1. The job resource is created.
1. The pod of ScalarDL Schema Loader is created via the job resource.
1. The status of the pod temporarily becomes `Ready` for a moment (but not completed yet) after pod creation.
1. The `helm install` command detects this temporary `Ready` of the pod and returns `success`.
1. Even after the `helm install` command finished with `success`, the pod executes Schema Loader inside of it.
1. If the Schema Loader failed, the pod status moves to `Error`. (But, the `ct` command doesn't detect it.)

We can resolve this issue by using the `--wait-for-jobs` flag of the `helm install` command. The `--wait-for-jobs` flag waits for the job status will be `Complete`. So, we can check if the job status is `Complete` or not in the test.
https://helm.sh/docs/helm/helm_install/#options

We can set this `--wait-for-jobs` to the `helm install` command via the `--helm-extra-set-args` flag of the `ct` command. We run the `ct` command in the CI, and the `ct` command runs the `helm install` command in its internal processes.

Also, now we use the configuration file to set several flags to the `ct` command. However, it seems that the config file of the `ct` command does not support the `--helm-extra-set-args`. So, I added this flag to the workflow file directly.
https://github.com/helm/chart-testing/blob/v3.8.0/pkg/config/config.go

Please take a look!
