### PR TITLE
[scalar-admin-for-kubernetes] Support TLS in Scalar Admin for Kubernetes chart

### DIFF
--- a/charts/scalar-admin-for-kubernetes/README.md
+++ b/charts/scalar-admin-for-kubernetes/README.md
@@ -28,5 +28,6 @@ Current chart version is `2.0.0-SNAPSHOT`.
 | scalarAdminForKubernetes.securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege). |
 | scalarAdminForKubernetes.serviceAccount.automountServiceAccountToken | bool | `true` | Specify whether to mount a service account token or not. |
 | scalarAdminForKubernetes.serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource. |
+| scalarAdminForKubernetes.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
 | scalarAdminForKubernetes.tolerations | list | `[]` | Tolerations are applied to pods and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | scalarAdminForKubernetes.ttlSecondsAfterFinished | int | `0` | ttlSecondsAfterFinished value for the job resource. |

--- a/charts/scalar-admin-for-kubernetes/README.md
+++ b/charts/scalar-admin-for-kubernetes/README.md
@@ -28,6 +28,6 @@ Current chart version is `2.0.0-SNAPSHOT`.
 | scalarAdminForKubernetes.securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege). |
 | scalarAdminForKubernetes.serviceAccount.automountServiceAccountToken | bool | `true` | Specify whether to mount a service account token or not. |
 | scalarAdminForKubernetes.serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource. |
-| scalarAdminForKubernetes.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. This chart mounts the root CA certificate file on /tls/certs/ directory. |
+| scalarAdminForKubernetes.tls.caRootCertSecret | string | `""` | Name of the secret containing the custom CA root certificate for TLS communication. This chart mounts the root CA certificate file on the /tls/certs/ directory. |
 | scalarAdminForKubernetes.tolerations | list | `[]` | Tolerations are applied to pods and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | scalarAdminForKubernetes.ttlSecondsAfterFinished | int | `0` | ttlSecondsAfterFinished value for the job resource. |

--- a/charts/scalar-admin-for-kubernetes/README.md
+++ b/charts/scalar-admin-for-kubernetes/README.md
@@ -28,6 +28,6 @@ Current chart version is `2.0.0-SNAPSHOT`.
 | scalarAdminForKubernetes.securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege). |
 | scalarAdminForKubernetes.serviceAccount.automountServiceAccountToken | bool | `true` | Specify whether to mount a service account token or not. |
 | scalarAdminForKubernetes.serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource. |
-| scalarAdminForKubernetes.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
+| scalarAdminForKubernetes.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. This chart mounts the root CA certificate file on /tls/certs/ directory. |
 | scalarAdminForKubernetes.tolerations | list | `[]` | Tolerations are applied to pods and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | scalarAdminForKubernetes.ttlSecondsAfterFinished | int | `0` | ttlSecondsAfterFinished value for the job resource. |

--- a/charts/scalar-admin-for-kubernetes/templates/_helpers.tpl
+++ b/charts/scalar-admin-for-kubernetes/templates/_helpers.tpl
@@ -101,6 +101,17 @@ template:
           {{- range .Values.scalarAdminForKubernetes.commandArgs }}
           - {{ . | quote }}
           {{- end }}
+        {{- if .Values.scalarAdminForKubernetes.tls.caRootCertSecret }}
+        volumeMounts:
+          - name: tls-ca-root-volume
+            mountPath: /tls/certs
+        {{- end }}
+    {{- if .Values.scalarAdminForKubernetes.tls.caRootCertSecret }}
+    volumes:
+      - name: tls-ca-root-volume
+        secret:
+          secretName: {{ .Values.scalarAdminForKubernetes.tls.caRootCertSecret }}
+    {{- end }}
     {{- with .Values.scalarAdminForKubernetes.nodeSelector }}
     nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/scalar-admin-for-kubernetes/values.schema.json
+++ b/charts/scalar-admin-for-kubernetes/values.schema.json
@@ -111,6 +111,14 @@
                         }
                     }
                 },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "caRootCertSecret": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "tolerations": {
                     "type": "array"
                 },

--- a/charts/scalar-admin-for-kubernetes/values.yaml
+++ b/charts/scalar-admin-for-kubernetes/values.yaml
@@ -89,3 +89,7 @@ scalarAdminForKubernetes:
 
   # -- ttlSecondsAfterFinished value for the job resource.
   ttlSecondsAfterFinished: 0
+
+  tls:
+    # -- Name of the Secret containing the custom CA root certificate for TLS communication.
+    caRootCertSecret: ""

--- a/charts/scalar-admin-for-kubernetes/values.yaml
+++ b/charts/scalar-admin-for-kubernetes/values.yaml
@@ -91,5 +91,5 @@ scalarAdminForKubernetes:
   ttlSecondsAfterFinished: 0
 
   tls:
-    # -- Name of the Secret containing the custom CA root certificate for TLS communication. This chart mounts the root CA certificate file on /tls/certs/ directory.
+    # -- Name of the secret containing the custom CA root certificate for TLS communication. This chart mounts the root CA certificate file on /tls/certs/ directory.
     caRootCertSecret: ""

--- a/charts/scalar-admin-for-kubernetes/values.yaml
+++ b/charts/scalar-admin-for-kubernetes/values.yaml
@@ -91,5 +91,5 @@ scalarAdminForKubernetes:
   ttlSecondsAfterFinished: 0
 
   tls:
-    # -- Name of the Secret containing the custom CA root certificate for TLS communication.
+    # -- Name of the Secret containing the custom CA root certificate for TLS communication. This chart mounts the root CA certificate file on /tls/certs/ directory.
     caRootCertSecret: ""


### PR DESCRIPTION
## Description

This PR adds TLS support in the Scalar Admin for Kubernetes chart.

In this update, users can mount a root CA certificate on the pod of Scalar Admin for Kubernetes.

Then, users can specify the root CA certificate by using the `--ca-root-cert-path` option and run a pause request with TLS as follows.

```console
[Scalar Admin for Kubernetes] ---> (TLS)---> [ScalarDB Cluster / ScalarDL]
```

## Related issues and/or PRs

* https://github.com/scalar-labs/docs-internal-orchestration/pull/21
  * I updated the document that is related to this PR.

## Changes made

* Add new values to specify the name of the secret resource including root CA certificate.
* Mount root CA certificate file on Pod to use TLS connections between Scalar Admin for Kubernetes and ScalarDB Cluster/ScalarDL.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Support TLS configuration in the Scalar Admin for Kubernetes chart. You can run a pause request with TLS.
