### PR TITLE
[scalardb-cluster] Support cert-manager in ScalarDB Cluster chart

### DIFF
--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -65,9 +65,17 @@ Current chart version is `2.0.0-SNAPSHOT`
 | scalardbCluster.strategy.rollingUpdate.maxSurge | string | `"25%"` | The number of pods that can be created above the desired amount of pods during an update |
 | scalardbCluster.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | The number of pods that can be unavailable during the update process |
 | scalardbCluster.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
-| scalardbCluster.tls.caRootCertSecret | string | `""` | Name of the Secret containing  the custom CA root certificate for TLS communication. |
-| scalardbCluster.tls.certChainSecret | string | `""` | Name of the Secret containing  the certificate chain file used for TLS communication. |
+| scalardbCluster.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
+| scalardbCluster.tls.certChainSecret | string | `""` | Name of the Secret containing the certificate chain file used for TLS communication. |
+| scalardbCluster.tls.certManager.dnsNames | list | `["localhost"]` | Subject Alternative Name (SAN) of a certificate. |
+| scalardbCluster.tls.certManager.duration | string | `"87600h0m0s"` | Duration of a certificate. |
+| scalardbCluster.tls.certManager.enabled | bool | `false` | Use cert-manager to manage private key and certificate files. |
+| scalardbCluster.tls.certManager.issuerRef | object | `{}` | Issuer references of cert-manager. |
+| scalardbCluster.tls.certManager.privateKey | object | `{"algorithm":"ECDSA","encoding":"PKCS1","size":256}` | Configuration of a private key. |
+| scalardbCluster.tls.certManager.renewBefore | string | `"360h0m0s"` | How long before expiry a certificate should be renewed. |
+| scalardbCluster.tls.certManager.selfSignedCaRootCert | object | `{"duration":"87600h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
+| scalardbCluster.tls.certManager.usages | list | `["server auth","key encipherment","signing"]` | List of key usages. |
 | scalardbCluster.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDB Cluster. |
 | scalardbCluster.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `scalardbCluster.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |
-| scalardbCluster.tls.privateKeySecret | string | `""` | Name of the Secret containing  the private key file used for TLS communication. |
+| scalardbCluster.tls.privateKeySecret | string | `""` | Name of the Secret containing the private key file used for TLS communication. |
 | scalardbCluster.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |

