### PR TITLE
[scalardl-ledger] Support cert-manager in ScalarDL Ledger chart

### DIFF
--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -77,12 +77,12 @@ Current chart version is `5.0.0-SNAPSHOT`
 | ledger.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
 | ledger.tls.certChainSecret | string | `""` | Name of the Secret containing the certificate chain file used for TLS communication. |
 | ledger.tls.certManager.dnsNames | list | `["localhost"]` | Subject Alternative Name (SAN) of a certificate. |
-| ledger.tls.certManager.duration | string | `"87600h0m0s"` | Duration of a certificate. |
+| ledger.tls.certManager.duration | string | `"8760h0m0s"` | Duration of a certificate. |
 | ledger.tls.certManager.enabled | bool | `false` | Use cert-manager to manage private key and certificate files. |
 | ledger.tls.certManager.issuerRef | object | `{}` | Issuer references of cert-manager. |
 | ledger.tls.certManager.privateKey | object | `{"algorithm":"ECDSA","encoding":"PKCS1","size":256}` | Configuration of a private key. |
 | ledger.tls.certManager.renewBefore | string | `"360h0m0s"` | How long before expiry a certificate should be renewed. |
-| ledger.tls.certManager.selfSignedCaRootCert | object | `{"duration":"87600h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
+| ledger.tls.certManager.selfSignedCaRootCert | object | `{"duration":"8760h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
 | ledger.tls.certManager.usages | list | `["server auth","key encipherment","signing"]` | List of key usages. |
 | ledger.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Ledger. |
 | ledger.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `ledger.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -76,6 +76,14 @@ Current chart version is `5.0.0-SNAPSHOT`
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |
 | ledger.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
 | ledger.tls.certChainSecret | string | `""` | Name of the Secret containing the certificate chain file used for TLS communication. |
+| ledger.tls.certManager.dnsNames | list | `["localhost"]` | Subject Alternative Name (SAN) of a certificate. |
+| ledger.tls.certManager.duration | string | `"87600h0m0s"` | Duration of a certificate. |
+| ledger.tls.certManager.enabled | bool | `false` | Use cert-manager to manage private key and certificate files. |
+| ledger.tls.certManager.issuerRef | object | `{}` | Issuer references of cert-manager. |
+| ledger.tls.certManager.privateKey | object | `{"algorithm":"ECDSA","encoding":"PKCS1","size":256}` | Configuration of a private key. |
+| ledger.tls.certManager.renewBefore | string | `"360h0m0s"` | How long before expiry a certificate should be renewed. |
+| ledger.tls.certManager.selfSignedCaRootCert | object | `{"duration":"87600h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
+| ledger.tls.certManager.usages | list | `["server auth","key encipherment","signing"]` | List of key usages. |
 | ledger.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Ledger. |
 | ledger.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `ledger.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |
 | ledger.tls.privateKeySecret | string | `""` | Name of the Secret containing the private key file used for TLS communication. |

--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -82,7 +82,9 @@ Current chart version is `5.0.0-SNAPSHOT`
 | ledger.tls.certManager.issuerRef | object | `{}` | Issuer references of cert-manager. |
 | ledger.tls.certManager.privateKey | object | `{"algorithm":"ECDSA","encoding":"PKCS1","size":256}` | Configuration of a private key. |
 | ledger.tls.certManager.renewBefore | string | `"360h0m0s"` | How long before expiry a certificate should be renewed. |
-| ledger.tls.certManager.selfSignedCaRootCert | object | `{"duration":"8760h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
+| ledger.tls.certManager.selfSigned.caRootCert.duration | string | `"8760h0m0s"` | Duration of a self-signed CA certificate. |
+| ledger.tls.certManager.selfSigned.caRootCert.renewBefore | string | `"360h0m0s"` | How long before expiry a self-signed CA certificate should be renewed. |
+| ledger.tls.certManager.selfSigned.enabled | bool | `false` | Use self-signed CA. |
 | ledger.tls.certManager.usages | list | `["server auth","key encipherment","signing"]` | List of key usages. |
 | ledger.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Ledger. |
 | ledger.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `ledger.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |

--- a/charts/scalardl/templates/ledger/certmanager.yaml
+++ b/charts/scalardl/templates/ledger/certmanager.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ledger.tls.certManager.enabled }}
-{{- if not .Values.ledger.tls.certManager.issuerRef }}
+{{- if .Values.ledger.tls.certManager.selfSigned.enabled }}
 # Self-signed root CA
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -26,8 +26,8 @@ spec:
     labels:
       {{- include "scalardl-ledger.labels" . | nindent 6 }}
   commonName: self-signed-ca
-  duration: {{ .Values.ledger.tls.certManager.selfSignedCaRootCert.duration | quote }}
-  renewBefore: {{ .Values.ledger.tls.certManager.selfSignedCaRootCert.renewBefore | quote }}
+  duration: {{ .Values.ledger.tls.certManager.selfSigned.caRootCert.duration | quote }}
+  renewBefore: {{ .Values.ledger.tls.certManager.selfSigned.caRootCert.renewBefore | quote }}
   privateKey:
     algorithm: ECDSA
     size: 256
@@ -75,9 +75,10 @@ spec:
     - {{ . | quote }}
     {{- end }}
   issuerRef:
-    {{- if .Values.ledger.tls.certManager.issuerRef }}
-    {{- toYaml .Values.ledger.tls.certManager.issuerRef | nindent 4 }}
-    {{- else }}
+    # If and only if you set `ledger.tls.certManager.selfSigned.enabled=true`, this chart automatically generates a self-signed CA and uses it.
+    {{- if .Values.ledger.tls.certManager.selfSigned.enabled }}
     name: {{ include "scalardl.fullname" . }}-ca-issuer
+    {{- else }}
+    {{- toYaml .Values.ledger.tls.certManager.issuerRef | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/scalardl/templates/ledger/certmanager.yaml
+++ b/charts/scalardl/templates/ledger/certmanager.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.ledger.tls.certManager.enabled }}
+{{- if not .Values.ledger.tls.certManager.issuerRef }}
+# Self-signed root CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "scalardl.fullname" . }}-self-signed-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-ledger.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the ScalarDL Ledger
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "scalardl.fullname" . }}-root-ca-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-ledger.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  secretName: {{ include "scalardl.fullname" . }}-root-ca-cert
+  secretTemplate:
+    labels:
+      {{- include "scalardl-ledger.labels" . | nindent 6 }}
+  commonName: self-signed-ca
+  duration: {{ .Values.ledger.tls.certManager.selfSignedCaRootCert.duration | quote }}
+  renewBefore: {{ .Values.ledger.tls.certManager.selfSignedCaRootCert.renewBefore | quote }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ include "scalardl.fullname" . }}-self-signed-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "scalardl.fullname" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-ledger.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "scalardl.fullname" . }}-root-ca-cert
+{{- end }}
+---
+# Generate a server certificate for the ScalarDL Ledger
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "scalardl.fullname" . }}-tls-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-ledger.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "scalardl.fullname" . }}-tls-cert
+  secretTemplate:
+    labels:
+      {{- include "scalardl-ledger.labels" . | nindent 6 }}
+  duration: {{ .Values.ledger.tls.certManager.duration | quote }}
+  renewBefore: {{ .Values.ledger.tls.certManager.renewBefore | quote }}
+  privateKey:
+    {{- toYaml .Values.ledger.tls.certManager.privateKey | nindent 4 }}
+  usages:
+    {{- range .Values.ledger.tls.certManager.usages }}
+    - {{ . | quote }}
+    {{- end }}
+  dnsNames:
+    {{- range .Values.ledger.tls.certManager.dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+  issuerRef:
+    {{- if .Values.ledger.tls.certManager.issuerRef }}
+    {{- toYaml .Values.ledger.tls.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    name: {{ include "scalardl.fullname" . }}-ca-issuer
+    {{- end }}
+{{- end }}

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -43,20 +43,21 @@ spec:
         - name: scalardl-ledger-properties-volume
           configMap:
             name: {{ include "scalardl.fullname" . }}-ledger-properties
-      {{- if .Values.ledger.tls.caRootCertSecret }}
-        - name: scalardl-ledger-tls-ca-root-volume
+      {{- if and .Values.ledger.tls.enabled .Values.ledger.tls.certManager.enabled }}
+        - name: scalardl-ledger-tls-volume
           secret:
-            secretName: {{ .Values.ledger.tls.caRootCertSecret }}
+            secretName: {{ include "scalardl.fullname" . }}-tls-cert
       {{- end }}
-      {{- if .Values.ledger.tls.certChainSecret }}
-        - name: scalardl-ledger-tls-cert-chain-volume
-          secret:
-            secretName: {{ .Values.ledger.tls.certChainSecret }}
-      {{- end }}
-      {{- if .Values.ledger.tls.privateKeySecret }}
-        - name: scalardl-ledger-tls-private-key-volume
-          secret:
-            secretName: {{ .Values.ledger.tls.privateKeySecret }}
+      {{- if and (.Values.ledger.tls.enabled) (not .Values.ledger.tls.certManager.enabled) }}
+        - name: scalardl-ledger-tls-volume
+          projected:
+            sources:
+              - secret:
+                  name: {{ .Values.ledger.tls.caRootCertSecret }}
+              - secret:
+                  name: {{ .Values.ledger.tls.certChainSecret }}
+              - secret:
+                  name: {{ .Values.ledger.tls.privateKeySecret }}
       {{- end }}
       {{- with .Values.ledger.extraVolumes }}
         {{- toYaml . | nindent 8 }}
@@ -76,20 +77,9 @@ spec:
             - name: scalardl-ledger-properties-volume
               mountPath: /scalar/ledger/ledger.properties
               subPath: ledger.properties
-          {{- if .Values.ledger.tls.caRootCertSecret }}
-            - name: scalardl-ledger-tls-ca-root-volume
-              mountPath: /tls/certs/ca-root-cert.pem
-              subPath: ca-root-cert
-          {{- end }}
-          {{- if .Values.ledger.tls.certChainSecret }}
-            - name: scalardl-ledger-tls-cert-chain-volume
-              mountPath: /tls/certs/cert-chain.pem
-              subPath: cert-chain
-          {{- end }}
-          {{- if .Values.ledger.tls.privateKeySecret }}
-            - name: scalardl-ledger-tls-private-key-volume
-              mountPath: /tls/certs/private-key.pem
-              subPath: private-key
+          {{- if .Values.ledger.tls.enabled }}
+            - name: scalardl-ledger-tls-volume
+              mountPath: /tls/scalardl-ledger/certs
           {{- end }}
           {{- with .Values.ledger.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -146,9 +136,7 @@ spec:
               - -addr=localhost:50051
               {{- if .Values.ledger.tls.enabled }}
               - -tls
-              {{- if .Values.ledger.tls.caRootCertSecret }}
-              - -tls-ca-cert=/tls/certs/ca-root-cert.pem
-              {{- end }}
+              - -tls-ca-cert=/tls/scalardl-ledger/certs/ca.crt
               {{- if .Values.ledger.tls.overrideAuthority }}
               - -tls-server-name={{ .Values.ledger.tls.overrideAuthority }}
               {{- end }}
@@ -162,9 +150,7 @@ spec:
               - -addr=localhost:50051
               {{- if .Values.ledger.tls.enabled }}
               - -tls
-              {{- if .Values.ledger.tls.caRootCertSecret }}
-              - -tls-ca-cert=/tls/certs/ca-root-cert.pem
-              {{- end }}
+              - -tls-ca-cert=/tls/scalardl-ledger/certs/ca.crt
               {{- if .Values.ledger.tls.overrideAuthority }}
               - -tls-server-name={{ .Values.ledger.tls.overrideAuthority }}
               {{- end }}

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -334,6 +334,60 @@
                         "certChainSecret": {
                             "type": "string"
                         },
+                        "certManager": {
+                            "type": "object",
+                            "properties": {
+                                "dnsNames": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "duration": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "issuerRef": {
+                                    "type": "object"
+                                },
+                                "privateKey": {
+                                    "type": "object",
+                                    "properties": {
+                                        "algorithm": {
+                                            "type": "string"
+                                        },
+                                        "encoding": {
+                                            "type": "string"
+                                        },
+                                        "size": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "renewBefore": {
+                                    "type": "string"
+                                },
+                                "selfSignedCaRootCert": {
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "type": "string"
+                                        },
+                                        "renewBefore": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "usages": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -369,14 +369,22 @@
                                 "renewBefore": {
                                     "type": "string"
                                 },
-                                "selfSignedCaRootCert": {
+                                "selfSigned": {
                                     "type": "object",
                                     "properties": {
-                                        "duration": {
-                                            "type": "string"
+                                        "caRootCert": {
+                                            "type": "object",
+                                            "properties": {
+                                                "duration": {
+                                                    "type": "string"
+                                                },
+                                                "renewBefore": {
+                                                    "type": "string"
+                                                }
+                                            }
                                         },
-                                        "renewBefore": {
-                                            "type": "string"
+                                        "enabled": {
+                                            "type": "boolean"
                                         }
                                     }
                                 },

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -250,10 +250,10 @@ ledger:
       enabled: false
       # -- Configuration of a certificate for self-signed CA.
       selfSignedCaRootCert:
-        duration: "87600h0m0s"
+        duration: "8760h0m0s"
         renewBefore: "360h0m0s"
       # -- Duration of a certificate.
-      duration: "87600h0m0s"
+      duration: "8760h0m0s"
       # -- How long before expiry a certificate should be renewed.
       renewBefore: "360h0m0s"
       # -- Configuration of a private key.

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -248,10 +248,14 @@ ledger:
     certManager:
       # -- Use cert-manager to manage private key and certificate files.
       enabled: false
-      # -- Configuration of a certificate for self-signed CA.
-      selfSignedCaRootCert:
-        duration: "8760h0m0s"
-        renewBefore: "360h0m0s"
+      selfSigned:
+        # -- Use self-signed CA.
+        enabled: false
+        caRootCert:
+          # -- Duration of a self-signed CA certificate.
+          duration: "8760h0m0s"
+          # -- How long before expiry a self-signed CA certificate should be renewed.
+          renewBefore: "360h0m0s"
       # -- Duration of a certificate.
       duration: "8760h0m0s"
       # -- How long before expiry a certificate should be renewed.

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -245,3 +245,29 @@ ledger:
     certChainSecret: ""
     # -- Name of the Secret containing the private key file used for TLS communication.
     privateKeySecret: ""
+    certManager:
+      # -- Use cert-manager to manage private key and certificate files.
+      enabled: false
+      # -- Configuration of a certificate for self-signed CA.
+      selfSignedCaRootCert:
+        duration: "87600h0m0s"
+        renewBefore: "360h0m0s"
+      # -- Duration of a certificate.
+      duration: "87600h0m0s"
+      # -- How long before expiry a certificate should be renewed.
+      renewBefore: "360h0m0s"
+      # -- Configuration of a private key.
+      privateKey:
+        algorithm: ECDSA
+        encoding: PKCS1
+        size: 256
+      # -- List of key usages.
+      usages:
+        - server auth
+        - key encipherment
+        - signing
+      # -- Subject Alternative Name (SAN) of a certificate.
+      dnsNames:
+        - localhost
+      # -- Issuer references of cert-manager.
+      issuerRef: {}


### PR DESCRIPTION
## Description

This PR updates ScalarDL Ledger chart to support cert-manager.

Please take a look!

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-internal-orchestration/pull/24
  - You can see the documents that describe how to use these new features in this PR.
- https://github.com/scalar-labs/helm-charts/pull/262
  - If you use self-signed CA, this chart deploy self-signed CA. And, Scalar Envoy chart refer it to generate certificate for Envoy.

## Changes made

Mainly, this PR adds/updates the following features (manifests):

1. Deploy a `Certificate` resource for cert-manager by using `charts/scalardl/templates/ledger/certmanager.yaml`.

2. Deploy self-signed CA and create certificate for ScalarDL Ledger if you don't specify any `Issuer` resources in `issuerRef` configuration.

   - If you deploy Scalar Envoy as a sub chart of this ScalarDL Ledger chart without `issuerRef` configuration, the Envoy chart will use self-signed CA that is deployed by this chart to create certificate for Envoy.

   ```
   [ScalarDL Ledger chart (this chart)] ---(Deploy)---> [Issuer (self-signed CA)] <---(Refer via issuerRef configuration)--- [Certificate resource] <---(Deploy)--- [Envoy chart]
   ```

3. Update `deployment.spec.template.spec.volumes` and `deployment.spec.template.spec.containers.volumeMounts` to remove `subPath` configuration.

   - Cert-manager creates a secret resource that includes private key and certificate, and we use them by mounting them on pods. And, cert-manager automatically renew (update) the certificate in the secret resource before the certificate will be expired. However, if we use `subPath` to specify the mounted file name, [Kubernetes does not apply the changes of the secret resource](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod). So, to take advantage of cert-manager's automatically renew feature, we should not use `subPath`. This is because I removed `subPath` from the `volumeMounts` configuration.

4. Update file names of private key and certificate.

   - From the perspective of cert-manager specification (strictly, [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) specification of Kubernetes), we must use the fixed names for private key and certificate files. This is because cert-manager creates a secret resource that includes private key and certificate files with fixed names based on the [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) specification. So, I updated the file names in existing manifests.
     - `cert.pem` -> `tls.crt`
     - `key.pem` -> `tls.key`
     - `ca.pem` -> `ca.crt`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Support cert-manager in ScalarDL Ledger chart. You can manage private key and certificate for TLS connections by using cert-manager.

