### PR TITLE
Revise the `Getting Started Monitoring` guide to support Scalar Manager

### DIFF
--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -36,7 +36,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 ## Step 2. Prepare a custom values file
 
-1. Get the sample file [scalar-prometheus-custom-values.yaml](./conf/scalar-prometheus-custom-values.yaml) for `kube-prometheus-stack`.
+1. Save the sample file [scalar-prometheus-custom-values.yaml](./conf/scalar-prometheus-custom-values.yaml) for `kube-prometheus-stack`.
 
 1. Add custom values in the `scalar-prometheus-custom-values.yaml` as follows.
    * settings

--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -72,8 +72,8 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * If you want to customize the Prometheus Operator deployment by using Helm Charts, you'll need to set the following configurations to monitor Scalar products:
            * Set `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` to `false` (`true` by default) so that Prometheus Operator can detect `ServiceMonitor` and `PrometheusRule` for Scalar products.
 
-       * If you use Scalar Manager, you need to set the following configurations to support Scalar Manager to collect CPU and memory resources.
-           * The `kubeStateMetrics.enabled`, `nodeExporter.enabled`, and `kubelet.enabled` must be set to `true`.
+       * If you want to use Scalar Manager, you'll need to set the following configurations to enable Scalar Manager to collect CPU and memory resources:
+           * Set `kubeStateMetrics.enabled`, `nodeExporter.enabled`, and `kubelet.enabled` to `true`.
 
 ## Step 3. Deploy `kube-prometheus-stack`
 

--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -69,8 +69,8 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
      ...
      ```
    * Note:
-       * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
-           * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
+       * If you want to customize the Prometheus Operator deployment by using Helm Charts, you'll need to set the following configurations to monitor Scalar products:
+           * Set `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` to `false` (`true` by default) so that Prometheus Operator can detect `ServiceMonitor` and `PrometheusRule` for Scalar products.
 
        * If you use Scalar Manager, you need to set the following configurations to support Scalar Manager to collect CPU and memory resources.
            * The `kubeStateMetrics.enabled`, `nodeExporter.enabled`, and `kubelet.enabled` must be set to `true`.

--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -36,7 +36,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 ## Step 2. Prepare a custom values file
 
-1. Get the sample file [scalar-prometheus-custom-values.yaml](./conf/scalar-prometheus-custom-values.yaml) for `kube-prometheus-stack`.  
+1. Get the sample file [scalar-prometheus-custom-values.yaml](./conf/scalar-prometheus-custom-values.yaml) for `kube-prometheus-stack`.
 
 1. Add custom values in the `scalar-prometheus-custom-values.yaml` as follows.
    * settings
@@ -47,30 +47,33 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
    * Example
      ```yaml
      alertmanager:
-     
+
        service:
          type: LoadBalancer
-     
+
      ...
-     
+
      grafana:
-     
+
        service:
          type: LoadBalancer
          port: 3000
-     
+
      ...
-     
+
      prometheus:
-     
+
        service:
          type: LoadBalancer
-     
+
      ...
      ```
    * Note:
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
+
+       * If you use Scalar Manager, you need to set the following configurations to support Scalar Manager to collect CPU and memory resources.
+           * The `kubeStateMetrics.enabled`, `nodeExporter.enabled`, and `kubelet.enabled` must be set to `true` must be set to `true`.
 
 ## Step 3. Deploy `kube-prometheus-stack`
 
@@ -91,7 +94,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
-* Note: 
+* Note:
    * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
        * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
        * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
@@ -112,7 +115,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
              enabled: true
            serviceMonitor:
              enabled: true
-         
+
          scalardb:
            prometheusRule:
              enabled: true
@@ -130,7 +133,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
              enabled: true
            serviceMonitor:
              enabled: true
-         
+
          ledger:
            prometheusRule:
              enabled: true
@@ -148,7 +151,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
              enabled: true
            serviceMonitor:
              enabled: true
-         
+
          auditor:
            prometheusRule:
              enabled: true

--- a/docs/getting-started-monitoring.md
+++ b/docs/getting-started-monitoring.md
@@ -73,7 +73,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
 
        * If you use Scalar Manager, you need to set the following configurations to support Scalar Manager to collect CPU and memory resources.
-           * The `kubeStateMetrics.enabled`, `nodeExporter.enabled`, and `kubelet.enabled` must be set to `true` must be set to `true`.
+           * The `kubeStateMetrics.enabled`, `nodeExporter.enabled`, and `kubelet.enabled` must be set to `true`.
 
 ## Step 3. Deploy `kube-prometheus-stack`
 


### PR DESCRIPTION
## Description

This PR revised the "Getting Started with Helm Charts (Monitoring using Prometheus Operator)" document to add the description about supporting Scalar Manager to collect CPU and memory resources.

Scalar Manager relies on Prometheus Stack to do so and some configurations need to be set correctly.

## Related issues and/or PRs

N/A

## Changes made

- revised https://github.com/scalar-labs/helm-charts/blob/main/docs/getting-started-monitoring.md

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Release notes

Added description to "Getting Started with Helm Charts (Monitoring using Prometheus Operator)" to support Scalar Manager to collect the CPU and memory resources
