### PR TITLE
Add new version k8s in CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -98,11 +98,11 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.26.15
-          - v1.27.13
-          - v1.28.9
-          - v1.29.4
-          - v1.30.0
+          - v1.27.16
+          - v1.28.13
+          - v1.29.8
+          - v1.30.4
+          - v1.31.0
 
     steps:
       - name: Checkout
@@ -149,11 +149,11 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.26.15
-          - v1.27.13
-          - v1.28.9
-          - v1.29.4
-          - v1.30.0
+          - v1.27.16
+          - v1.28.13
+          - v1.29.8
+          - v1.30.4
+          - v1.31.0
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This directory contains the following helm charts.
 
 ## Prerequisites
 
-You need the [`helm`](https://helm.sh/docs/intro/install/) command. See [Package manager section in Requirements document](https://scalardb.scalar-labs.com/docs/latest/requirements/#package-manager) for details on supported Helm versions.
+You need the [`helm`](https://helm.sh/docs/intro/install/) command. For details on supported Helm versions, see the [Package manager section in the Requirements document](https://scalardb.scalar-labs.com/docs/latest/requirements/#package-manager).
 
 ## Supported Kubernetes versions
 
-See [Kubernetes section in Requirements document](https://scalardb.scalar-labs.com/docs/latest/requirements/#platform) for details on supported Kubernetes versions.
+For details on supported Kubernetes versions, see the [Kubernetes section in the Requirements document](https://scalardb.scalar-labs.com/docs/latest/requirements/#platform).
 
 We decide which versions to support based on the supported versions in [Amazon Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) and [Azure Kubernetes Service](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions). However, we do not consider the LTS versions in each managed Kubernetes service.
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This directory contains the following helm charts.
 
 ## Prerequisites
 
-* Helm 3.5+
+You need the [`helm`](https://helm.sh/docs/intro/install/) command. See [Package manager section in Requirements document](https://scalardb.scalar-labs.com/docs/latest/requirements/#package-manager) for details on supported Helm versions.
 
 ## Supported Kubernetes versions
 
-* 1.30.x, 1.29.x, 1.28.x, 1.27.x, 1.26.x
+See [Kubernetes section in Requirements document](https://scalardb.scalar-labs.com/docs/latest/requirements/#platform) for details on supported Kubernetes versions.
 
 We decide which versions to support based on the supported versions in [Amazon Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) and [Azure Kubernetes Service](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions). However, we do not consider the LTS versions in each managed Kubernetes service.
 


### PR DESCRIPTION
## Description

This PR updates the Kubernetes version in the CI.

Also, updated the `Supported Kubernetes Version` section in the `README`. Now, we have an official document that describes `Supported Kubernetes Versions`. So, I updated the `README` to refer to the official document.

In addition, I will update the supported Kubernetes version from `1.26 - 1.30` to `1.27 - 1.31` on the official document side in another PR.

Please take a look!

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-internal-scalardb/pull/421
  - I updated the official document in this PR. 

## Changes made

- Update Kubernetes versions in `.github/workflows/helm_charts_scalar.yml`.
- Update `README.md` to refer to the [official document](https://scalardb.scalar-labs.com/docs/latest/requirements/#kubernetes).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Basically, we decide on which Kubernetes versions are supported based on the managed Kubernetes services.

- https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
- https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli
- https://cloud.google.com/kubernetes-engine/docs/release-notes-regular
- https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengaboutk8sversions.htm

## Release notes

N/A