### PR TITLE
Change link for "Getting Started with ScalarDB"

### DIFF
--- a/docs/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/configure-custom-values-scalardl-schema-loader.md
@@ -22,7 +22,7 @@ If you use AWS/Azure Marketplace, please refer to the following documents for mo
 
 ### Database configurations
 
-You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for more details on the database configuration of ScalarDB.
+You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for more details on the database configuration of ScalarDB.
 
 ```yaml
 schemaLoading:


### PR DESCRIPTION
This PR changes the link for the "Getting Started with ScalarDB" doc, which we updated in https://github.com/scalar-labs/scalardb/pull/990. The previous doc no longer exists, so that's why we need to update this link.