### PR TITLE
Update version of ScalarDB Cluster chart in main branch

### DIFF
--- a/charts/scalardb-cluster/Chart.lock
+++ b/charts/scalardb-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: envoy
-  repository: https://scalar-labs.github.io/helm-charts
-  version: 2.2.0
-digest: sha256:2400613e162d0acb575e173d8623a67281e131d0e00b0da7925177e793c13643
-generated: "2022-09-14T12:34:38.629511121+09:00"
+  repository: file://../envoy/
+  version: 3.0.0-SNAPSHOT
+digest: sha256:7f522dc715c13c57b8c9d9fc494ce5928a76a44839c26a9d62d8728927e6547e
+generated: "2023-05-29T12:18:04.156959826+09:00"

--- a/charts/scalardb-cluster/Chart.yaml
+++ b/charts/scalardb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalardb-cluster
 description: ScalarDB Cluster
 type: application
-version: 1.0.0-SNAPSHOT
+version: 2.0.0-SNAPSHOT
 appVersion: 4.0.0-SNAPSHOT
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
@@ -16,8 +16,8 @@ sources:
   - https://github.com/scalar-labs/scalardb-cluster
 dependencies:
 - name: envoy
-  version: ~2.2.0
-  repository: https://scalar-labs.github.io/helm-charts
+  version: ~3.0.0-SNAPSHOT
+  repository: file://../envoy/
   condition: envoy.enabled
 maintainers:
   - name: Takanori Yokoyama

--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -1,13 +1,13 @@
 # scalardb-cluster
 
 ScalarDB Cluster
-Current chart version is `1.0.0-SNAPSHOT`
+Current chart version is `2.0.0-SNAPSHOT`
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://scalar-labs.github.io/helm-charts | envoy | ~2.2.0 |
+| file://../envoy/ | envoy | ~3.0.0-SNAPSHOT |
 
 ## Values
 
@@ -15,7 +15,7 @@ Current chart version is `1.0.0-SNAPSHOT`
 |-----|------|---------|-------------|
 | envoy.enabled | bool | `false` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardb-cluster-service:60053"` | list of service name and port |
-| envoy.image.version | string | `"1.3.0"` | Docker tag |
+| envoy.image.version | string | `"2.0.0-SNAPSHOT"` | Docker tag |
 | envoy.nameOverride | string | `"scalardb-cluster"` | String to partially override envoy.fullname template |
 | envoy.service.annotations | object | `{}` | Service annotations, e.g: prometheus, etc. |
 | envoy.service.ports.envoy.port | int | `60053` | envoy public port |

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -19,7 +19,7 @@ envoy:
 
   image:
     # -- Docker tag
-    version: 1.3.0
+    version: 2.0.0-SNAPSHOT
 
   service:
     # -- service types in kubernetes


### PR DESCRIPTION
This PR updates the chart version of the ScalarDB Cluster chart in the main branch.

We released `v1.0.0` of the ScalarDB Cluster chart, so I update the version in the main branch from `1.0.0-SNAPSHOT` to `2.0.0-SNAPSHOT`.

Also, before we were developing the ScalarDB Cluster chart in the topic branch, so we cannot access Scalar Envoy's SNAPSHOT version. However, now we merge that topic branch into the main branch and we can use Envoy's SNAPSHOT version. Therefore, I also updated Envoy's version to the SNAPSHOT version.

Please take a look!