### PR TITLE
Update supported Kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This directory contains the following helm charts.
 
 ## Supported Kubernetes versions
 
-* 1.25.x, 1.24.x, 1.23.x, 1.22.x, 1.21.x
+* 1.27.x, 1.26.x, 1.25.x, 1.24.x, 1.23.x
 
 ## Usage
 

--- a/docs/how-to-deploy-scalar-products.md
+++ b/docs/how-to-deploy-scalar-products.md
@@ -25,7 +25,7 @@ You must prepare a Kubernetes cluster for the deployment of Scalar products. If 
 
 * [scalar-labs/scalar-kubernetes](https://github.com/scalar-labs/scalar-kubernetes/blob/master/README.md)
 
-You must prepare a Kubernetes with supported versions. See [Supported Kubernetes versions](https://github.com/scalar-labs/helm-charts#supported-kubernetes-versions) for the versions that Scalar Helm Chart supports.
+You must prepare a supported version of Kubernetes. For versions that Scalar Helm Charts supports, see [Supported Kubernetes versions](https://github.com/scalar-labs/helm-charts#supported-kubernetes-versions).
 
 ### Prepare a database (ScalarDB, ScalarDL Ledger, ScalarDL Auditor)
 

--- a/docs/how-to-deploy-scalar-products.md
+++ b/docs/how-to-deploy-scalar-products.md
@@ -25,6 +25,8 @@ You must prepare a Kubernetes cluster for the deployment of Scalar products. If 
 
 * [scalar-labs/scalar-kubernetes](https://github.com/scalar-labs/scalar-kubernetes/blob/master/README.md)
 
+You must prepare a Kubernetes with supported versions. See [Supported Kubernetes versions](https://github.com/scalar-labs/helm-charts#supported-kubernetes-versions) for the versions that Scalar Helm Chart supports.
+
 ### Prepare a database (ScalarDB, ScalarDL Ledger, ScalarDL Auditor)
 
 You must prepare a database as a backend storage of ScalarDB/ScalarDL. You can see the supported databases by ScalarDB/ScalarDL in the following document.


### PR DESCRIPTION
This PR updates the supported Kubernetes version.

At this time, each managed Kubernetes service supports the following versions.

* [EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
  * v1.23 - v1.27
* [AKS](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions)
  * v1.25 - v1.28

So, I updated the supported Kubernetes versions that the Scalar Helm Chart supports based on the above versions.

Also, we test these new versions in our CI as follows.
https://github.com/scalar-labs/helm-charts/actions/runs/6155343603

Please take a look!
