### PR TITLE
[envoy] Support TLS in Scalar Envoy chart

### DIFF
--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -45,11 +45,11 @@ Current chart version is `3.0.0-SNAPSHOT`
 | strategy.rollingUpdate | object | `{"maxSurge":"25%","maxUnavailable":"25%"}` | The number of pods that can be unavailable during the update process |
 | strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | tls.downstream | object | `{"certChainSecret":"","enabled":false,"privateKeySecret":""}` | TLS configuration between client and Envoy. |
-| tls.downstream.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| tls.downstream.certChainSecret | string | `""` | Name of the Secret containing the certificate chain file used for TLS communication. |
 | tls.downstream.enabled | bool | `false` | Enable TLS between client and Envoy. |
-| tls.downstream.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
+| tls.downstream.privateKeySecret | string | `""` | Name of the Secret containing the private key file used for TLS communication. |
 | tls.upstream | object | `{"caRootCertSecret":"","enabled":false,"overrideAuthority":""}` | TLS configuration between Envoy and ScalarDB Cluster or ScalarDL. |
-| tls.upstream.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
+| tls.upstream.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
 | tls.upstream.enabled | bool | `false` | Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL. |
-| tls.upstream.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL. |
+| tls.upstream.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `scalardbCluster.tls.certChainSecret`, `ledger.tls.certChainSecret`, or `auditor.tls.certChainSecret`. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL. |
 | tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -48,6 +48,8 @@ Current chart version is `3.0.0-SNAPSHOT`
 | tls.downstreamTls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
 | tls.downstreamTls.enabled | bool | `false` | Enable TLS between client and Envoy. |
 | tls.downstreamTls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
-| tls.upstreamTls | object | `{"enabled":false}` | TLS configuration between Envoy and ScalarDB Cluster or ScalarDL. |
+| tls.upstreamTls | object | `{"caRootCertSecret":"","enabled":false,"overrideAuthority":""}` | TLS configuration between Envoy and ScalarDB Cluster or ScalarDL. |
+| tls.upstreamTls.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
 | tls.upstreamTls.enabled | bool | `false` | Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL. |
+| tls.upstreamTls.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL. |
 | tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -44,4 +44,10 @@ Current chart version is `3.0.0-SNAPSHOT`
 | serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | strategy.rollingUpdate | object | `{"maxSurge":"25%","maxUnavailable":"25%"}` | The number of pods that can be unavailable during the update process |
 | strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
+| tls.downstreamTls | object | `{"certChainSecret":"","enabled":false,"privateKeySecret":""}` | TLS configuration between client and Envoy. |
+| tls.downstreamTls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| tls.downstreamTls.enabled | bool | `false` | Enable TLS between client and Envoy. |
+| tls.downstreamTls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
+| tls.upstreamTls | object | `{"enabled":false}` | TLS configuration between Envoy and ScalarDB Cluster or ScalarDL. |
+| tls.upstreamTls.enabled | bool | `false` | Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL. |
 | tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -44,12 +44,12 @@ Current chart version is `3.0.0-SNAPSHOT`
 | serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | strategy.rollingUpdate | object | `{"maxSurge":"25%","maxUnavailable":"25%"}` | The number of pods that can be unavailable during the update process |
 | strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
-| tls.downstreamTls | object | `{"certChainSecret":"","enabled":false,"privateKeySecret":""}` | TLS configuration between client and Envoy. |
-| tls.downstreamTls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
-| tls.downstreamTls.enabled | bool | `false` | Enable TLS between client and Envoy. |
-| tls.downstreamTls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
-| tls.upstreamTls | object | `{"caRootCertSecret":"","enabled":false,"overrideAuthority":""}` | TLS configuration between Envoy and ScalarDB Cluster or ScalarDL. |
-| tls.upstreamTls.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
-| tls.upstreamTls.enabled | bool | `false` | Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL. |
-| tls.upstreamTls.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL. |
+| tls.downstream | object | `{"certChainSecret":"","enabled":false,"privateKeySecret":""}` | TLS configuration between client and Envoy. |
+| tls.downstream.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| tls.downstream.enabled | bool | `false` | Enable TLS between client and Envoy. |
+| tls.downstream.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
+| tls.upstream | object | `{"caRootCertSecret":"","enabled":false,"overrideAuthority":""}` | TLS configuration between Envoy and ScalarDB Cluster or ScalarDL. |
+| tls.upstream.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
+| tls.upstream.enabled | bool | `false` | Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL. |
+| tls.upstream.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL. |
 | tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |

