### PR TITLE
Fix here documents to support zsh

### DIFF
--- a/docs/getting-started-scalardb.md
+++ b/docs/getting-started-scalardb.md
@@ -96,7 +96,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
      ```console
-     cat << EOF > scalardb-custom-values.yaml
+     cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
        image:
          repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-envoy"
@@ -120,7 +120,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
    * Azure Marketplace
      ```console
-     cat << EOF > scalardb-custom-values.yaml
+     cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
        image:
          repository: "<your private container registry>/scalarinc/scalardb-envoy"
@@ -272,7 +272,7 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
    ```console
-   cat << EOF > scalardb.properties
+   cat << 'EOF' > scalardb.properties
    scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
    scalar.db.contact_port=60051
    scalar.db.storage=grpc
@@ -282,7 +282,7 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
    ```console
-   cat << EOF > emoney-transaction.json
+   cat << 'EOF' > emoney-transaction.json
    {
      "emoney.account": {
        "transaction": true,

--- a/docs/getting-started-scalardl-auditor.md
+++ b/docs/getting-started-scalardl-auditor.md
@@ -121,7 +121,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
 
 1. Create a JSON file that includes Ledger information.
    ```console
-   cat << EOF > ~/scalardl-test/certs/ledger.json
+   cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
        "CN": "ledger",
        "hosts": ["example.com","*.example.com"],
@@ -144,7 +144,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
 
 1. Create a JSON file that includes Auditor information.
    ```console
-   cat << EOF > ~/scalardl-test/certs/auditor.json
+   cat << 'EOF' > ~/scalardl-test/certs/auditor.json
    {
        "CN": "auditor",
        "hosts": ["example.com","*.example.com"],
@@ -167,7 +167,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
 
 1. Create a JSON file that includes Client information.
    ```console
-   cat << EOF > ~/scalardl-test/certs/client.json
+   cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
        "CN": "client",
        "hosts": ["example.com","*.example.com"],
@@ -262,7 +262,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
        schemaType: "ledger"
        image:
@@ -280,7 +280,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
    * Azure Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
        schemaType: "ledger"
        image:
@@ -300,7 +300,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
        schemaType: "auditor"
        image:
@@ -318,7 +318,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
    * Azure Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
        schemaType: "auditor"
        image:
@@ -378,7 +378,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/scalardl-ledger-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
        image:
          repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger-envoy"
@@ -413,7 +413,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
    * Azure Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/scalardl-ledger-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
        image:
          repository: "<your private container registry>/scalarinc/scalardl-envoy"
@@ -449,7 +449,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/scalardl-auditor-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
        image:
          repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor-envoy"
@@ -484,7 +484,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
    * Azure Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/scalardl-auditor-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
        image:
          repository: "<your private container registry>/scalarinc/scalardl-envoy"
@@ -598,7 +598,7 @@ We will use certificate files in a Client container. So, we create a secret reso
 
 1. Start a Client container on the Kubernetes cluster.
    ```console
-   cat << EOF | kubectl apply -f -
+   cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
    kind: Pod
    metadata:
@@ -712,7 +712,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
    ```console
-   cat << EOF > ledger.as.client.properties
+   cat << 'EOF' > ledger.as.client.properties
    # Ledger
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
    
@@ -729,7 +729,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
    ```console
-   cat << EOF > auditor.as.client.properties
+   cat << 'EOF' > auditor.as.client.properties
    # Ledger
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
    
@@ -746,7 +746,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
    ```console
-   cat << EOF > client.properties
+   cat << 'EOF' > client.properties
    # Ledger
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
    

--- a/docs/getting-started-scalardl-ledger.md
+++ b/docs/getting-started-scalardl-ledger.md
@@ -95,7 +95,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
 
 1. Create a JSON file that includes Ledger information.
    ```console
-   cat << EOF > ~/scalardl-test/certs/ledger.json
+   cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
        "CN": "ledger",
        "hosts": ["example.com","*.example.com"],
@@ -118,7 +118,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
 
 1. Create a JSON file that includes Client information.
    ```console
-   cat << EOF > ~/scalardl-test/certs/client.json
+   cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
        "CN": "client",
        "hosts": ["example.com","*.example.com"],
@@ -204,7 +204,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
        schemaType: "ledger"
        image:
@@ -222,7 +222,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
    * Azure Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
        schemaType: "ledger"
        image:
@@ -268,7 +268,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/scalardl-ledger-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
        image:
          repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger-envoy"
@@ -302,7 +302,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
    * Azure Marketplace
      ```console
-     cat << EOF > ~/scalardl-test/scalardl-ledger-custom-values.yaml
+     cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
        image:
          repository: "<your private container registry>/scalarinc/scalardl-envoy"
@@ -391,7 +391,7 @@ We will use certificate files in a Client container. So, we create a secret reso
 
 1. Start a Client container on the Kubernetes cluster.
    ```console
-   cat << EOF | kubectl apply -f -
+   cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
    kind: Pod
    metadata:
@@ -489,7 +489,7 @@ The following explains the minimum steps. If you want to know more details about
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
    ```console
-   cat << EOF > client.properties
+   cat << 'EOF' > client.properties
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
    scalar.dl.client.cert_holder_id=client
    scalar.dl.client.cert_path=/keys/certificate


### PR DESCRIPTION
This PR fixes the `here documents` to support zsh environment.
This issue was reported in another PR https://github.com/scalar-labs/scalardb-cluster/pull/102#discussion_r1246368249.

Please take a look!