### PR TITLE
[scalardl-auditor] Support cert-manager in ScalarDL Auditor chart

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -75,7 +75,9 @@ Current chart version is `3.0.0-SNAPSHOT`
 | auditor.tls.certManager.issuerRef | object | `{}` | Issuer references of cert-manager. |
 | auditor.tls.certManager.privateKey | object | `{"algorithm":"ECDSA","encoding":"PKCS1","size":256}` | Configuration of a private key. |
 | auditor.tls.certManager.renewBefore | string | `"360h0m0s"` | How long before expiry a certificate should be renewed. |
-| auditor.tls.certManager.selfSignedCaRootCert | object | `{"duration":"8760h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
+| auditor.tls.certManager.selfSigned.caRootCert.duration | string | `"8760h0m0s"` | Duration of a self-signed CA certificate. |
+| auditor.tls.certManager.selfSigned.caRootCert.renewBefore | string | `"360h0m0s"` | How long before expiry a self-signed CA certificate should be renewed. |
+| auditor.tls.certManager.selfSigned.enabled | bool | `false` | Use self-signed CA. |
 | auditor.tls.certManager.usages | list | `["server auth","key encipherment","signing"]` | List of key usages. |
 | auditor.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Auditor. |
 | auditor.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `auditor.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -70,12 +70,12 @@ Current chart version is `3.0.0-SNAPSHOT`
 | auditor.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
 | auditor.tls.certChainSecret | string | `""` | Name of the Secret containing the certificate chain file used for TLS communication. |
 | auditor.tls.certManager.dnsNames | list | `["localhost"]` | Subject Alternative Name (SAN) of a certificate. |
-| auditor.tls.certManager.duration | string | `"87600h0m0s"` | Duration of a certificate. |
+| auditor.tls.certManager.duration | string | `"8760h0m0s"` | Duration of a certificate. |
 | auditor.tls.certManager.enabled | bool | `false` | Use cert-manager to manage private key and certificate files. |
 | auditor.tls.certManager.issuerRef | object | `{}` | Issuer references of cert-manager. |
 | auditor.tls.certManager.privateKey | object | `{"algorithm":"ECDSA","encoding":"PKCS1","size":256}` | Configuration of a private key. |
 | auditor.tls.certManager.renewBefore | string | `"360h0m0s"` | How long before expiry a certificate should be renewed. |