--- a/charts/envoy/templates/deployment.yaml
+++ b/charts/envoy/templates/deployment.yaml
@@ -54,12 +54,12 @@ spec:
           - name: service_listeners
             value: "{{ .Values.envoyConfiguration.serviceListeners }}"
           - name: envoy_tls
-            value: "{{ .Values.tls.downstreamTls.enabled }}"
+            value: "{{ .Values.tls.downstream.enabled }}"
           - name: envoy_upstream_tls
-            value: "{{ .Values.tls.upstreamTls.enabled }}"
-          {{- if .Values.tls.upstreamTls.overrideAuthority }}
+            value: "{{ .Values.tls.upstream.enabled }}"
+          {{- if .Values.tls.upstream.overrideAuthority }}
           - name: envoy_upstream_tls_override_authority
-            value: "{{ .Values.tls.upstreamTls.overrideAuthority }}"
+            value: "{{ .Values.tls.upstream.overrideAuthority }}"
           {{- end }}
           startupProbe:
             httpGet:
@@ -82,36 +82,36 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if .Values.tls.upstreamTls.caRootCertSecret }}
+            {{- if .Values.tls.upstream.caRootCertSecret }}
             - name: scalar-envoy-tls-ca-root-volume
               mountPath: /etc/envoy/upstream/tls/ca.pem
               subPath: ca-root-cert
             {{- end }}
-            {{- if .Values.tls.downstreamTls.certChainSecret }}
+            {{- if .Values.tls.downstream.certChainSecret }}
             - name: scalar-envoy-tls-cert-chain-volume
               mountPath: /etc/envoy/cert.pem
               subPath: cert-chain
             {{- end }}
-            {{- if .Values.tls.downstreamTls.privateKeySecret }}
+            {{- if .Values.tls.downstream.privateKeySecret }}
             - name: scalar-envoy-tls-private-key-volume
               mountPath: /etc/envoy/key.pem
               subPath: private-key
             {{- end }}
       volumes:
-        {{- if .Values.tls.upstreamTls.caRootCertSecret }}
+        {{- if .Values.tls.upstream.caRootCertSecret }}
         - name: scalar-envoy-tls-ca-root-volume
           secret:
-            secretName: {{ .Values.tls.upstreamTls.caRootCertSecret }}
+            secretName: {{ .Values.tls.upstream.caRootCertSecret }}
         {{- end }}
-        {{- if .Values.tls.downstreamTls.certChainSecret }}
+        {{- if .Values.tls.downstream.certChainSecret }}
         - name: scalar-envoy-tls-cert-chain-volume
           secret:
-            secretName: {{ .Values.tls.downstreamTls.certChainSecret }}
+            secretName: {{ .Values.tls.downstream.certChainSecret }}
         {{- end }}
-        {{- if .Values.tls.downstreamTls.privateKeySecret }}
+        {{- if .Values.tls.downstream.privateKeySecret }}
         - name: scalar-envoy-tls-private-key-volume
           secret:
