### PR TITLE
Add --version flag to deploy document

### DIFF
--- a/docs/how-to-deploy-scalar-manager.md
+++ b/docs/how-to-deploy-scalar-manager.md
@@ -30,13 +30,13 @@ helm upgrade <RELEASE_NAME> prometheus-community/kube-prometheus-stack -n <NAMES
 ## Deploy Scalar Manager
 
 ```console
-helm install <RELEASE_NAME> scalar-labs/scalar-manager -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALAR_MANAGER> --version <CHART_VERSION>
+helm install <RELEASE_NAME> scalar-labs/scalar-manager -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALAR_MANAGER> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of Scalar Manager
 
 ```console
-helm upgrade <RELEASE_NAME> scalar-labs/scalar-manager -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALAR_MANAGER> --version <CHART_VERSION>
+helm upgrade <RELEASE_NAME> scalar-labs/scalar-manager -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALAR_MANAGER> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of Scalar Manager

--- a/docs/how-to-deploy-scalar-manager.md
+++ b/docs/how-to-deploy-scalar-manager.md
@@ -24,23 +24,23 @@ grafana:
 If you already have a deployment of kube-prometheus-stack, please upgrade the configuration using the following command.
 
 ```console
-helm upgrade <release name> prometheus-community/kube-prometheus-stack -n <namespace> -f /path/to/<your custom values file for kube-prometheus-stack>
+helm upgrade <RELEASE_NAME> prometheus-community/kube-prometheus-stack -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_KUBE_PROMETHEUS_STACK> --version <CHART_VERSION>
 ```
 
 ## Deploy Scalar Manager
 
 ```console
-helm install <release name> scalar-labs/scalar-manager -n <namespace> -f /path/to/<your custom values file for Scalar Manager>
+helm install <RELEASE_NAME> scalar-labs/scalar-manager -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALAR_MANAGER> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of Scalar Manager
 
 ```console
-helm upgrade <release name> scalar-labs/scalar-manager -n <namespace> -f /path/to/<your custom values file for Scalar Manager>
+helm upgrade <RELEASE_NAME> scalar-labs/scalar-manager -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALAR_MANAGER> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of Scalar Manager
 
 ```console
-helm uninstall <release name> -n <namespace>
+helm uninstall <RELEASE_NAME> -n <NAMESPACE>
 ```

--- a/docs/how-to-deploy-scalar-manager.md
+++ b/docs/how-to-deploy-scalar-manager.md
@@ -24,7 +24,7 @@ grafana:
 If you already have a deployment of kube-prometheus-stack, please upgrade the configuration using the following command.
 
 ```console
-helm upgrade <RELEASE_NAME> prometheus-community/kube-prometheus-stack -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_KUBE_PROMETHEUS_STACK> --version <CHART_VERSION>
+helm upgrade <RELEASE_NAME> prometheus-community/kube-prometheus-stack -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_KUBE_PROMETHEUS_STACK> --version <CHART_VERSION>
 ```
 
 ## Deploy Scalar Manager

--- a/docs/how-to-deploy-scalardb-cluster.md
+++ b/docs/how-to-deploy-scalardb-cluster.md
@@ -5,13 +5,13 @@ This document explains how to deploy ScalarDB Cluster by using Scalar Helm Chart
 ## Deploy ScalarDB Cluster
 
 ```console
-helm install <RELEASE_NAME> scalar-labs/scalardb-cluster -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_CLUSTER> --version <CHART_VERSION>
+helm install <RELEASE_NAME> scalar-labs/scalardb-cluster -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_CLUSTER> --version <CHART_VERSION>
 ```
 
 ## Upgrade a ScalarDB Cluster deployment
 
 ```console
-helm upgrade <RELEASE_NAME> scalar-labs/scalardb-cluster -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_CLUSTER> --version <CHART_VERSION>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardb-cluster -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_CLUSTER> --version <CHART_VERSION>
 ```
 
 ## Delete a ScalarDB Cluster deployment

