### PR TITLE
[scalardl-ledger] Support Azure Marketplace

### DIFF
--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -26,6 +26,10 @@ Current chart version is `5.0.0-SNAPSHOT`
 | envoy.service.ports.envoy.targetPort | int | `50051` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | fullnameOverride | string | `""` | String to fully override scalardl.fullname template |
+| global.azure | object | `{"images":{"envoy":{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"},"scalardlLedger":{"image":"scalardl-ledger-azure-payg","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}}}` | Azure Marketplace specific configurations. |
+| global.azure.images.envoy | object | `{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"}` | Container image of Envoy for Azure Marketplace. |
+| global.azure.images.scalardlLedger | object | `{"image":"scalardl-ledger-azure-payg","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}` | Container image of ScalarDL Ledger for Azure Marketplace. |
+| global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | ledger.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | ledger.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | ledger.extraVolumeMounts | list | `[]` | Defines additional volume mounts. |

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/ledger/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "scalardl-ledger.selectorLabels" . | nindent 8 }}
+        {{- if eq .Values.global.platform "azure" }}
+        azure-extensions-usage-release-identifier: {{ .Release.Name }}
+        {{- end }}
     spec:
       restartPolicy: Always
       {{- if .Values.ledger.serviceAccount.serviceAccountName }}
@@ -66,7 +69,11 @@ spec:
         - name: {{ .Chart.Name }}-ledger
           securityContext:
             {{- toYaml .Values.ledger.securityContext | nindent 12 }}
+          {{- if eq .Values.global.platform "azure" }}
+          image: "{{ .Values.global.azure.images.scalardlLedger.registry }}/{{ .Values.global.azure.images.scalardlLedger.image }}:{{ .Values.global.azure.images.scalardlLedger.tag }}"
+          {{- else }}
           image: "{{ .Values.ledger.image.repository }}:{{ .Values.ledger.image.version }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.ledger.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.ledger.scalarLedgerConfiguration.ledgerProofEnabled }}

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -76,6 +76,52 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "azure": {
+                    "type": "object",
+                    "properties": {
+                        "images": {
+                            "type": "object",
+                            "properties": {
+                                "envoy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "scalardlLedger": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "platform": {
+                    "type": "string"
+                }
+            }
+        },
         "ledger": {
             "type": "object",
             "properties": {

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -2,6 +2,23 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # -- Specify the platform that you use. This configuration is for internal use.
+  platform: ""
+  # -- Azure Marketplace specific configurations.
+  azure:
+    images:
+      # -- Container image of ScalarDL Ledger for Azure Marketplace.
+      scalardlLedger:
+        tag: "4.0.0-SNAPSHOT"
+        image: "scalardl-ledger-azure-payg"
+        registry: "scalar.azurecr.io"
+      # -- Container image of Envoy for Azure Marketplace.
+      envoy:
+        tag: "2.0.0-SNAPSHOT"
+        image: "scalar-envoy"
+        registry: "scalar.azurecr.io"
+
 # -- String to partially override scalardl.fullname template (will maintain the release name)
 nameOverride: ""
 


### PR DESCRIPTION
## Description

This PR updates the ScalarDL Ledger Helm Chart to support Azure Marketplace.

To list ScalarDL Ledger on the Azure Marketplace, we have to update our helm chart based on the rules of Azure Marketplace. So, I updated ScalarDL Ledger chart as follows:

- Add `global.azure.*` in the `values.yaml` file.
- Update `spec.template.spec.containers[].image` in the `deployment.yaml` file to pull the container image from ACR for Azure Marketplace.
- Add the `azure-extensions-usage-release-identifier` label in the `deployment.yaml` to trace pods and charge license fees by Azure.

You can see what we need to list products on the Azure Marketplace in the following Azure document.

- [Update the Helm chart](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes#update-the-helm-chart)
- [Make updates based on your billing model](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes#make-updates-based-on-your-billing-model)

Also, to reduce the maintenance cost (avoid duplicated maintenance), I updated the current helm chart instead of creating the Azure Marketplace dedicated helm chart. To achieve that, I added the following things:

- Add `global.platform` in the `values.yaml` file.
  - I assume this parameter for switching our helm chart based on platforms (to list on each cloud marketplace, partner catalog or something like that) in the future. In other words, this configuration is not related to Azure Marketplace directly.
  - For example, if you set `global.platform=azure`, ScalarDL Ledger chart use or add the Azure Marketplace dedicated configurations.
  - We need to do the same thing in the Envoy chart (subchart of ScalarDL Ledger chart). So, I decided to add this parameter as [Global Values](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values). We can use this `global.platform` configuration in both ScalarDL Ledger chart (main chart) and Envoy chart (subchart).

Please take a look!

## Related issues and/or PRs

- I updated the Envoy chart in the following PR.
  - https://github.com/scalar-labs/helm-charts/pull/276

## Changes made

- Update `charts/scalardl/templates/ledter/deployment.yaml` to add the Azure Marketplace dedicated configurations.
- Update `charts/scalardl/values.yaml` to add the Azure Marketplace dedicated configurations.
- `charts/scalardl/README.md` and `charts/scalardl/values.schema.json` are updated automatically based on `values.yaml`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A