--- a/charts/scalardb-cluster/templates/scalardb-cluster/certmanager.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/certmanager.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.scalardbCluster.tls.certManager.enabled }}
+{{- if not .Values.scalardbCluster.tls.certManager.issuerRef }}
+# Self-signed root CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "scalardb-cluster.fullname" . }}-self-signed-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardb-cluster.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the ScalarDB Cluster
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "scalardb-cluster.fullname" . }}-root-ca-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardb-cluster.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  secretName: {{ include "scalardb-cluster.fullname" . }}-root-ca-cert
+  secretTemplate:
+    labels:
+      {{- include "scalardb-cluster.labels" . | nindent 6 }}
+  commonName: self-signed-ca
+  duration: {{ .Values.scalardbCluster.tls.certManager.selfSignedCaRootCert.duration | quote }}
+  renewBefore: {{ .Values.scalardbCluster.tls.certManager.selfSignedCaRootCert.renewBefore | quote }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ include "scalardb-cluster.fullname" . }}-self-signed-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "scalardb-cluster.fullname" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardb-cluster.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "scalardb-cluster.fullname" . }}-root-ca-cert
+{{- end }}
+---
+# Generate a server certificate for the ScalarDB Cluster
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "scalardb-cluster.fullname" . }}-tls-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardb-cluster.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "scalardb-cluster.fullname" . }}-tls-cert
+  secretTemplate:
+    labels:
+      {{- include "scalardb-cluster.labels" . | nindent 6 }}
+  duration: {{ .Values.scalardbCluster.tls.certManager.duration | quote }}
+  renewBefore: {{ .Values.scalardbCluster.tls.certManager.renewBefore | quote }}
+  privateKey:
+    {{- toYaml .Values.scalardbCluster.tls.certManager.privateKey | nindent 4 }}
+  usages:
+    {{- range .Values.scalardbCluster.tls.certManager.usages }}
+    - {{ . | quote }}
+    {{- end }}
+  dnsNames:
+    {{- range .Values.scalardbCluster.tls.certManager.dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+  issuerRef:
+    {{- if .Values.scalardbCluster.tls.certManager.issuerRef }}
+    {{- toYaml .Values.scalardbCluster.tls.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    name: {{ include "scalardb-cluster.fullname" . }}-ca-issuer
+    {{- end }}
+{{- end }}

--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -66,9 +66,7 @@ spec:
                 - -addr=localhost:60053
                 {{- if .Values.scalardbCluster.tls.enabled }}
                 - -tls
-                {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
-                - -tls-ca-cert=/tls/certs/ca-root-cert.pem
-                {{- end }}
+                - -tls-ca-cert=/tls/scalardb-cluster/certs/ca.crt
                 {{- if .Values.scalardbCluster.tls.overrideAuthority }}
                 - -tls-server-name={{ .Values.scalardbCluster.tls.overrideAuthority }}
                 {{- end }}
@@ -82,9 +80,7 @@ spec:
                 - -addr=localhost:60053
                 {{- if .Values.scalardbCluster.tls.enabled }}
                 - -tls
-                {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
-                - -tls-ca-cert=/tls/certs/ca-root-cert.pem
-                {{- end }}
+                - -tls-ca-cert=/tls/scalardb-cluster/certs/ca.crt
                 {{- if .Values.scalardbCluster.tls.overrideAuthority }}
                 - -tls-server-name={{ .Values.scalardbCluster.tls.overrideAuthority }}
                 {{- end }}
@@ -97,20 +93,9 @@ spec:
             - name: scalardb-cluster-database-properties-volume
               mountPath: /scalardb-cluster/node/scalardb-cluster-node.properties
               subPath: scalardb-cluster-node.properties
-            {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
-            - name: scalardb-cluster-tls-ca-root-volume
-              mountPath: /tls/certs/ca-root-cert.pem
-              subPath: ca-root-cert
-            {{- end }}
-            {{- if .Values.scalardbCluster.tls.certChainSecret }}
-            - name: scalardb-cluster-tls-cert-chain-volume
-              mountPath: /tls/certs/cert-chain.pem
-              subPath: cert-chain
-            {{- end }}
-            {{- if .Values.scalardbCluster.tls.privateKeySecret }}
-            - name: scalardb-cluster-tls-private-key-volume
-              mountPath: /tls/certs/private-key.pem
-              subPath: private-key
+            {{- if .Values.scalardbCluster.tls.enabled }}
+            - name: scalardb-cluster-tls-volume
+              mountPath: /tls/scalardb-cluster/certs
             {{- end }}
           {{- with .Values.scalardbCluster.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -119,20 +104,21 @@ spec:
         - name: scalardb-cluster-database-properties-volume
           configMap:
             name: {{ include "scalardb-cluster.fullname" . }}-node-properties
-        {{- if .Values.scalardbCluster.tls.caRootCertSecret }}
-        - name: scalardb-cluster-tls-ca-root-volume
+        {{- if and .Values.scalardbCluster.tls.enabled .Values.scalardbCluster.tls.certManager.enabled }}
+        - name: scalardb-cluster-tls-volume
           secret:
-            secretName: {{ .Values.scalardbCluster.tls.caRootCertSecret }}
+            secretName: {{ include "scalardb-cluster.fullname" . }}-tls-cert
         {{- end }}
-        {{- if .Values.scalardbCluster.tls.certChainSecret }}
-        - name: scalardb-cluster-tls-cert-chain-volume
-          secret:
-            secretName: {{ .Values.scalardbCluster.tls.certChainSecret }}
-        {{- end }}
-        {{- if .Values.scalardbCluster.tls.privateKeySecret }}
-        - name: scalardb-cluster-tls-private-key-volume
-          secret:
-            secretName: {{ .Values.scalardbCluster.tls.privateKeySecret }}
+        {{- if and (.Values.scalardbCluster.tls.enabled) (not .Values.scalardbCluster.tls.certManager.enabled) }}
+        - name: scalardb-cluster-tls-volume
+          projected:
+            sources:
+              - secret:
+                  name: {{ .Values.scalardbCluster.tls.caRootCertSecret }}
+              - secret:
+                  name: {{ .Values.scalardbCluster.tls.certChainSecret }}
+              - secret:
+                  name: {{ .Values.scalardbCluster.tls.privateKeySecret }}
         {{- end }}
       {{- with .Values.scalardbCluster.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/scalardb-cluster/values.schema.json
+++ b/charts/scalardb-cluster/values.schema.json
@@ -298,6 +298,60 @@
                         "certChainSecret": {
                             "type": "string"
                         },
+                        "certManager": {
+                            "type": "object",
+                            "properties": {
+                                "dnsNames": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "duration": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "issuerRef": {
+                                    "type": "object"
+                                },
+                                "privateKey": {
+                                    "type": "object",
+                                    "properties": {
+                                        "algorithm": {
+                                            "type": "string"
+                                        },
+                                        "encoding": {
+                                            "type": "string"
+                                        },
+                                        "size": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "renewBefore": {
+                                    "type": "string"
+                                },
+                                "selfSignedCaRootCert": {
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "type": "string"
+                                        },
+                                        "renewBefore": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "usages": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -278,9 +278,35 @@ scalardbCluster:
     enabled: false
     # -- The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `scalardbCluster.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe.
     overrideAuthority: ""
-    # -- Name of the Secret containing  the custom CA root certificate for TLS communication.
+    # -- Name of the Secret containing the custom CA root certificate for TLS communication.
     caRootCertSecret: ""
-    # -- Name of the Secret containing  the certificate chain file used for TLS communication.
+    # -- Name of the Secret containing the certificate chain file used for TLS communication.
     certChainSecret: ""
-    # -- Name of the Secret containing  the private key file used for TLS communication.
+    # -- Name of the Secret containing the private key file used for TLS communication.
     privateKeySecret: ""
+    certManager:
+      # -- Use cert-manager to manage private key and certificate files.
+      enabled: false
+      # -- Configuration of a certificate for self-signed CA.
+      selfSignedCaRootCert:
+        duration: "87600h0m0s"
+        renewBefore: "360h0m0s"
+      # -- Duration of a certificate.
+      duration: "87600h0m0s"
+      # -- How long before expiry a certificate should be renewed.
+      renewBefore: "360h0m0s"
+      # -- Configuration of a private key.
+      privateKey:
+        algorithm: ECDSA
+        encoding: PKCS1
+        size: 256
+      # -- List of key usages.
+      usages:
+        - server auth
+        - key encipherment
+        - signing
+      # -- Subject Alternative Name (SAN) of a certificate.
+      dnsNames:
+        - localhost
+      # -- Issuer references of cert-manager.
+      issuerRef: {}


### PR DESCRIPTION
## Description

This PR update ScalarDB Cluster chart to support cert-manager.

Please take a look!

## Related issues and/or PRs

- TBD
  - You can see the documents that describes how to use these new features in this PR.
- https://github.com/scalar-labs/helm-charts/pull/262
  - If you use self-signed CA, this chart deploy self-signed CA. And, Scalar Envoy chart refer it to generate certificate for Envoy.

## Changes made

Mainly, this PR adds/updates the following features (manifests):

1. Deploy a `Certificate` resource for cert-manager by using `charts/scalardb-cluster/templates/scalardb-cluster/certmanager.yaml`.

2. Deploy self-signed CA and create certificate for ScalarDB Cluster if you don't specify any `Issuer` resources in `issuerRef` configuration.

   - If you deploy Scalar Envoy as a sub chart of this ScalarDB Cluster chart without `issuerRef` configuration, the Envoy chart will use self-signed CA that is deployed by this chart to create certificate for Envoy.

   ```
   [ScalarDB Cluster chart (this chart)] ---(Deploy)---> [Issuer (self-signed CA)] <---(Refer via issuerRef configuration)--- [Certificate resource] <---(Deploy)--- [Envoy chart]
   ```

3. Update `deployment.spec.template.spec.volumes` and `deployment.spec.template.spec.containers.volumeMounts` to remove `subPath` configuration.

   - Cert-manager creates a secret resource that includes private key and certificate, and we use them by mounting them on pods. And, cert-manager automatically renew (update) the certificate in the secret resource before the certificate will be expired. However, if we use `subPath` to specify the mounted file name, [Kubernetes does not apply the changes of the secret resource](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod). So, to take advantage of cert-manager's automatically renew feature, we should not use `subPath`. This is because I removed `subPath` from the `volumeMounts` configuration.

4. Update file names of private key and certificate.

   - From the perspective of cert-manager specification (strictly, [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) specification of Kubernetes), we must use the fixed names for private key and certificate files. This is because cert-manager creates a secret resource that includes private key and certificate files with fixed names based on the [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) specification. So, I updated the file names in existing manifests.
     - `cert.pem` -> `tls.crt`
     - `key.pem` -> `tls.key`
     - `ca.pem` -> `ca.crt`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Support cert-manager in ScalarDB Cluster chart. You can manage private key and certificate for TLS connections by using cert-manager.

