### PR TITLE
Fix broken link in configure ScalarDB Cluster doc

### DIFF
--- a/docs/configure-custom-values-scalardb-cluster.md
+++ b/docs/configure-custom-values-scalardb-cluster.md
@@ -17,7 +17,7 @@ scalardbCluster:
 
 ### Database configurations
 
-You must set `scalardbCluster.scalardbClusterNodeProperties`. Please set `scalardb-cluster-node.properties` to this parameter. For more details on the configurations of ScalarDB Cluster, see [Configurations](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/index.md#configurations).
+You must set `scalardbCluster.scalardbClusterNodeProperties`. Please set `scalardb-cluster-node.properties` to this parameter. For more details on the configurations of ScalarDB Cluster, see [ScalarDB Cluster Configurations](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-cluster-configurations.md).
 
 ```yaml
 scalardbCluster:


### PR DESCRIPTION
This PR fixes the broken link in the document.
The linked document was updated before.
Please take a look!

---

@josh-wong 
I have one question about the document.

We can see the same document in both GitHub and Scalar Doc Site as follows.

- https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-cluster-configurations.md
- https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-cluster-configurations/

In this case, which URL should we set in the document if we want to link other documents from a document?

In this PR I used GitHub's URL. Is it OK to use GitHub's URL when I link some other documents from one document?

If we should use the Scalar Doc Site URL, I will update this PR.