### PR TITLE
[scalardb-cluster] Fix environment variable name for log level

### DIFF
--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             value: {{ .Release.Namespace }}
           - name: SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
             value: {{ include "scalardb-cluster.fullname" . }}-headless
-          - name: SCALAR_DB_LOG_LEVEL
+          - name: SCALAR_DB_CLUSTER_LOG_LEVEL
             value: "{{ .Values.scalardbCluster.logLevel }}"
           {{- if .Values.scalardbCluster.secretName }}
           envFrom:


### PR DESCRIPTION
This PR fixes the environment variable name that we use for setting of log level.
In the `log4j2.properties` file, ScalarDB Cluster uses the environment variable `SCALAR_DB_CLUSTER_LOG_LEVEL`.
https://github.com/scalar-labs/scalardb-cluster/blob/v3.10.1/node/conf/log4j2.properties

So, we must use this environment variable name in the Helm Chart for ScalarDB Clsuter.

Please take a look!