### PR TITLE
[scalardl-auditor] Support TLS in ScalarDL Auditor chart

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -66,6 +66,12 @@ Current chart version is `3.0.0-SNAPSHOT`
 | auditor.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | auditor.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | auditor.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
+| auditor.tls.caRootCertForLedgerSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication between Auditor and Ledger. |
+| auditor.tls.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
+| auditor.tls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| auditor.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Auditor. |
+| auditor.tls.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe. |
+| auditor.tls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardl-audit-service:40051,scalardl-audit-privileged:40052"` | list of service name and port |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -66,12 +66,12 @@ Current chart version is `3.0.0-SNAPSHOT`
 | auditor.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | auditor.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | auditor.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
-| auditor.tls.caRootCertForLedgerSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication between Auditor and Ledger. |
-| auditor.tls.caRootCertSecret | string | `""` | Secret name that includes the custom CA root certificate for TLS communication. |
-| auditor.tls.certChainSecret | string | `""` | Secret name that includes the certificate chain file used for TLS communication. |
+| auditor.tls.caRootCertForLedgerSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication between Auditor and Ledger. |
+| auditor.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
+| auditor.tls.certChainSecret | string | `""` | Name of the Secret containing the certificate chain file used for TLS communication. |
 | auditor.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Auditor. |
-| auditor.tls.overrideAuthority | string | `""` | Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe. |
-| auditor.tls.privateKeySecret | string | `""` | Secret name that includes the private key file used for TLS communication. |
+| auditor.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `auditor.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |
+| auditor.tls.privateKeySecret | string | `""` | Name of the Secret containing the private key file used for TLS communication. |
 | auditor.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | envoy.enabled | bool | `true` | enable envoy |
 | envoy.envoyConfiguration.serviceListeners | string | `"scalardl-audit-service:40051,scalardl-audit-privileged:40052"` | list of service name and port |

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -41,6 +41,26 @@ spec:
         - name: scalardl-auditor-properties-volume
           configMap:
             name: {{ include "scalardl-audit.fullname" . }}-auditor-properties
+      {{- if .Values.auditor.tls.caRootCertSecret }}
+        - name: scalardl-auditor-tls-ca-root-volume
+          secret:
+            secretName: {{ .Values.auditor.tls.caRootCertSecret }}
+      {{- end }}
+      {{- if .Values.auditor.tls.certChainSecret }}
+        - name: scalardl-auditor-tls-cert-chain-volume
+          secret:
+            secretName: {{ .Values.auditor.tls.certChainSecret }}
+      {{- end }}
+      {{- if .Values.auditor.tls.privateKeySecret }}
+        - name: scalardl-auditor-tls-private-key-volume
+          secret:
+            secretName: {{ .Values.auditor.tls.privateKeySecret }}
+      {{- end }}
+      {{- if .Values.auditor.tls.caRootCertForLedgerSecret }}
+        - name: scalardl-auditor-tls-ca-root-for-ledger-volume
+          secret:
+            secretName: {{ .Values.auditor.tls.caRootCertForLedgerSecret }}
+      {{- end }}
       {{- with .Values.auditor.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -61,6 +81,26 @@ spec:
             - name: scalardl-auditor-properties-volume
               mountPath: /scalar/auditor/auditor.properties
               subPath: auditor.properties
+          {{- if .Values.auditor.tls.caRootCertSecret }}
+            - name: scalardl-auditor-tls-ca-root-volume
+              mountPath: /tls/certs/ca-root-cert.pem
+              subPath: ca-root-cert
+          {{- end }}
+          {{- if .Values.auditor.tls.certChainSecret }}
+            - name: scalardl-auditor-tls-cert-chain-volume
+              mountPath: /tls/certs/cert-chain.pem
+              subPath: cert-chain
+          {{- end }}
+          {{- if .Values.auditor.tls.privateKeySecret }}
+            - name: scalardl-auditor-tls-private-key-volume
+              mountPath: /tls/certs/private-key.pem
+              subPath: private-key
+          {{- end }}
+          {{- if .Values.auditor.tls.caRootCertSecret }}
+            - name: scalardl-auditor-tls-ca-root-for-ledger-volume
+              mountPath: /tls/certs/ca-root-cert-for-ledger.pem
+              subPath: ca-root-cert-for-ledger
+          {{- end }}
           {{- with .Values.auditor.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -122,6 +162,13 @@ spec:
               command:
               - /usr/local/bin/grpc_health_probe
               - -addr=:40051
+              {{- if .Values.auditor.tls.enabled }}
+              - -tls
+              {{- if .Values.auditor.tls.caRootCertSecret }}
+              - -tls-ca-cert=/tls/certs/ca-root-cert.pem
+              {{- end }}
+              - -tls-server-name={{ .Values.auditor.tls.overrideAuthority }}
+              {{- end }}
             failureThreshold: 60
             periodSeconds: 5
           livenessProbe:
@@ -129,6 +176,13 @@ spec:
               command:
               - /usr/local/bin/grpc_health_probe
               - -addr=:40051
+              {{- if .Values.auditor.tls.enabled }}
+              - -tls
+              {{- if .Values.auditor.tls.caRootCertSecret }}
+              - -tls-ca-cert=/tls/certs/ca-root-cert.pem
+              {{- end }}
+              - -tls-server-name={{ .Values.auditor.tls.overrideAuthority }}
+              {{- end }}
             failureThreshold: 3
             periodSeconds: 10
             successThreshold: 1

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -161,13 +161,15 @@ spec:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
-              - -addr=:40051
+              - -addr=localhost:40051
               {{- if .Values.auditor.tls.enabled }}
               - -tls
               {{- if .Values.auditor.tls.caRootCertSecret }}
               - -tls-ca-cert=/tls/certs/ca-root-cert.pem
               {{- end }}
+              {{- if .Values.auditor.tls.overrideAuthority }}
               - -tls-server-name={{ .Values.auditor.tls.overrideAuthority }}
+              {{- end }}
               {{- end }}
             failureThreshold: 60
             periodSeconds: 5
@@ -175,13 +177,15 @@ spec:
             exec:
               command:
               - /usr/local/bin/grpc_health_probe
-              - -addr=:40051
+              - -addr=localhost:40051
               {{- if .Values.auditor.tls.enabled }}
               - -tls
               {{- if .Values.auditor.tls.caRootCertSecret }}
               - -tls-ca-cert=/tls/certs/ca-root-cert.pem
               {{- end }}
+              {{- if .Values.auditor.tls.overrideAuthority }}
               - -tls-server-name={{ .Values.auditor.tls.overrideAuthority }}
+              {{- end }}
               {{- end }}
             failureThreshold: 3
             periodSeconds: 10

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -266,6 +266,29 @@
                         }
                     }
                 },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "caRootCertForLedgerSecret": {
+                            "type": "string"
+                        },
+                        "caRootCertSecret": {
+                            "type": "string"
+                        },
+                        "certChainSecret": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "overrideAuthority": {
+                            "type": "string"
+                        },
+                        "privateKeySecret": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "tolerations": {
                     "type": "array"
                 }

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -270,13 +270,13 @@ auditor:
   tls:
     # -- Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Auditor.
     enabled: false
-    # -- Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe.
+    # -- The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `auditor.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe.
     overrideAuthority: ""
