### PR TITLE
[scalardb-cluster] Support TLS in ScalarDB Cluster chart

### DIFF
--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -65,9 +65,9 @@ Current chart version is `2.0.0-SNAPSHOT`
 | scalardbCluster.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | scalardbCluster.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | scalardbCluster.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
-| scalardbCluster.tls.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
-| scalardbCluster.tls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| scalardbCluster.tls.caRootCertSecret | string | `""` | Name of the Secret containing  the custom CA root certificate for TLS communication. |
+| scalardbCluster.tls.certChainSecret | string | `""` | Name of the Secret containing  the certificate chain file used for TLS communication. |
 | scalardbCluster.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster. |
-| scalardbCluster.tls.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe. |
-| scalardbCluster.tls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
+| scalardbCluster.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `scalardbCluster.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |
+| scalardbCluster.tls.privateKeySecret | string | `""` | Name of the Secret containing  the private key file used for TLS communication. |
 | scalardbCluster.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |

--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -65,4 +65,9 @@ Current chart version is `2.0.0-SNAPSHOT`
 | scalardbCluster.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | scalardbCluster.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | scalardbCluster.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
+| scalardbCluster.tls.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
+| scalardbCluster.tls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| scalardbCluster.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster. |
+| scalardbCluster.tls.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe. |
+| scalardbCluster.tls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
 | scalardbCluster.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |

--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -63,13 +63,15 @@ spec:
             exec:
               command:
                 - /usr/local/bin/grpc_health_probe
-                - -addr=:60053
+                - -addr=localhost:60053
                 {{- if .Values.scalardbCluster.tls.enabled }}
                 - -tls
                 {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
                 - -tls-ca-cert=/tls/certs/ca-root-cert.pem
                 {{- end }}
+                {{- if .Values.scalardbCluster.tls.overrideAuthority }}
                 - -tls-server-name={{ .Values.scalardbCluster.tls.overrideAuthority }}
+                {{- end }}
                 {{- end }}
             failureThreshold: 60
             periodSeconds: 5
@@ -77,13 +79,15 @@ spec:
             exec:
               command:
                 - /usr/local/bin/grpc_health_probe
-                - -addr=:60053
+                - -addr=localhost:60053
                 {{- if .Values.scalardbCluster.tls.enabled }}
                 - -tls
                 {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
                 - -tls-ca-cert=/tls/certs/ca-root-cert.pem
                 {{- end }}
+                {{- if .Values.scalardbCluster.tls.overrideAuthority }}
                 - -tls-server-name={{ .Values.scalardbCluster.tls.overrideAuthority }}
+                {{- end }}
                 {{- end }}
             failureThreshold: 3
             periodSeconds: 10

--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -64,13 +64,27 @@ spec:
               command:
                 - /usr/local/bin/grpc_health_probe
                 - -addr=:60053
+                {{- if .Values.scalardbCluster.tls.enabled }}
+                - -tls
+                {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
+                - -tls-ca-cert=/tls/certs/ca-root-cert.pem
+                {{- end }}
+                - -tls-server-name={{ .Values.scalardbCluster.tls.overrideAuthority }}
+                {{- end }}
             failureThreshold: 60
             periodSeconds: 5
           livenessProbe:
             exec:
               command:
-              - /usr/local/bin/grpc_health_probe
-              - -addr=:60053
+                - /usr/local/bin/grpc_health_probe
+                - -addr=:60053
+                {{- if .Values.scalardbCluster.tls.enabled }}
+                - -tls
+                {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
+                - -tls-ca-cert=/tls/certs/ca-root-cert.pem
+                {{- end }}
+                - -tls-server-name={{ .Values.scalardbCluster.tls.overrideAuthority }}
+                {{- end }}
             failureThreshold: 3
             periodSeconds: 10
             successThreshold: 1
@@ -79,6 +93,21 @@ spec:
             - name: scalardb-cluster-database-properties-volume
               mountPath: /scalardb-cluster/node/scalardb-cluster-node.properties
               subPath: scalardb-cluster-node.properties
+            {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
+            - name: scalardb-cluster-tls-ca-root-volume
+              mountPath: /tls/certs/ca-root-cert.pem
+              subPath: ca-root-cert
+            {{- end }}
+            {{- if .Values.scalardbCluster.tls.certChainSecret }}
+            - name: scalardb-cluster-tls-cert-chain-volume
+              mountPath: /tls/certs/cert-chain.pem
+              subPath: cert-chain
+            {{- end }}
+            {{- if .Values.scalardbCluster.tls.privateKeySecret }}
+            - name: scalardb-cluster-tls-private-key-volume
+              mountPath: /tls/certs/private-key.pem
+              subPath: private-key
+            {{- end }}
           {{- with .Values.scalardbCluster.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -86,6 +115,21 @@ spec:
         - name: scalardb-cluster-database-properties-volume
           configMap:
             name: {{ include "scalardb-cluster.fullname" . }}-node-properties
+        {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
+        - name: scalardb-cluster-tls-ca-root-volume
+          secret:
+            secretName: {{ .Values.scalardbCluster.tls.caRootCertSecret }}
+        {{- end }}
+        {{- if .Values.scalardbCluster.tls.certChainSecret }}
+        - name: scalardb-cluster-tls-cert-chain-volume
+          secret:
+            secretName: {{ .Values.scalardbCluster.tls.certChainSecret }}
+        {{- end }}
+        {{- if .Values.scalardbCluster.tls.privateKeySecret }}
+        - name: scalardb-cluster-tls-private-key-volume
+          secret:
+            secretName: {{ .Values.scalardbCluster.tls.privateKeySecret }}
+        {{- end }}
       {{- with .Values.scalardbCluster.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/scalardb-cluster/values.schema.json
+++ b/charts/scalardb-cluster/values.schema.json
@@ -289,6 +289,26 @@
                         }
                     }
                 },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "caRootCertSecret": {
+                            "type": "string"
+                        },
+                        "certChainSecret": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "overrideAuthority": {
+                            "type": "string"
+                        },
+                        "privateKeySecret": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "tolerations": {
                     "type": "array"
                 }

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -276,11 +276,11 @@ scalardbCluster:
   tls:
     # -- Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster.
     enabled: false
-    # -- Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe.
+    # -- The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `scalardbCluster.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe.
     overrideAuthority: ""
