### PR TITLE
Fix CI error of ScalarDB Server chart

### DIFF
--- a/charts/scalardb/ci/scalardb-ct-values.yaml
+++ b/charts/scalardb/ci/scalardb-ct-values.yaml
@@ -4,3 +4,4 @@ scalardb:
     scalar.db.contact_points=jdbc:postgresql://postgresql.default.svc.cluster.local:5432/postgres
     scalar.db.username=postgres
     scalar.db.password=postgres
+  imagePullSecrets: "reg-docker-secrets"

--- a/charts/scalardb/ci/scalardb-ct-values.yaml
+++ b/charts/scalardb/ci/scalardb-ct-values.yaml
@@ -5,4 +5,4 @@ scalardb:
     scalar.db.username=postgres
     scalar.db.password=postgres
   imagePullSecrets:
-    - "reg-docker-secrets"
+    - name: "reg-docker-secrets"

--- a/charts/scalardb/ci/scalardb-ct-values.yaml
+++ b/charts/scalardb/ci/scalardb-ct-values.yaml
@@ -4,4 +4,5 @@ scalardb:
     scalar.db.contact_points=jdbc:postgresql://postgresql.default.svc.cluster.local:5432/postgres
     scalar.db.username=postgres
     scalar.db.password=postgres
-  imagePullSecrets: "reg-docker-secrets"
+  imagePullSecrets:
+    - "reg-docker-secrets"


### PR DESCRIPTION
## Description

Recently, we updated the visibility of the ScalarDB Server container image from `public` to `private`.
https://github.com/orgs/scalar-labs/packages/container/package/scalardb-server

The old CI assumes that the ScalarDB Server container image is public. In other words, we don't set credentials for the ScalarDB Server chart in the CI. So, the CI failed in the `main` branch.

To resolve this issue, I set credentials (`reg-docker-secrets`) in the custom values file for CI.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add a secret resource configuration in the custom values file that is used in CI.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
