### PR TITLE
Update configuration of PostgreSQL for CI to use /tmp directory

### DIFF
--- a/.github/postgresql.yaml
+++ b/.github/postgresql.yaml
@@ -4,3 +4,5 @@ primary:
 
 auth:
   postgresPassword: postgres
+
+postgresqlDataDir: /tmp/data

--- a/.github/postgresql.yaml
+++ b/.github/postgresql.yaml
@@ -1,6 +1,7 @@
 primary:
   persistence:
     enabled: false
+  resourcesPreset: none
 
 auth:
   postgresPassword: postgres


### PR DESCRIPTION
## Description

This PR updates the configuration of PostgreSQL for CI.

Recently, bitnami releases a new major version of helm chart for PostgreSQL.
https://github.com/bitnami/charts/tree/main/bitnami/postgresql#to-1500

It includes backward-incompatible updates and it causes error of PostgreSQL.

### 1. Security configurations

Some security configurations are changed to more strict.

```console
postgresql 07:12:47.96 INFO  ==> Initializing PostgreSQL database...
mkdir: cannot create directory '/bitnami/postgresql/data': Permission denied
```

Since the security configuration was made more strict, the container cannot create a new directory under the `/bitnami/` directory.

So, I update to use `/tmp` directory instead of `/bitnami/`.

I think there is no problem if we use the `/tmp` directory because we use this PostgreSQL temporarily for CI. (I think for the production environment, using the `/tmp` directory is not good.)

### 2. Resources configurations

Before there is no resource limitations by default, but in the latest version, the bitnami helm chart set minimum resource configuration by default as follows.

```json
$ kubectl get pod postgresql-scalardb-0 -o json | jq .spec.containers[].resources
{
  "limits": {
    "cpu": "150m",
    "ephemeral-storage": "1Gi",
    "memory": "192Mi"
  },
  "requests": {
    "cpu": "100m",
    "ephemeral-storage": "50Mi",
    "memory": "128Mi"
  }
}
```

Sometimes, this minimum resource limitation might cause OOM error as follows.

```console
$ kubectl get pod postgresql-scalardb-0 -w
NAME                    READY   STATUS    RESTARTS   AGE

...(omit)...

postgresql-scalardb-0                     0/1     OOMKilled   0          90s
```

So, I added the configuration `primary.resourcesPreset: none` (the default value of previous version) explicitly.

Please take a look!

## Related issues and/or PRs

Some CI failed by the PostgreSQL failure.

* https://github.com/scalar-labs/helm-charts/actions/runs/8386619771/job/22967491007?pr=255
* https://github.com/scalar-labs/helm-charts/actions/runs/8386647038/job/22967426752?pr=256
* https://github.com/scalar-labs/helm-charts/actions/runs/8386663296/job/22967474683?pr=257

## Changes made

* Use the `/tmp` directory for the data directory of PostgreSQL.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

By using this new configuration, I was able to run the PostgreSQL in my local environment.

```console
$ helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql -f .github/postgresql.yaml
Pulled: registry-1.docker.io/bitnamicharts/postgresql:15.1.2
Digest: sha256:48e069eb0d4926ca35ea7b864de66a622f29dab37df27c641b8434e66175ef16
NAME: postgresql
LAST DEPLOYED: Fri Mar 22 16:35:18 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
CHART NAME: postgresql
CHART VERSION: 15.1.2
APP VERSION: 16.2.0

...(omit)...
```

```console
$ kubectl logs postgresql-0

...(omit)...

postgresql 07:37:36.18 INFO  ==> ** PostgreSQL setup finished! **
postgresql 07:37:36.26 INFO  ==> ** Starting PostgreSQL **
2024-03-22 07:37:36.365 GMT [1] LOG:  pgaudit extension initialized
2024-03-22 07:37:36.377 GMT [1] LOG:  starting PostgreSQL 16.2 on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
2024-03-22 07:37:36.377 GMT [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2024-03-22 07:37:36.377 GMT [1] LOG:  listening on IPv6 address "::", port 5432
2024-03-22 07:37:36.388 GMT [1] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2024-03-22 07:37:36.401 GMT [134] LOG:  database system was shut down at 2024-03-22 07:37:36 GMT
2024-03-22 07:37:36.418 GMT [1] LOG:  database system is ready to accept connections
```

## Release notes

N/A
