### PR TITLE
[scalardl-ledger] Support TLS in ScalarDL Ledger chart

### DIFF
--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -74,5 +74,10 @@ Current chart version is `5.0.0-SNAPSHOT`
 | ledger.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | ledger.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
+| ledger.tls.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
+| ledger.tls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| ledger.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Ledger. |
+| ledger.tls.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe. |
+| ledger.tls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
 | ledger.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | nameOverride | string | `""` | String to partially override scalardl.fullname template (will maintain the release name) |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -74,10 +74,10 @@ Current chart version is `5.0.0-SNAPSHOT`
 | ledger.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | ledger.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
-| ledger.tls.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
-| ledger.tls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| ledger.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
+| ledger.tls.certChainSecret | string | `""` | Name of the Secret containing the certificate chain file used for TLS communication. |
 | ledger.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Ledger. |
-| ledger.tls.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe. |
-| ledger.tls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
+| ledger.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `ledger.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |
+| ledger.tls.privateKeySecret | string | `""` | Name of the Secret containing the private key file used for TLS communication. |
 | ledger.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | nameOverride | string | `""` | String to partially override scalardl.fullname template (will maintain the release name) |

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -143,13 +143,15 @@ spec:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
-              - -addr=:50051
+              - -addr=localhost:50051
               {{- if .Values.ledger.tls.enabled }}
               - -tls
               {{- if .Values.ledger.tls.caRootCertSecret }}
               - -tls-ca-cert=/tls/certs/ca-root-cert.pem
               {{- end }}
+              {{- if .Values.ledger.tls.overrideAuthority }}
               - -tls-server-name={{ .Values.ledger.tls.overrideAuthority }}
+              {{- end }}
               {{- end }}
             failureThreshold: 60
             periodSeconds: 5
@@ -157,13 +159,15 @@ spec:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
-              - -addr=:50051
+              - -addr=localhost:50051
               {{- if .Values.ledger.tls.enabled }}
               - -tls
               {{- if .Values.ledger.tls.caRootCertSecret }}
               - -tls-ca-cert=/tls/certs/ca-root-cert.pem
               {{- end }}
+              {{- if .Values.ledger.tls.overrideAuthority }}
               - -tls-server-name={{ .Values.ledger.tls.overrideAuthority }}
+              {{- end }}
               {{- end }}
             failureThreshold: 3
             periodSeconds: 10

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -43,6 +43,21 @@ spec:
         - name: scalardl-ledger-properties-volume
           configMap:
             name: {{ include "scalardl.fullname" . }}-ledger-properties
+      {{- if .Values.ledger.tls.caRootCertSecret }}
+        - name: scalardl-ledger-tls-ca-root-volume
+          secret:
+            secretName: {{ .Values.ledger.tls.caRootCertSecret }}
+      {{- end }}
+      {{- if .Values.ledger.tls.certChainSecret }}
+        - name: scalardl-ledger-tls-cert-chain-volume
+          secret:
+            secretName: {{ .Values.ledger.tls.certChainSecret }}
+      {{- end }}
+      {{- if .Values.ledger.tls.privateKeySecret }}
+        - name: scalardl-ledger-tls-private-key-volume
+          secret:
+            secretName: {{ .Values.ledger.tls.privateKeySecret }}
+      {{- end }}
       {{- with .Values.ledger.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -61,6 +76,21 @@ spec:
             - name: scalardl-ledger-properties-volume
               mountPath: /scalar/ledger/ledger.properties
               subPath: ledger.properties
+          {{- if .Values.ledger.tls.caRootCertSecret }}
+            - name: scalardl-ledger-tls-ca-root-volume
+              mountPath: /tls/certs/ca-root-cert.pem
+              subPath: ca-root-cert
+          {{- end }}
+          {{- if .Values.ledger.tls.certChainSecret }}
+            - name: scalardl-ledger-tls-cert-chain-volume
+              mountPath: /tls/certs/cert-chain.pem
+              subPath: cert-chain
+          {{- end }}
+          {{- if .Values.ledger.tls.privateKeySecret }}
+            - name: scalardl-ledger-tls-private-key-volume
+              mountPath: /tls/certs/private-key.pem
+              subPath: private-key
+          {{- end }}
           {{- with .Values.ledger.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -114,6 +144,13 @@ spec:
               command:
               - /usr/local/bin/grpc_health_probe
               - -addr=:50051
+              {{- if .Values.ledger.tls.enabled }}
+              - -tls
+              {{- if .Values.ledger.tls.caRootCertSecret }}
+              - -tls-ca-cert=/tls/certs/ca-root-cert.pem
+              {{- end }}
+              - -tls-server-name={{ .Values.ledger.tls.overrideAuthority }}
+              {{- end }}
             failureThreshold: 60
             periodSeconds: 5
           livenessProbe:
@@ -121,6 +158,13 @@ spec:
               command:
               - /usr/local/bin/grpc_health_probe
               - -addr=:50051
+              {{- if .Values.ledger.tls.enabled }}
+              - -tls
+              {{- if .Values.ledger.tls.caRootCertSecret }}
+              - -tls-ca-cert=/tls/certs/ca-root-cert.pem
+              {{- end }}
+              - -tls-server-name={{ .Values.ledger.tls.overrideAuthority }}
+              {{- end }}
             failureThreshold: 3
             periodSeconds: 10
             successThreshold: 1

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -325,6 +325,26 @@
                         }
                     }
                 },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "caRootCertSecret": {
+                            "type": "string"
+                        },
+                        "certChainSecret": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "overrideAuthority": {
+                            "type": "string"
+                        },
+                        "privateKeySecret": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "tolerations": {
                     "type": "array"
                 }

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -233,3 +233,15 @@ ledger:
     serviceAccountName: ""
     # -- Specify to mount a service account token or not
     automountServiceAccountToken: false
+
+  tls:
+    # -- Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Ledger.
+    enabled: false
+    # -- Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe.
+    overrideAuthority: ""
+    # -- Secret name that includes the custom CA root certificate for TLS communication.
+    caRootCertSecret: ""
+    # -- Secret name that includes the certificate chain file used for TLS communication.
+    certChainSecret: ""
+    # -- Secret name that includes the private key file used for TLS communication.
+    privateKeySecret: ""

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -237,11 +237,11 @@ ledger:
   tls:
     # -- Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Ledger.
     enabled: false
-    # -- Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe.
+    # -- The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `ledger.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe.
     overrideAuthority: ""
