### PR TITLE
Update version of k8s and some tools in CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -12,27 +12,27 @@ on:
   workflow_dispatch:
 
 env:
-  HELM_VERSION: v3.5.2
+  HELM_VERSION: v3.11.3
 
 jobs:
   lint-chart:
     runs-on: ubuntu-latest
     env:
-      PYTHON_VERSION: 3.7
+      PYTHON_VERSION: 3.11
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: ${{ env.HELM_VERSION }}
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -41,7 +41,7 @@ jobs:
           helm repo add scalar https://scalar-labs.github.io/helm-charts
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
@@ -49,21 +49,21 @@ jobs:
   kubeaudit-chart:
     runs-on: ubuntu-latest
     env:
-      KUBE_AUDIT_VERSION: 0.16.0
+      KUBE_AUDIT_VERSION: 0.22.0
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: ${{ env.HELM_VERSION }}
 
       - name: Set up kubeaudit
-        uses: supplypike/setup-bin@v1
+        uses: supplypike/setup-bin@v3
         with:
           uri: "https://github.com/Shopify/kubeaudit/releases/download/${{ env.KUBE_AUDIT_VERSION }}/kubeaudit_${{ env.KUBE_AUDIT_VERSION }}_linux_amd64.tar.gz"
           name: "kubeaudit"
@@ -91,20 +91,21 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.21.14
-          - v1.22.15
-          - v1.23.13
-          - v1.24.7
-          - v1.25.3
+          - v1.22.17
+          - v1.23.17
+          - v1.24.13
+          - v1.25.9
+          - v1.26.4
+          - v1.27.2
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: ${{ env.HELM_VERSION }}
 
@@ -142,20 +143,21 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.21.14
-          - v1.22.15
-          - v1.23.13
-          - v1.24.7
-          - v1.25.3
+          - v1.22.17
+          - v1.23.17
+          - v1.24.13
+          - v1.25.9
+          - v1.26.4
+          - v1.27.2
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2
 
       - name: Add Helm repos
         run: |
@@ -170,7 +172,7 @@ jobs:
           fi
 
       - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.7.0
         with:
           config: .github/kind-cluster.yaml
           node_image: kindest/node:${{ matrix.k8s }}
@@ -202,7 +204,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Verify chart docs
         run: ./scripts/verify-chart-docs.sh
@@ -212,7 +214,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Verify values schema json
         run: ./scripts/verify-values-schema-json.sh

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up kubeaudit
         uses: supplypike/setup-bin@v3
         with:
-          uri: "https://github.com/Shopify/kubeaudit/releases/download/${{ env.KUBE_AUDIT_VERSION }}/kubeaudit_${{ env.KUBE_AUDIT_VERSION }}_linux_amd64.tar.gz"
+          uri: "https://github.com/Shopify/kubeaudit/releases/download/v${{ env.KUBE_AUDIT_VERSION }}/kubeaudit_${{ env.KUBE_AUDIT_VERSION }}_linux_amd64.tar.gz"
           name: "kubeaudit"
           version: ${{ env.KUBE_AUDIT_VERSION }}
 

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -176,6 +176,7 @@ jobs:
         with:
           config: .github/kind-cluster.yaml
           node_image: kindest/node:${{ matrix.k8s }}
+          kubectl_version: ${{ matrix.k8s }}
         if: ${{ steps.list-changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch' }}
 
       - name: Setup kubernetes (Kind) with registry, PostgreSQL and schema


### PR DESCRIPTION
This PR updates the version of Kubernetes and some tools in the CI.
After this CI passed, we can support new versions of Kubernetes (v1.26 and v1.27) in our Scalar Helm Chart.

Please take a look!