-            secretName: {{ .Values.tls.downstreamTls.privateKeySecret }}
+            secretName: {{ .Values.tls.downstream.privateKeySecret }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/envoy/templates/deployment.yaml
+++ b/charts/envoy/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
             value: "{{ .Values.tls.downstreamTls.enabled }}"
           - name: envoy_upstream_tls
             value: "{{ .Values.tls.upstreamTls.enabled }}"
+          {{- if .Values.tls.upstreamTls.overrideAuthority }}
+          - name: envoy_upstream_tls_override_authority
+            value: "{{ .Values.tls.upstreamTls.overrideAuthority }}"
+          {{- end }}
           startupProbe:
             httpGet:
               path: /ready
@@ -78,6 +82,11 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.tls.upstreamTls.caRootCertSecret }}
+            - name: scalar-envoy-tls-ca-root-volume
+              mountPath: /etc/envoy/upstream/tls/ca.pem
+              subPath: ca-root-cert
+            {{- end }}
             {{- if .Values.tls.downstreamTls.certChainSecret }}
             - name: scalar-envoy-tls-cert-chain-volume
               mountPath: /etc/envoy/cert.pem
@@ -89,6 +98,11 @@ spec:
               subPath: private-key
             {{- end }}
       volumes:
+        {{- if .Values.tls.upstreamTls.caRootCertSecret }}
+        - name: scalar-envoy-tls-ca-root-volume
+          secret:
+            secretName: {{ .Values.tls.upstreamTls.caRootCertSecret }}
+        {{- end }}
         {{- if .Values.tls.downstreamTls.certChainSecret }}
         - name: scalar-envoy-tls-cert-chain-volume
           secret:

--- a/charts/envoy/templates/deployment.yaml
+++ b/charts/envoy/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
             value: {{ include "envoy.fullname" . }}-headless
           - name: service_listeners
             value: "{{ .Values.envoyConfiguration.serviceListeners }}"
+          - name: envoy_tls
+            value: "{{ .Values.tls.downstreamTls.enabled }}"
+          - name: envoy_upstream_tls
+            value: "{{ .Values.tls.upstreamTls.enabled }}"
           startupProbe:
             httpGet:
               path: /ready
@@ -73,6 +77,28 @@ spec:
                 command: ["/bin/sh", "-c", "curl -sX POST 127.0.0.1:9001/healthcheck/fail; sleep 30"]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.tls.downstreamTls.certChainSecret }}
