### PR TITLE
[envoy] Support Azure Marketplace

### DIFF
--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -14,6 +14,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 | affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
 | envoyConfiguration.serviceListeners | string | `"scalar-service:50051,scalar-privileged:50052"` | list of service name and port |
+| global.platform | string | `""` |  |
 | grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |

--- a/charts/envoy/README.md
+++ b/charts/envoy/README.md
@@ -14,7 +14,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 | affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | envoyConfiguration.adminAccessLogPath | string | `"/dev/stdout"` | admin log path |
 | envoyConfiguration.serviceListeners | string | `"scalar-service:50051,scalar-privileged:50052"` | list of service name and port |
-| global.platform | string | `""` |  |
+| global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |

--- a/charts/envoy/templates/deployment.yaml
+++ b/charts/envoy/templates/deployment.yaml
@@ -40,7 +40,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if eq .Values.global.platform "azure" }}
+          image: "{{ .Values.global.azure.images.envoy.registry }}/{{ .Values.global.azure.images.envoy.image }}:{{ .Values.global.azure.images.envoy.tag }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.version }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: 50051

--- a/charts/envoy/values.schema.json
+++ b/charts/envoy/values.schema.json
@@ -16,6 +16,14 @@
                 }
             }
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "platform": {
+                    "type": "string"
+                }
+            }
+        },
         "grafanaDashboard": {
             "type": "object",
             "properties": {

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -1,5 +1,5 @@
 global:
-  # Specify the platform that you use. This configuration is for internal use.
+  # -- Specify the platform that you use. This configuration is for internal use.
   platform: ""
 
 # replicaCount -- number of replicas to deploy

--- a/charts/envoy/values.yaml
+++ b/charts/envoy/values.yaml
@@ -1,3 +1,7 @@
+global:
+  # Specify the platform that you use. This configuration is for internal use.
+  platform: ""
+
 # replicaCount -- number of replicas to deploy
 replicaCount: 3
 


### PR DESCRIPTION
## Description

This PR updates the Envoy Helm Chart to support Azure Marketplace.

To list Scalar products (ScalarDB Cluster and ScalarDL) on the Azure Marketplace, we have to update our helm chart based on the rules of Azure Marketplace. So, I updated Envoy chart as follows:

- Update `spec.template.spec.containers[].image` in the `deployment.yaml` file to pull the container image from ACR for Azure Marketplace.

Also, I added the condition (if statement) based on the value of `global.platform`. Basically, Envoy chart is used as `subchart` from Scalar products charts (main charts). So, this `global.platform` value is passed from the main chart. However, we must set default value in `values.yaml` on the Envoy chart side.

You can see more details on the Azure Marketplace support on the ScalarDB Cluster's PR side.
https://github.com/scalar-labs/helm-charts/pull/275

Please take a look!

## Related issues and/or PRs

- I updated the ScalarDB Cluster chart in the following PR.
  - https://github.com/scalar-labs/helm-charts/pull/275

## Changes made

- Update `charts/envoy/templates/deployment.yaml` to add the Azure Marketplace dedicated configurations.
- Update `charts/envoy/values.yaml` to add `global.platform` that is used for switching assumed platform.
- `charts/envoy/README.md` and `charts/envoy/values.yaml` are updated automatically based on `values.yaml`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A