-| auditor.tls.certManager.selfSignedCaRootCert | object | `{"duration":"87600h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
+| auditor.tls.certManager.selfSignedCaRootCert | object | `{"duration":"8760h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
 | auditor.tls.certManager.usages | list | `["server auth","key encipherment","signing"]` | List of key usages. |
 | auditor.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Auditor. |
 | auditor.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `auditor.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -69,6 +69,14 @@ Current chart version is `3.0.0-SNAPSHOT`
 | auditor.tls.caRootCertForLedgerSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication between Auditor and Ledger. |
 | auditor.tls.caRootCertSecret | string | `""` | Name of the Secret containing the custom CA root certificate for TLS communication. |
 | auditor.tls.certChainSecret | string | `""` | Name of the Secret containing the certificate chain file used for TLS communication. |
+| auditor.tls.certManager.dnsNames | list | `["localhost"]` | Subject Alternative Name (SAN) of a certificate. |
+| auditor.tls.certManager.duration | string | `"87600h0m0s"` | Duration of a certificate. |
+| auditor.tls.certManager.enabled | bool | `false` | Use cert-manager to manage private key and certificate files. |
+| auditor.tls.certManager.issuerRef | object | `{}` | Issuer references of cert-manager. |
+| auditor.tls.certManager.privateKey | object | `{"algorithm":"ECDSA","encoding":"PKCS1","size":256}` | Configuration of a private key. |
+| auditor.tls.certManager.renewBefore | string | `"360h0m0s"` | How long before expiry a certificate should be renewed. |
+| auditor.tls.certManager.selfSignedCaRootCert | object | `{"duration":"87600h0m0s","renewBefore":"360h0m0s"}` | Configuration of a certificate for self-signed CA. |
+| auditor.tls.certManager.usages | list | `["server auth","key encipherment","signing"]` | List of key usages. |
 | auditor.tls.enabled | bool | `false` | Enable TLS. You need to enable TLS when you use wire encryption feature of ScalarDL Auditor. |
 | auditor.tls.overrideAuthority | string | `""` | The custom authority for TLS communication. This doesn't change what host is actually connected. This is intended for testing, but may safely be used outside of tests as an alternative to DNS overrides. For example, you can specify the hostname presented in the certificate chain file that you set by using `auditor.tls.certChainSecret`. This chart uses this value for startupProbe and livenessProbe. |
 | auditor.tls.privateKeySecret | string | `""` | Name of the Secret containing the private key file used for TLS communication. |

--- a/charts/scalardl-audit/templates/auditor/certmanager.yaml
+++ b/charts/scalardl-audit/templates/auditor/certmanager.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.auditor.tls.certManager.enabled }}
-{{- if not .Values.auditor.tls.certManager.issuerRef }}
+{{- if .Values.auditor.tls.certManager.selfSigned.enabled }}
 # Self-signed root CA
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -26,8 +26,8 @@ spec:
     labels:
       {{- include "scalardl-audit-auditor.labels" . | nindent 6 }}
   commonName: self-signed-ca
-  duration: {{ .Values.auditor.tls.certManager.selfSignedCaRootCert.duration | quote }}
-  renewBefore: {{ .Values.auditor.tls.certManager.selfSignedCaRootCert.renewBefore | quote }}
+  duration: {{ .Values.auditor.tls.certManager.selfSigned.caRootCert.duration | quote }}
+  renewBefore: {{ .Values.auditor.tls.certManager.selfSigned.caRootCert.renewBefore | quote }}
   privateKey:
     algorithm: ECDSA
     size: 256
@@ -75,9 +75,10 @@ spec:
     - {{ . | quote }}
     {{- end }}
   issuerRef:
-    {{- if .Values.auditor.tls.certManager.issuerRef }}
-    {{- toYaml .Values.auditor.tls.certManager.issuerRef | nindent 4 }}
-    {{- else }}
+    # If and only if you set `auditor.tls.certManager.selfSigned.enabled=true`, this chart automatically generates a self-signed CA and uses it.
+    {{- if .Values.auditor.tls.certManager.selfSigned.enabled }}
     name: {{ include "scalardl-audit.fullname" . }}-ca-issuer
+    {{- else }}
+    {{- toYaml .Values.auditor.tls.certManager.issuerRef | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/scalardl-audit/templates/auditor/certmanager.yaml
+++ b/charts/scalardl-audit/templates/auditor/certmanager.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.auditor.tls.certManager.enabled }}
+{{- if not .Values.auditor.tls.certManager.issuerRef }}
+# Self-signed root CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "scalardl-audit.fullname" . }}-self-signed-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the ScalarDL Auditor
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "scalardl-audit.fullname" . }}-root-ca-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  secretName: {{ include "scalardl-audit.fullname" . }}-root-ca-cert
+  secretTemplate:
+    labels:
+      {{- include "scalardl-audit-auditor.labels" . | nindent 6 }}
+  commonName: self-signed-ca
+  duration: {{ .Values.auditor.tls.certManager.selfSignedCaRootCert.duration | quote }}
+  renewBefore: {{ .Values.auditor.tls.certManager.selfSignedCaRootCert.renewBefore | quote }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ include "scalardl-audit.fullname" . }}-self-signed-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "scalardl-audit.fullname" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "scalardl-audit.fullname" . }}-root-ca-cert
+{{- end }}
+---
+# Generate a server certificate for the ScalarDL Auditor
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "scalardl-audit.fullname" . }}-tls-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "scalardl-audit.fullname" . }}-tls-cert
+  secretTemplate:
+    labels:
+      {{- include "scalardl-audit-auditor.labels" . | nindent 6 }}
+  duration: {{ .Values.auditor.tls.certManager.duration | quote }}
+  renewBefore: {{ .Values.auditor.tls.certManager.renewBefore | quote }}
+  privateKey:
+    {{- toYaml .Values.auditor.tls.certManager.privateKey | nindent 4 }}
+  usages:
+    {{- range .Values.auditor.tls.certManager.usages }}
+    - {{ . | quote }}
+    {{- end }}
+  dnsNames:
+    {{- range .Values.auditor.tls.certManager.dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+  issuerRef:
+    {{- if .Values.auditor.tls.certManager.issuerRef }}
+    {{- toYaml .Values.auditor.tls.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    name: {{ include "scalardl-audit.fullname" . }}-ca-issuer
+    {{- end }}
+{{- end }}

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -41,25 +41,30 @@ spec:
         - name: scalardl-auditor-properties-volume
           configMap:
             name: {{ include "scalardl-audit.fullname" . }}-auditor-properties
-      {{- if .Values.auditor.tls.caRootCertSecret }}
-        - name: scalardl-auditor-tls-ca-root-volume
+      {{- if and .Values.auditor.tls.enabled .Values.auditor.tls.certManager.enabled }}
+        - name: scalardl-auditor-tls-volume
           secret:
-            secretName: {{ .Values.auditor.tls.caRootCertSecret }}
+            secretName: {{ include "scalardl-audit.fullname" . }}-tls-cert
       {{- end }}
-      {{- if .Values.auditor.tls.certChainSecret }}
-        - name: scalardl-auditor-tls-cert-chain-volume
-          secret:
-            secretName: {{ .Values.auditor.tls.certChainSecret }}
+      {{- if and (.Values.auditor.tls.enabled) (not .Values.auditor.tls.certManager.enabled) }}
+        - name: scalardl-auditor-tls-volume
+          projected:
+            sources:
+              - secret:
+                  name: {{ .Values.auditor.tls.caRootCertSecret }}
+              - secret:
+                  name: {{ .Values.auditor.tls.certChainSecret }}
+              - secret:
+                  name: {{ .Values.auditor.tls.privateKeySecret }}
       {{- end }}
-      {{- if .Values.auditor.tls.privateKeySecret }}
-        - name: scalardl-auditor-tls-private-key-volume
+      {{- if .Values.auditor.tls.enabled }}
+        - name: scalardl-auditor-tls-for-ledger-volume
           secret:
-            secretName: {{ .Values.auditor.tls.privateKeySecret }}
-      {{- end }}
-      {{- if .Values.auditor.tls.caRootCertForLedgerSecret }}
-        - name: scalardl-auditor-tls-ca-root-for-ledger-volume
-          secret:
+            {{- if .Values.auditor.tls.caRootCertForLedgerSecret }}
             secretName: {{ .Values.auditor.tls.caRootCertForLedgerSecret }}
+            {{- else }}
+            secretName: {{ include "scalardl-audit.fullname" . }}-tls-cert
+            {{- end }}
       {{- end }}
       {{- with .Values.auditor.extraVolumes }}
         {{- toYaml . | nindent 8 }}
@@ -81,25 +86,11 @@ spec:
             - name: scalardl-auditor-properties-volume
               mountPath: /scalar/auditor/auditor.properties
               subPath: auditor.properties
-          {{- if .Values.auditor.tls.caRootCertSecret }}
-            - name: scalardl-auditor-tls-ca-root-volume
-              mountPath: /tls/certs/ca-root-cert.pem
-              subPath: ca-root-cert
-          {{- end }}
-          {{- if .Values.auditor.tls.certChainSecret }}
-            - name: scalardl-auditor-tls-cert-chain-volume
-              mountPath: /tls/certs/cert-chain.pem
-              subPath: cert-chain
-          {{- end }}
-          {{- if .Values.auditor.tls.privateKeySecret }}
-            - name: scalardl-auditor-tls-private-key-volume
-              mountPath: /tls/certs/private-key.pem
-              subPath: private-key
-          {{- end }}
-          {{- if .Values.auditor.tls.caRootCertSecret }}
-            - name: scalardl-auditor-tls-ca-root-for-ledger-volume
-              mountPath: /tls/certs/ca-root-cert-for-ledger.pem
-              subPath: ca-root-cert-for-ledger
+          {{- if .Values.auditor.tls.enabled }}
+            - name: scalardl-auditor-tls-volume
+              mountPath: /tls/scalardl-auditor/certs
+            - name: scalardl-auditor-tls-for-ledger-volume
+              mountPath: /tls/scalardl-ledger/certs
           {{- end }}
           {{- with .Values.auditor.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -164,9 +155,7 @@ spec:
               - -addr=localhost:40051
               {{- if .Values.auditor.tls.enabled }}
               - -tls
-              {{- if .Values.auditor.tls.caRootCertSecret }}
-              - -tls-ca-cert=/tls/certs/ca-root-cert.pem
-              {{- end }}
+              - -tls-ca-cert=/tls/scalardl-auditor/certs/ca.crt
               {{- if .Values.auditor.tls.overrideAuthority }}
               - -tls-server-name={{ .Values.auditor.tls.overrideAuthority }}
               {{- end }}
@@ -180,9 +169,7 @@ spec:
               - -addr=localhost:40051
               {{- if .Values.auditor.tls.enabled }}
               - -tls
-              {{- if .Values.auditor.tls.caRootCertSecret }}
-              - -tls-ca-cert=/tls/certs/ca-root-cert.pem
-              {{- end }}
+              - -tls-ca-cert=/tls/scalardl-auditor/certs/ca.crt
               {{- if .Values.auditor.tls.overrideAuthority }}
               - -tls-server-name={{ .Values.auditor.tls.overrideAuthority }}
               {{- end }}

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -278,6 +278,60 @@
                         "certChainSecret": {
                             "type": "string"
                         },
+                        "certManager": {
+                            "type": "object",
+                            "properties": {
+                                "dnsNames": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "duration": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "issuerRef": {
+                                    "type": "object"
+                                },
+                                "privateKey": {
+                                    "type": "object",
+                                    "properties": {
+                                        "algorithm": {
+                                            "type": "string"
+                                        },
+                                        "encoding": {
+                                            "type": "string"
+                                        },
+                                        "size": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "renewBefore": {
+                                    "type": "string"
+                                },
+                                "selfSignedCaRootCert": {
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "type": "string"
+                                        },
+                                        "renewBefore": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "usages": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -313,14 +313,22 @@
                                 "renewBefore": {
                                     "type": "string"
                                 },
-                                "selfSignedCaRootCert": {
+                                "selfSigned": {
                                     "type": "object",
                                     "properties": {
-                                        "duration": {
-                                            "type": "string"
+                                        "caRootCert": {
+                                            "type": "object",
+                                            "properties": {
+                                                "duration": {
+                                                    "type": "string"
+                                                },
+                                                "renewBefore": {
+                                                    "type": "string"
+                                                }
+                                            }
                                         },
-                                        "renewBefore": {
-                                            "type": "string"
+                                        "enabled": {
+                                            "type": "boolean"
                                         }
                                     }
                                 },

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -285,10 +285,10 @@ auditor:
       enabled: false
       # -- Configuration of a certificate for self-signed CA.
       selfSignedCaRootCert:
-        duration: "87600h0m0s"
+        duration: "8760h0m0s"
         renewBefore: "360h0m0s"
       # -- Duration of a certificate.
-      duration: "87600h0m0s"
+      duration: "8760h0m0s"
       # -- How long before expiry a certificate should be renewed.
       renewBefore: "360h0m0s"
       # -- Configuration of a private key.

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -280,3 +280,29 @@ auditor:
     privateKeySecret: ""
     # -- Name of the Secret containing the custom CA root certificate for TLS communication between Auditor and Ledger.
     caRootCertForLedgerSecret: ""
+    certManager:
+      # -- Use cert-manager to manage private key and certificate files.
+      enabled: false
+      # -- Configuration of a certificate for self-signed CA.
+      selfSignedCaRootCert:
+        duration: "87600h0m0s"
+        renewBefore: "360h0m0s"
+      # -- Duration of a certificate.
+      duration: "87600h0m0s"
+      # -- How long before expiry a certificate should be renewed.
+      renewBefore: "360h0m0s"
+      # -- Configuration of a private key.
+      privateKey:
+        algorithm: ECDSA
+        encoding: PKCS1
+        size: 256
+      # -- List of key usages.
+      usages:
+        - server auth
+        - key encipherment
+        - signing
+      # -- Subject Alternative Name (SAN) of a certificate.
+      dnsNames:
+        - localhost
+      # -- Issuer references of cert-manager.
+      issuerRef: {}

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -283,10 +283,14 @@ auditor:
     certManager:
       # -- Use cert-manager to manage private key and certificate files.
       enabled: false
-      # -- Configuration of a certificate for self-signed CA.
-      selfSignedCaRootCert:
-        duration: "8760h0m0s"
-        renewBefore: "360h0m0s"
+      selfSigned:
+        # -- Use self-signed CA.
+        enabled: false
+        caRootCert:
+          # -- Duration of a self-signed CA certificate.
+          duration: "8760h0m0s"
+          # -- How long before expiry a self-signed CA certificate should be renewed.
+          renewBefore: "360h0m0s"
       # -- Duration of a certificate.
       duration: "8760h0m0s"
       # -- How long before expiry a certificate should be renewed.


### PR DESCRIPTION
## Description

This PR updates ScalarDL Auditor chart to support cert-manager.

Please take a look!

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-internal-orchestration/pull/24
  - You can see the documents that describe how to use these new features in this PR.
- https://github.com/scalar-labs/helm-charts/pull/262
  - If you use self-signed CA, this chart deploy self-signed CA. And, Scalar Envoy chart refer it to generate certificate for Envoy.

## Changes made

Mainly, this PR adds/updates the following features (manifests):

1. Deploy a `Certificate` resource for cert-manager by using `charts/scalardl-audit/templates/auditor/certmanager.yaml`.

2. Deploy self-signed CA and create certificate for ScalarDL Auditor if you don't specify any `Issuer` resources in `issuerRef` configuration.

   - If you deploy Scalar Envoy as a sub chart of this ScalarDL Auditor chart without `issuerRef` configuration, the Envoy chart will use self-signed CA that is deployed by this chart to create certificate for Envoy.

   ```
   [ScalarDL Auditor chart (this chart)] ---(Deploy)---> [Issuer (self-signed CA)] <---(Refer via issuerRef configuration)--- [Certificate resource] <---(Deploy)--- [Envoy chart]
   ```

3. Update `deployment.spec.template.spec.volumes` and `deployment.spec.template.spec.containers.volumeMounts` to remove `subPath` configuration.

   - Cert-manager creates a secret resource that includes private key and certificate, and we use them by mounting them on pods. And, cert-manager automatically renew (update) the certificate in the secret resource before the certificate will be expired. However, if we use `subPath` to specify the mounted file name, [Kubernetes does not apply the changes of the secret resource](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod). So, to take advantage of cert-manager's automatically renew feature, we should not use `subPath`. This is because I removed `subPath` from the `volumeMounts` configuration.

4. Update file names of private key and certificate.

   - From the perspective of cert-manager specification (strictly, [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) specification of Kubernetes), we must use the fixed names for private key and certificate files. This is because cert-manager creates a secret resource that includes private key and certificate files with fixed names based on the [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) specification. So, I updated the file names in existing manifests.
     - `cert.pem` -> `tls.crt`
     - `key.pem` -> `tls.key`
     - `ca.pem` -> `ca.crt`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Support cert-manager in ScalarDL Auditor chart. You can manage private key and certificate for TLS connections by using cert-manager.