-    # -- Secret name that includes the custom CA root certificate for TLS communication.
+    # -- Name of the Secret containing the custom CA root certificate for TLS communication.
     caRootCertSecret: ""
-    # -- Secret name that includes the certificate chain file used for TLS communication.
+    # -- Name of the Secret containing the certificate chain file used for TLS communication.
     certChainSecret: ""
-    # -- Secret name that includes the private key file used for TLS communication.
+    # -- Name of the Secret containing the private key file used for TLS communication.
     privateKeySecret: ""
-    # -- Secret name that includes the custom CA root certificate for TLS communication between Auditor and Ledger.
+    # -- Name of the Secret containing the custom CA root certificate for TLS communication between Auditor and Ledger.
     caRootCertForLedgerSecret: ""

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -266,3 +266,17 @@ auditor:
     serviceAccountName: ""
     # -- Specify to mount a service account token or not
     automountServiceAccountToken: false
+
+  tls:
+    # -- Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Auditor.
+    enabled: false
+    # -- Specify the custom authority for TLS communication. This chart uses this value for startupProbe and livenessProbe.
+    overrideAuthority: ""
+    # -- Secret name that includes the custom CA root certificate for TLS communication.
+    caRootCertSecret: ""
+    # -- Secret name that includes the certificate chain file used for TLS communication.
+    certChainSecret: ""
+    # -- Secret name that includes the private key file used for TLS communication.
+    privateKeySecret: ""
+    # -- Secret name that includes the custom CA root certificate for TLS communication between Auditor and Ledger.
+    caRootCertForLedgerSecret: ""


### PR DESCRIPTION
## Description

This PR adds TLS support in the ScalarDL Auditor chart.

In this update, users can configure TLS features and set key/cert files for ScalarDL Auditor.

Note: You need to enable the wire encryption feature on the ScalarDL Auditor side by setting `scalar.dl.auditor.server.tls.enabled=true` and `scalar.dl.auditor.tls.enabled=true` in the `auditor.auditorProperties` in your custom values file.

```console
                         +---(TLS)---> [ScalarDL Ledger] <---(TLS)------------------+
                         |                                                          |
[Client] ---> [Envoy] ---+                                                          |
                         |                                                          |
                         +---(TLS)---> [ScalarDL Auditor] ---(Recovery operation)---+
```

## Related issues and/or PRs

* https://github.com/scalar-labs/scalar-envoy/pull/28
  * I updated the Scalar Envoy to support TLS both downstream and upstream connections.
* https://github.com/scalar-labs/helm-charts/pull/253
  * I updated the Helm Chart of Scalar Envoy to support TLS between Envoy and ScalarDL Auditor.
* https://github.com/scalar-labs/docs-internal-orchestration/pull/14
  * I updated the document that is related to this PR. You can see the usage of this new feature and the getting started guide.

## Changes made

* Add new values to configure the TLS configurations.
* Mount key/cert file to use TLS connections between client (Envoy) and ScalarDL Auditor in the Deployment manifest.
* Mount key/cert file to use TLS connections between ScalarDL Auditor and ScalarDL Ledger in the Deployment manifest.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Support TLS configuration in the ScalarDL Auditor chart. You can enable TLS in both "Envoy - ScalarDL Auditor" and "ScalarDL Auditor - ScalarDL Ledger" connections.

