### PR TITLE
[scalardb-cluster] Support Azure Marketplace

### DIFF
--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -23,6 +23,13 @@ Current chart version is `2.0.0-SNAPSHOT`
 | envoy.service.ports.envoy.targetPort | int | `60053` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | fullnameOverride | string | `""` | String to fully override scalardb-cluster.fullname template |
+| global.azure.images.envoy.image | string | `"scalar-envoy"` |  |
+| global.azure.images.envoy.registry | string | `"ghcr.io/scalar-labs"` |  |
+| global.azure.images.envoy.tag | string | `"2.0.0-SNAPSHOT"` |  |
+| global.azure.images.scalardbCluster.image | string | `"scalardb-cluster-node-azure-payg-premium"` |  |
+| global.azure.images.scalardbCluster.registry | string | `"scalar.azurecr.io"` |  |
+| global.azure.images.scalardbCluster.tag | string | `"4.0.0-SNAPSHOT"` |  |
+| global.platform | string | `""` |  |
 | nameOverride | string | `""` | String to partially override scalardb-cluster.fullname template (will maintain the release name) |
 | scalardbCluster.affinity | object | `{}` | The affinity/anti-affinity feature, greatly expands the types of constraints you can express. |
 | scalardbCluster.extraVolumeMounts | list | `[]` | Defines additional volume mounts. If you want to get a heap dump of the ScalarDB Cluster node, you need to mount a volume to make the dump file persistent. |

--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -24,7 +24,7 @@ Current chart version is `2.0.0-SNAPSHOT`
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | fullnameOverride | string | `""` | String to fully override scalardb-cluster.fullname template |
 | global.azure.images.envoy.image | string | `"scalar-envoy"` |  |
-| global.azure.images.envoy.registry | string | `"ghcr.io/scalar-labs"` |  |
+| global.azure.images.envoy.registry | string | `"scalar.azurecr.io"` |  |
 | global.azure.images.envoy.tag | string | `"2.0.0-SNAPSHOT"` |  |
 | global.azure.images.scalardbCluster.image | string | `"scalardb-cluster-node-azure-payg-premium"` |  |
 | global.azure.images.scalardbCluster.registry | string | `"scalar.azurecr.io"` |  |

--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -23,13 +23,10 @@ Current chart version is `2.0.0-SNAPSHOT`
 | envoy.service.ports.envoy.targetPort | int | `60053` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | fullnameOverride | string | `""` | String to fully override scalardb-cluster.fullname template |
-| global.azure.images.envoy.image | string | `"scalar-envoy"` |  |
-| global.azure.images.envoy.registry | string | `"scalar.azurecr.io"` |  |
-| global.azure.images.envoy.tag | string | `"2.0.0-SNAPSHOT"` |  |
-| global.azure.images.scalardbCluster.image | string | `"scalardb-cluster-node-azure-payg-premium"` |  |
-| global.azure.images.scalardbCluster.registry | string | `"scalar.azurecr.io"` |  |
-| global.azure.images.scalardbCluster.tag | string | `"4.0.0-SNAPSHOT"` |  |
-| global.platform | string | `""` |  |
+| global.azure | object | `{"images":{"envoy":{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"},"scalardbCluster":{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}}}` | Azure Marketplace specific configurations. |
+| global.azure.images.envoy | object | `{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"}` | Container image of Envoy for Azure Marketplace. |
+| global.azure.images.scalardbCluster | object | `{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}` | Container image of ScalarDB Cluster for Azure Marketplace. |
+| global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | nameOverride | string | `""` | String to partially override scalardb-cluster.fullname template (will maintain the release name) |
 | scalardbCluster.affinity | object | `{}` | The affinity/anti-affinity feature, greatly expands the types of constraints you can express. |
 | scalardbCluster.extraVolumeMounts | list | `[]` | Defines additional volume mounts. If you want to get a heap dump of the ScalarDB Cluster node, you need to mount a volume to make the dump file persistent. |

--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         {{- end }}
       labels:
         {{- include "scalardb-cluster.selectorLabels" . | nindent 8 }}
+        {{- if eq .Values.global.platform "azure" }}
+        azure-extensions-usage-release-identifier: {{ .Release.Name }}
+        {{- end }}
     spec:
       restartPolicy: Always
       serviceAccountName: {{ include "scalardb-cluster.serviceAccountName" . }}
@@ -39,7 +42,11 @@ spec:
         - name: {{ .Chart.Name }}-node
           securityContext:
             {{- toYaml .Values.scalardbCluster.securityContext | nindent 12 }}
+          {{- if eq .Values.global.platform "azure" }}
+          image: "{{ .Values.global.azure.images.scalardbCluster.registry }}/{{ .Values.global.azure.images.scalardbCluster.image }}:{{ .Values.global.azure.images.scalardbCluster.tag }}"
+          {{- else }}
           image: "{{ .Values.scalardbCluster.image.repository }}:{{ .Values.scalardbCluster.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.scalardbCluster.image.pullPolicy }}
           ports:
             - containerPort: 60053