--- a/docs/how-to-deploy-scalardb-cluster.md
+++ b/docs/how-to-deploy-scalardb-cluster.md
@@ -5,19 +5,19 @@ This document explains how to deploy ScalarDB Cluster by using Scalar Helm Chart
 ## Deploy ScalarDB Cluster
 
 ```console
-helm install <release name> scalar-labs/scalardb-cluster -n <namespace> -f /path/to/<your custom values file for ScalarDB Cluster>
+helm install <RELEASE_NAME> scalar-labs/scalardb-cluster -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_CLUSTER> --version <CHART_VERSION>
 ```
 
 ## Upgrade a ScalarDB Cluster deployment
 
 ```console
-helm upgrade <release name> scalar-labs/scalardb-cluster -n <namespace> -f /path/to/<your custom values file for ScalarDB Cluster>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardb-cluster -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_CLUSTER> --version <CHART_VERSION>
 ```
 
 ## Delete a ScalarDB Cluster deployment
 
 ```console
-helm uninstall <release name> -n <namespace>
+helm uninstall <RELEASE_NAME> -n <NAMESPACE>
 ```
 
 ## Deploy your client application on Kubernetes with `direct-kubernetes` mode

--- a/docs/how-to-deploy-scalardb-graphql.md
+++ b/docs/how-to-deploy-scalardb-graphql.md
@@ -17,13 +17,13 @@ Please deploy ScalarDB Server before you deploy ScalarDB GraphQL according to th
 ## Deploy ScalarDB GraphQL
 
 ```console
-helm install <RELEASE_NAME> scalar-labs/scalardb-graphql -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_GRAPHQL> --version <CHART_VERSION>
+helm install <RELEASE_NAME> scalar-labs/scalardb-graphql -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_GRAPHQL> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of ScalarDB GraphQL
 
 ```console
-helm upgrade <RELEASE_NAME> scalar-labs/scalardb-graphql -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_GRAPHQL> --version <CHART_VERSION>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardb-graphql -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_GRAPHQL> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of ScalarDB GraphQL

--- a/docs/how-to-deploy-scalardb-graphql.md
+++ b/docs/how-to-deploy-scalardb-graphql.md
@@ -17,17 +17,17 @@ Please deploy ScalarDB Server before you deploy ScalarDB GraphQL according to th
 ## Deploy ScalarDB GraphQL
 
 ```console
-helm install <release name> scalar-labs/scalardb-graphql -n <namespace> -f /path/to/<your custom values file for ScalarDB GraphQL>
+helm install <RELEASE_NAME> scalar-labs/scalardb-graphql -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_GRAPHQL> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of ScalarDB GraphQL
 
 ```console
-helm upgrade <release name> scalar-labs/scalardb-graphql -n <namespace> -f /path/to/<your custom values file for ScalarDB GraphQL>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardb-graphql -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_GRAPHQL> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of ScalarDB GraphQL
 
 ```console
-helm uninstall <release name> -n <namespace>
+helm uninstall <RELEASE_NAME> -n <NAMESPACE>
 ```

--- a/docs/how-to-deploy-scalardb.md
+++ b/docs/how-to-deploy-scalardb.md
@@ -7,13 +7,13 @@ This document explains how to deploy ScalarDB Server using Scalar Helm Charts. Y
 ## Deploy ScalarDB Server
 
 ```console
-helm install <RELEASE_NAME> scalar-labs/scalardb -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_SERVER> --version <CHART_VERSION>
+helm install <RELEASE_NAME> scalar-labs/scalardb -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_SERVER> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of ScalarDB Server
 
 ```console
-helm upgrade <RELEASE_NAME> scalar-labs/scalardb -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_SERVER> --version <CHART_VERSION>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardb -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_SERVER> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of ScalarDB Server

--- a/docs/how-to-deploy-scalardb.md
+++ b/docs/how-to-deploy-scalardb.md
@@ -7,17 +7,17 @@ This document explains how to deploy ScalarDB Server using Scalar Helm Charts. Y
 ## Deploy ScalarDB Server
 
 ```console
-helm install <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server>
+helm install <RELEASE_NAME> scalar-labs/scalardb -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_SERVER> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of ScalarDB Server
 
 ```console
-helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardb -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDB_SERVER> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of ScalarDB Server
 
 ```console
-helm uninstall <release name> -n <namespace>
+helm uninstall <RELEASE_NAME> -n <NAMESPACE>
 ```

--- a/docs/how-to-deploy-scalardl-auditor.md
+++ b/docs/how-to-deploy-scalardl-auditor.md
@@ -16,19 +16,19 @@ For more details on how to mount the key and certificate files on the ScalarDL p
 Before you deploy ScalarDL Auditor, you must create schemas for ScalarDL Auditor on the backend database.
 
 ```console
-helm install <RELEASE_NAME> scalar-labs/schema-loading -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_SCHEMA_LOADER> --version <CHART_VERSION>
+helm install <RELEASE_NAME> scalar-labs/schema-loading -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_SCHEMA_LOADER> --version <CHART_VERSION>
 ```
 
 ## Deploy ScalarDL Auditor
 
 ```console
-helm install <RELEASE_NAME> scalar-labs/scalardl-audit -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_AUDITOR> --version <CHART_VERSION>
+helm install <RELEASE_NAME> scalar-labs/scalardl-audit -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_AUDITOR> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of ScalarDL Auditor
 
 ```console
