### PR TITLE
Revise scalar-loki-stack-custom-values.yaml to scrape the logs of scalar-admin-for-kubernetes

### DIFF
--- a/docs/conf/scalar-loki-stack-custom-values.yaml
+++ b/docs/conf/scalar-loki-stack-custom-values.yaml
@@ -57,6 +57,7 @@ promtail:
         - job_name: scalar-admin-for-kubernetes
           pipeline_stages:
             - docker: {}
+            - cri: {}
           kubernetes_sd_configs:
             - role: pod
           relabel_configs:

--- a/docs/conf/scalar-loki-stack-custom-values.yaml
+++ b/docs/conf/scalar-loki-stack-custom-values.yaml
@@ -53,3 +53,27 @@ promtail:
                 - __meta_kubernetes_pod_uid
                 - __meta_kubernetes_pod_container_name
               target_label: __path__
+        # -- the `scalar-admin-for-kubernetes` job scrapes all the logs of Scalar Admin for Kubernetes Pods
+        - job_name: scalar-admin-for-kubernetes
+          pipeline_stages:
+            - docker: {}
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: __host__
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod
+            - action: keep
+              regex: (.*)scalar-admin-for-kubernetes-(.+)
+              source_labels:
+                - pod
+            - replacement: /var/log/pods/*$1/*.log
+              separator: /
+              source_labels:
+                - __meta_kubernetes_pod_uid
+                - __meta_kubernetes_pod_container_name
+              target_label: __path__


### PR DESCRIPTION
## Description

This PR adds a configuration to `scalar-loki-stack-custom-values.yaml` to make Loki to scrape the logs of the pods that run scalar-admin-for-kubernetes. This is an important configuration because the results of scalar-admin-for-kubernetes are displayed as logs.

## Related issues and/or PRs

N/A

## Changes made

- revised `scalar-loki-stack-custom-values.yaml`

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.