--- a/charts/scalardb-cluster/values.schema.json
+++ b/charts/scalardb-cluster/values.schema.json
@@ -62,6 +62,52 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "azure": {
+                    "type": "object",
+                    "properties": {
+                        "images": {
+                            "type": "object",
+                            "properties": {
+                                "envoy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "scalardbCluster": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "platform": {
+                    "type": "string"
+                }
+            }
+        },
         "nameOverride": {
             "type": "string"
         },

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -15,7 +15,7 @@ global:
       envoy:
         tag: "2.0.0-SNAPSHOT"
         image: "scalar-envoy"
-        registry: "ghcr.io/scalar-labs"
+        registry: "scalar.azurecr.io"
 
 # -- String to partially override scalardb-cluster.fullname template (will maintain the release name)
 nameOverride: ""

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -332,4 +332,3 @@ scalardbCluster:
         - localhost
       # -- Issuer references of cert-manager.
       issuerRef: {}
-

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -3,15 +3,17 @@
 # Declare variables to be passed into your templates.
 
 global:
-  # Specify the platform that you use. This configuration is for internal use.
+  # -- Specify the platform that you use. This configuration is for internal use.
   platform: ""
-  # Azure Marketplace specific configurations.
+  # -- Azure Marketplace specific configurations.
   azure:
     images:
+      # -- Container image of ScalarDB Cluster for Azure Marketplace.
       scalardbCluster:
         tag: "4.0.0-SNAPSHOT"
         image: "scalardb-cluster-node-azure-payg-premium"
         registry: "scalar.azurecr.io"
+      # -- Container image of Envoy for Azure Marketplace.
       envoy:
         tag: "2.0.0-SNAPSHOT"
         image: "scalar-envoy"

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -2,6 +2,21 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # Specify the platform that you use. This configuration is for internal use.
+  platform: ""
+  # Azure Marketplace specific configurations.
+  azure:
+    images:
+      scalardbCluster:
+        tag: "4.0.0-SNAPSHOT"
+        image: "scalardb-cluster-node-azure-payg-premium"
+        registry: "scalar.azurecr.io"
+      envoy:
+        tag: "2.0.0-SNAPSHOT"
+        image: "scalar-envoy"
+        registry: "ghcr.io/scalar-labs"
+
 # -- String to partially override scalardb-cluster.fullname template (will maintain the release name)
 nameOverride: ""
 # -- String to fully override scalardb-cluster.fullname template
@@ -317,3 +332,4 @@ scalardbCluster:
         - localhost
       # -- Issuer references of cert-manager.
       issuerRef: {}
+


### PR DESCRIPTION
## Description

This PR updates the ScalarDB Cluster Helm Chart to support Azure Marketplace.

To list ScalarDB Cluster on the Azure Marketplace, we have to update our helm chart based on the rules of Azure Marketplace. So, I updated ScalarDB Cluster chart as follows:

- Add `global.azure.*` in the `values.yaml` file.
- Update `spec.template.spec.containers[].image` in the `deployment.yaml` file to pull the container image from ACR for Azure Marketplace.
- Add the `azure-extensions-usage-release-identifier` label in the `deployment.yaml` to trace pods and charge license fees by Azure.

You can see what we need to list products on the Azure Marketplace in the following Azure document.

- [Update the Helm chart](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes#update-the-helm-chart)
- [Make updates based on your billing model](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes#make-updates-based-on-your-billing-model)

Also, to reduce the maintenance cost (avoid duplicated maintenance), I updated the current helm chart instead of creating the Azure Marketplace dedicated helm chart. To achieve that, I added the following things:

- Add `global.platform` in the `values.yaml` file.
  - I assume this parameter for switching our helm chart based on platforms (to list on each cloud marketplace, partner catalog or something like that) in the future. In other words, this configuration is not related to Azure Marketplace directly.
  - For example, if you set `global.platform=azure`, ScalarDB Cluster chart use or add the Azure Marketplace dedicated configurations.
  - We need to do the same thing in the Envoy chart (subchart of ScalarDB Cluster chart). So, I decided to add this parameter as [Global Values](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values). We can use this `global.platform` configuration in both ScalarDB Cluster chart (main chart) and Envoy chart (subchart).

Please take a look!

## Related issues and/or PRs

- I updated the Envoy chart in the following PR.
  - 

## Changes made

- Update `charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml` to add the Azure Marketplace dedicated configurations.
- Update `charts/scalardb-cluster/values.yaml` to add the Azure Marketplace dedicated configurations.
- `charts/scalardb-cluster/README.md` and `charts/scalardb-cluster/values.schema.json` are updated automatically based on `values.yaml`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A