+            - name: scalar-envoy-tls-cert-chain-volume
+              mountPath: /etc/envoy/cert.pem
+              subPath: cert-chain
+            {{- end }}
+            {{- if .Values.tls.downstreamTls.privateKeySecret }}
+            - name: scalar-envoy-tls-private-key-volume
+              mountPath: /etc/envoy/key.pem
+              subPath: private-key
+            {{- end }}
+      volumes:
+        {{- if .Values.tls.downstreamTls.certChainSecret }}
+        - name: scalar-envoy-tls-cert-chain-volume
+          secret:
+            secretName: {{ .Values.tls.downstreamTls.certChainSecret }}
+        {{- end }}
+        {{- if .Values.tls.downstreamTls.privateKeySecret }}
+        - name: scalar-envoy-tls-private-key-volume
+          secret:
+            secretName: {{ .Values.tls.downstreamTls.privateKeySecret }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/envoy/values.schema.json
+++ b/charts/envoy/values.schema.json
@@ -204,8 +204,14 @@
                 "upstreamTls": {
                     "type": "object",
                     "properties": {
+                        "caRootCertSecret": {
+                            "type": "string"
+                        },
                         "enabled": {
                             "type": "boolean"
+                        },
+                        "overrideAuthority": {
+                            "type": "string"
                         }
                     }
                 }

--- a/charts/envoy/values.schema.json
+++ b/charts/envoy/values.schema.json
@@ -184,6 +184,33 @@
                 }
             }
         },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "downstreamTls": {
+                    "type": "object",
+                    "properties": {
+                        "certChainSecret": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "privateKeySecret": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "upstreamTls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "tolerations": {
             "type": "array"
         }

--- a/charts/envoy/values.schema.json
+++ b/charts/envoy/values.schema.json
@@ -187,7 +187,7 @@
         "tls": {
             "type": "object",
             "properties": {
-                "downstreamTls": {
+                "downstream": {
                     "type": "object",
                     "properties": {
                         "certChainSecret": {
@@ -201,7 +201,7 @@
                         }
                     }
                 },
-                "upstreamTls": {
+                "upstream": {
                     "type": "object",
                     "properties": {
                         "caRootCertSecret": {

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -117,7 +117,7 @@ affinity: {}
 
 tls:
   # -- TLS configuration between client and Envoy.
-  downstreamTls:
+  downstream:
     # -- Enable TLS between client and Envoy.
     enabled: false
     # -- Secret name that includes the certificate chain file used for TLS communication.
@@ -125,7 +125,7 @@ tls:
     # -- Secret name that includes the private key file used for TLS communication.
     privateKeySecret: ""
   # -- TLS configuration between Envoy and ScalarDB Cluster or ScalarDL.
-  upstreamTls:
+  upstream:
     # -- Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL.
     enabled: false
     # -- Specify the custom authority for TLS communication. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL.

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -128,3 +128,7 @@ tls:
   upstreamTls:
     # -- Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL.
     enabled: false
+    # -- Specify the custom authority for TLS communication. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL.
+    overrideAuthority: ""
+    # -- Secret name that includes the custom CA root certificate for TLS communication.
+    caRootCertSecret: ""

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -120,15 +120,15 @@ tls:
   downstream:
     # -- Enable TLS between client and Envoy.
     enabled: false
-    # -- Secret name that includes the certificate chain file used for TLS communication.
+    # -- Name of the Secret containing the certificate chain file used for TLS communication.
     certChainSecret: ""
-    # -- Secret name that includes the private key file used for TLS communication.
+    # -- Name of the Secret containing the private key file used for TLS communication.
     privateKeySecret: ""
   # -- TLS configuration between Envoy and ScalarDB Cluster or ScalarDL.
   upstream:
     # -- Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL.
     enabled: false
-    # -- Specify the custom authority for TLS communication. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL.
+    # -- The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `scalardbCluster.tls.certChainSecret`, `ledger.tls.certChainSecret`, or `auditor.tls.certChainSecret`. Envoy uses this value for certificate verification of TLS connection with ScalarDB Cluster or ScalarDL.
     overrideAuthority: ""
-    # -- Secret name that includes the custom CA root certificate for TLS communication.
+    # -- Name of the Secret containing the custom CA root certificate for TLS communication.
     caRootCertSecret: ""

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -114,3 +114,17 @@ tolerations: []
 
 # affinity -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
 affinity: {}
+
+tls:
+  # -- TLS configuration between client and Envoy.
+  downstreamTls:
+    # -- Enable TLS between client and Envoy.
+    enabled: false
+    # -- Secret name that includes the certificate chain file used for TLS communication.
+    certChainSecret: ""
+    # -- Secret name that includes the private key file used for TLS communication.
+    privateKeySecret: ""
+  # -- TLS configuration between Envoy and ScalarDB Cluster or ScalarDL.
+  upstreamTls:
+    # -- Enable TLS between Envoy and ScalarDB Cluster or ScalarDL. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster or ScalarDL.
+    enabled: false


### PR DESCRIPTION
## Description

This PR adds TLS support in the Scalar Envoy chart.

In this update, users can configure TLS in both downstream and upstream connections respectively.

```console
[Client] ---(downstream connections)---> [Envoy] ---(upstream connections)---> [ScalarDB/ScalarDL]
```

## Related issues and/or PRs

* https://github.com/scalar-labs/scalar-envoy/pull/28
  * I updated the Scalar Envoy to support TLS both downstream and upstream connections.
* https://github.com/scalar-labs/docs-internal-orchestration/pull/14
  * I updated the document that is related to this PR. You can see the usage of this new feature and the getting started guide.

## Changes made

* Add new values to configure the TLS configurations.
* Mount key/cert file to use TLS connections between client and Envoy in the Deployment manifest.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Support TLS configuration in the Scalar Envoy chart. You can enable TLS in both downstream (client - Envoy) and upstream (Envoy - ScalarDB/ScalarDL) connections.

