### PR TITLE
[scalardl-schema-loader] Support OpenShift (ScalarDL v3)

### DIFF
--- a/charts/schema-loading/templates/batchjob-schema-loading.yaml
+++ b/charts/schema-loading/templates/batchjob-schema-loading.yaml
@@ -58,7 +58,7 @@ spec:
         {{- end }}
         {{- else }}
         - "--config"
-        - "database.properties"
+        - "/tmp/database.properties"
         {{- if eq .Values.schemaLoading.schemaType "ledger" }}
         - "--coordinator"
         {{- end }}


### PR DESCRIPTION
## Description

Note: We will apply this update to schema-loading chart v2. In other words, we don't apply this update to the `main` branch. So, I changed the target branch.

This PR updates the path of `database.properties` for ScalarDL Schema Loader.

To support OpenShift as a platform of ScalarDL v3, we updated the file path of `database.properties` in the following PR on the ScalarDL side.
https://github.com/scalar-labs/scalar/pull/1112

So, we have to update the file path of `database.properties` on the Helm Chart side too.

Please take a look!

## Related issues and/or PRs

* https://github.com/scalar-labs/scalar/pull/1112

## Changes made

* Update file path from `./database.properties` to `/tmp/database.properties`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
