### PR TITLE
[scalar-admin-for-kubernetes] Fix typo in README

### DIFF
--- a/charts/scalar-admin-for-kubernetes/README.md
+++ b/charts/scalar-admin-for-kubernetes/README.md
@@ -28,6 +28,6 @@ Current chart version is `2.0.0-SNAPSHOT`.
 | scalarAdminForKubernetes.securityContext.runAsNonRoot | bool | `true` | Containers should be run as a non-root user with the minimum required permissions (principle of least privilege). |
 | scalarAdminForKubernetes.serviceAccount.automountServiceAccountToken | bool | `true` | Specify whether to mount a service account token or not. |
 | scalarAdminForKubernetes.serviceAccount.serviceAccountName | string | `""` | Name of the existing service account resource. |
-| scalarAdminForKubernetes.tls.caRootCertSecret | string | `""` | Name of the secret containing the custom CA root certificate for TLS communication. This chart mounts the root CA certificate file on the /tls/certs/ directory. |
+| scalarAdminForKubernetes.tls.caRootCertSecret | string | `""` | Name of the secret containing the custom CA root certificate for TLS communication. This chart mounts the root CA certificate file on /tls/certs/ directory. |
 | scalarAdminForKubernetes.tolerations | list | `[]` | Tolerations are applied to pods and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | scalarAdminForKubernetes.ttlSecondsAfterFinished | int | `0` | ttlSecondsAfterFinished value for the job resource. |


### PR DESCRIPTION
## Description

This PR fix typo.

It's a very minor thing, but this typo (difference between `values.yaml comment` and `README`) cause the CI error.
https://github.com/scalar-labs/helm-charts/actions/runs/8655786113/job/23735277413

So, we have to fix it to run the CI properly.

Please take a look!

## Related issues and/or PRs

* https://github.com/scalar-labs/helm-charts/actions/runs/8655786113/job/23735277413

## Changes made

* Fix typo and keep consistency between `values.yaml` and `README`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