-helm upgrade <RELEASE_NAME> scalar-labs/scalardl-audit -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_AUDITOR> --version <CHART_VERSION>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardl-audit -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_AUDITOR> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of ScalarDL Auditor and ScalarDL Schema Loader

--- a/docs/how-to-deploy-scalardl-auditor.md
+++ b/docs/how-to-deploy-scalardl-auditor.md
@@ -16,23 +16,23 @@ For more details on how to mount the key and certificate files on the ScalarDL p
 Before you deploy ScalarDL Auditor, you must create schemas for ScalarDL Auditor on the backend database.
 
 ```console
-helm install <release name> scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader>
+helm install <RELEASE_NAME> scalar-labs/schema-loading -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_SCHEMA_LOADER> --version <CHART_VERSION>
 ```
 
 ## Deploy ScalarDL Auditor
 
 ```console
-helm install <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor>
+helm install <RELEASE_NAME> scalar-labs/scalardl-audit -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_AUDITOR> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of ScalarDL Auditor
 
 ```console
-helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardl-audit -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_AUDITOR> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of ScalarDL Auditor and ScalarDL Schema Loader
 
 ```console
-helm uninstall <release name> -n <namespace>
+helm uninstall <RELEASE_NAME> -n <NAMESPACE>
 ```

--- a/docs/how-to-deploy-scalardl-ledger.md
+++ b/docs/how-to-deploy-scalardl-ledger.md
@@ -18,19 +18,19 @@ Please refer to the following document for more details on how to mount the key/
 Before you deploy ScalarDL Ledger, you must create schemas for ScalarDL Ledger on the backend database.
 
 ```console
-helm install <RELEASE_NAME> scalar-labs/schema-loading -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_SCHEMA_LOADER> --version <CHART_VERSION>
+helm install <RELEASE_NAME> scalar-labs/schema-loading -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_SCHEMA_LOADER> --version <CHART_VERSION>
 ```
 
 ## Deploy ScalarDL Ledger
 
 ```console
-helm install <RELEASE_NAME> scalar-labs/scalardl -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_LEDGER> --version <CHART_VERSION>
+helm install <RELEASE_NAME> scalar-labs/scalardl -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_LEDGER> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of ScalarDL Ledger
 
 ```console
-helm upgrade <RELEASE_NAME> scalar-labs/scalardl -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_LEDGER> --version <CHART_VERSION>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardl -n <NAMESPACE> -f /<PATH_TO_YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_LEDGER> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of ScalarDL Ledger and ScalarDL Schema Loader

--- a/docs/how-to-deploy-scalardl-ledger.md
+++ b/docs/how-to-deploy-scalardl-ledger.md
@@ -18,23 +18,23 @@ Please refer to the following document for more details on how to mount the key/
 Before you deploy ScalarDL Ledger, you must create schemas for ScalarDL Ledger on the backend database.
 
 ```console
-helm install <release name> scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader>
+helm install <RELEASE_NAME> scalar-labs/schema-loading -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_SCHEMA_LOADER> --version <CHART_VERSION>
 ```
 
 ## Deploy ScalarDL Ledger
 
 ```console
-helm install <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger>
+helm install <RELEASE_NAME> scalar-labs/scalardl -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_LEDGER> --version <CHART_VERSION>
 ```
 
 ## Upgrade the deployment of ScalarDL Ledger
 
 ```console
-helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger>
+helm upgrade <RELEASE_NAME> scalar-labs/scalardl -n <NAMESPACE> -f /path/to/<YOUR_CUSTOM_VALUES_FILE_FOR_SCALARDL_LEDGER> --version <CHART_VERSION>
 ```
 
 ## Delete the deployment of ScalarDL Ledger and ScalarDL Schema Loader
 
 ```console
-helm uninstall <release name> -n <namespace>
+helm uninstall <RELEASE_NAME> -n <NAMESPACE>
 ```


### PR DESCRIPTION
This PR adds the `--version` flag in the documents `How to deploy XXXX`.

If we don't specify this `--version` flag, helm uses the latest version automatically. However, there is a possibility that it causes upgrading Scalar products and Charts by accident.

To avoid upgrading by accident, it is better to specify the `--version` flag to use the same version explicitly in the same environment/system.

So, I added the `--version` flag in the documents.

Please take a look!