-    # -- Secret name that includes the custom CA root certificate for TLS communication.
+    # -- Name of the Secret containing  the custom CA root certificate for TLS communication.
     caRootCertSecret: ""
-    # -- Secret name that includes the certificate chain file used for TLS communication.
+    # -- Name of the Secret containing  the certificate chain file used for TLS communication.
     certChainSecret: ""
-    # -- Secret name that includes the private key file used for TLS communication.
+    # -- Name of the Secret containing  the private key file used for TLS communication.
     privateKeySecret: ""

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -272,3 +272,15 @@ scalardbCluster:
     serviceAccountName: ""
     # -- Specify to mount a service account token or not
     automountServiceAccountToken: true
+
+  tls:
+    # -- Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster.
+    enabled: false
+    # -- Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe.
+    overrideAuthority: ""
+    # -- Secret name that includes the custom CA root certificate for TLS communication.
+    caRootCertSecret: ""
+    # -- Secret name that includes the certificate chain file used for TLS communication.
+    certChainSecret: ""
+    # -- Secret name that includes the private key file used for TLS communication.
+    privateKeySecret: ""


### PR DESCRIPTION
## Description

This PR adds TLS support in the ScalarDB Cluster chart.

In this update, users can configure TLS features and set key/cert files for ScalarDB Cluster.

Note: You need to enable the wire encryption feature on the ScalarDB Cluster side by setting `scalar.db.cluster.tls.enabled=true` in the `scalardbCluster.scalardbClusterNodeProperties` in your custom values file.

* Indirect mode of Java Client SDK or using gRPC directly
  ```console
  [Client] ---> [Envoy] ---(TLS)---> [ScalarDB Cluster]
  ```
* Direct Kubernetes mode of Java Client SDK
  ```console
  [Client] ---(TLS)---> [ScalarDB Cluster]
  ```

## Related issues and/or PRs

* https://github.com/scalar-labs/scalar-envoy/pull/28
  * I updated the Scalar Envoy to support TLS both downstream and upstream connections.
* https://github.com/scalar-labs/helm-charts/pull/253
  * I updated the Helm Chart of Scalar Envoy to support TLS between Envoy and ScalarDB Cluster.
* https://github.com/scalar-labs/docs-internal-orchestration/pull/14
  * I updated the document that is related to this PR. You can see the usage of this new feature and the getting started guide.

## Changes made

* Add new values to configure the TLS configurations.
* Mount key/cert file to use TLS connections between client (Envoy) and ScalarDB Cluster in the Deployment manifest.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Support TLS configuration in the ScalarDB Cluster chart. You can enable TLS between Client/Envoy and ScalarDB Cluster.