-    # -- Secret name that includes the custom CA root certificate for TLS communication.
+    # -- Name of the Secret containing the custom CA root certificate for TLS communication.
     caRootCertSecret: ""
-    # -- Secret name that includes the certificate chain file used for TLS communication.
+    # -- Name of the Secret containing the certificate chain file used for TLS communication.
     certChainSecret: ""
-    # -- Secret name that includes the private key file used for TLS communication.
+    # -- Name of the Secret containing the private key file used for TLS communication.
     privateKeySecret: ""


### PR DESCRIPTION
## Description

This PR adds TLS support in the ScalarDL Ledger chart.

In this update, users can configure TLS features and set key/cert files for ScalarDL Ledger.

Note: You need to enable the wire encryption feature on the ScalarDL Ledger side by setting `scalar.dl.ledger.server.tls.enabled=true` in the `ledger.ledgerProperties` in your custom values file.

```console
[Client] ---> [Envoy] ---(TLS)---> [ScalarDL Ledger]
```

## Related issues and/or PRs

* https://github.com/scalar-labs/scalar-envoy/pull/28
  * I updated the Scalar Envoy to support TLS both downstream and upstream connections.
* https://github.com/scalar-labs/helm-charts/pull/253
  * I updated the Helm Chart of Scalar Envoy to support TLS between Envoy and ScalarDL Ledger.
* https://github.com/scalar-labs/docs-internal-orchestration/pull/14
  * I updated the document that is related to this PR. You can see the usage of this new feature and the getting started guide.

## Changes made

* Add new values to configure the TLS configurations.
* Mount key/cert file to use TLS connections between client (Envoy) and ScalarDL Ledger in the Deployment manifest.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Support TLS configuration in the ScalarDL Ledger chart. You can enable TLS between Envoy and ScalarDL Ledger.
