### PR TITLE
Update CI to fix error of "ct lint" command

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -43,8 +43,16 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2
 
-      - name: Run chart-testing (lint)
+      - name: Confirm ct command version (for testing)
+        run: ct version
+
+      - name: Run chart-testing (updated chart)
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: ct lint --config .github/ct.yaml
+
+      - name: Run chart-testing (all charts)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: ct lint --config .github/ct-all.yaml
 
   kubeaudit-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2
+        with:
+          version: 3.10.1
 
       - name: Confirm ct command version (for testing)
         run: ct version

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -45,9 +45,6 @@ jobs:
         with:
           version: 3.10.1
 
-      - name: Confirm ct command version (for testing)
-        run: ct version
-
       - name: Run chart-testing (updated chart)
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: ct lint --config .github/ct.yaml


### PR DESCRIPTION
## Description

This PR fixes the following two issues.

### Error of `ct lint` command in the CI

At this time, the `helm lint` command that is called in the `ct lint` command fail as follows.

```console
>>> helm lint charts/scalardb-analytics-postgresql --values charts/scalardb-analytics-postgresql/ci/scalardb-analytics-postgresql-ct-values.yaml --timeout 300s
Error: unknown flag: --timeout
Error: failed linting charts: failed processing charts
```

The root cause is `the ct command cannot treat extra args properly`. In other words, `ct lint` command passes the invalid option `--timeout` to the `helm lint` command. The `--timeout` is supported in `helm install` or `helm uninstall` etc. But, `helm lint` does not support `--timeout` option. So, the `helm lint` command that called via `ct lint` with `--timeout` option (invalid option) failed as above.

This issue is fixed in the following PR on the `ct` side. The latest (v3.10.1) `ct` command can treat extra args for `helm install` and `helm lint` respectively. In other words, `ct lint` command does not pass the invalid option `--timeout` to the `helm lint` command.

https://github.com/helm/chart-testing/pull/605/files

Also, it seems that the latest action of `helm/chart-testing-action@v2` does not support `ct v3.10.1` yet. So, to fix this issue, I specified the latest version explicitly in the CI.
(I think we can remove this specifying version in the future after the latest action supports the latest ct (v3.10.1).)

### CI don't test all charts when we trigger CI from Web UI

If we run this CI via Web UI (i.e., run with the `workflow_dispatch` trigger), we assume that the `ct` command checks all charts.

In the current CI, `ct install` (testing for actual deployment) works against all charts. However, `ct lint` (testing for yaml syntax check) does not work against all charts.

So, I added a new `if` statement to run the `ct lint` against all charts when we trigger this CI with `workflow_dispatch`.

## Related issues and/or PRs

N/A

## Changes made

* Specify the version of the `ct` command explicitly.
* Add a new `if` statement to run the `ct` command against all charts when we run this CI with the `workflow_dispatch` trigger.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I ran this new CI manually, and it worked properly as follows.
https://github.com/scalar-labs/helm-charts/actions/runs/6807941663/job/18511581758

You can see the result of the `ct lint` command against all charts in the `Run chart-testing (all charts)` section as follows.

```console
------------------------------------------------------------------------------------------------------------------------
 ✔︎ envoy => (version: "3.0.0-SNAPSHOT", path: "charts/envoy")
 ✔︎ scalar-manager => (version: "2.0.0-SNAPSHOT", path: "charts/scalar-manager")
 ✔︎ scalardb => (version: "3.0.0-SNAPSHOT", path: "charts/scalardb")
 ✔︎ scalardb-cluster => (version: "2.0.0-SNAPSHOT", path: "charts/scalardb-cluster")
 ✔︎ scalardb-graphql => (version: "2.0.0-SNAPSHOT", path: "charts/scalardb-graphql")
 ✔︎ scalardl => (version: "5.0.0-SNAPSHOT", path: "charts/scalardl")
 ✔︎ scalardl-audit => (version: "3.0.0-SNAPSHOT", path: "charts/scalardl-audit")
 ✔︎ schema-loading => (version: "3.0.0-SNAPSHOT", path: "charts/schema-loading")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

## Release notes

N/A
