### PR TITLE
[scalardl-auditor] Support Azure Marketplace

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -97,8 +97,8 @@ Current chart version is `3.0.0-SNAPSHOT`
 | envoy.service.ports.envoy.targetPort | int | `40051` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | fullnameOverride | string | `""` | String to fully override scalardl-audit.fullname template |
-| global.azure | object | `{"images":{"envoy":{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"},"scalardbCluster":{"image":"scalardl-auditor-azure-payg","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}}}` | Azure Marketplace specific configurations. |
+| global.azure | object | `{"images":{"envoy":{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"},"scalardlAuditor":{"image":"scalardl-auditor-azure-payg","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}}}` | Azure Marketplace specific configurations. |
 | global.azure.images.envoy | object | `{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"}` | Container image of Envoy for Azure Marketplace. |
-| global.azure.images.scalardbCluster | object | `{"image":"scalardl-auditor-azure-payg","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}` | Container image of ScalarDL Auditor for Azure Marketplace. |
+| global.azure.images.scalardlAuditor | object | `{"image":"scalardl-auditor-azure-payg","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}` | Container image of ScalarDL Auditor for Azure Marketplace. |
 | global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | nameOverride | string | `""` | String to partially override scalardl-audit.fullname template (will maintain the release name) |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -97,4 +97,8 @@ Current chart version is `3.0.0-SNAPSHOT`
 | envoy.service.ports.envoy.targetPort | int | `40051` | envoy k8s internal name |
 | envoy.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | fullnameOverride | string | `""` | String to fully override scalardl-audit.fullname template |
+| global.azure | object | `{"images":{"envoy":{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"},"scalardbCluster":{"image":"scalardl-auditor-azure-payg","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}}}` | Azure Marketplace specific configurations. |
+| global.azure.images.envoy | object | `{"image":"scalar-envoy","registry":"scalar.azurecr.io","tag":"2.0.0-SNAPSHOT"}` | Container image of Envoy for Azure Marketplace. |
+| global.azure.images.scalardbCluster | object | `{"image":"scalardl-auditor-azure-payg","registry":"scalar.azurecr.io","tag":"4.0.0-SNAPSHOT"}` | Container image of ScalarDL Auditor for Azure Marketplace. |
+| global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | nameOverride | string | `""` | String to partially override scalardl-audit.fullname template (will maintain the release name) |

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/auditor/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 8 }}
+        {{- if eq .Values.global.platform "azure" }}
+        azure-extensions-usage-release-identifier: {{ .Release.Name }}
+        {{- end }}
     spec:
       restartPolicy: Always
       {{- if .Values.auditor.serviceAccount.serviceAccountName }}
@@ -75,7 +78,11 @@ spec:
         - name: {{ .Chart.Name }}-auditor
           securityContext:
             {{- toYaml .Values.auditor.securityContext | nindent 12 }}
+          {{- if eq .Values.global.platform "azure" }}
+          image: "{{ .Values.global.azure.images.scalardbCluster.registry }}/{{ .Values.global.azure.images.scalardbCluster.image }}:{{ .Values.global.azure.images.scalardbCluster.tag }}"
+          {{- else }}
           image: "{{ .Values.auditor.image.repository }}:{{ .Values.auditor.image.version }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.auditor.image.pullPolicy }}
           volumeMounts:
           {{- if not .Values.auditor.extraVolumeMounts }}

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -79,7 +79,7 @@ spec:
           securityContext:
             {{- toYaml .Values.auditor.securityContext | nindent 12 }}
           {{- if eq .Values.global.platform "azure" }}
-          image: "{{ .Values.global.azure.images.scalardbCluster.registry }}/{{ .Values.global.azure.images.scalardbCluster.image }}:{{ .Values.global.azure.images.scalardbCluster.tag }}"
+          image: "{{ .Values.global.azure.images.scalardlAuditor.registry }}/{{ .Values.global.azure.images.scalardlAuditor.image }}:{{ .Values.global.azure.images.scalardlAuditor.tag }}"
           {{- else }}
           image: "{{ .Values.auditor.image.repository }}:{{ .Values.auditor.image.version }}"
           {{- end }}

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -456,7 +456,7 @@
                                         }
                                     }
                                 },
-                                "scalardbCluster": {
+                                "scalardlAuditor": {
                                     "type": "object",
                                     "properties": {
                                         "image": {

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -433,6 +433,52 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "azure": {
+                    "type": "object",
+                    "properties": {
+                        "images": {
+                            "type": "object",
+                            "properties": {
+                                "envoy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "scalardbCluster": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "platform": {
+                    "type": "string"
+                }
+            }
+        },
         "nameOverride": {
             "type": "string"
         }

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -2,6 +2,23 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # -- Specify the platform that you use. This configuration is for internal use.
+  platform: ""
+  # -- Azure Marketplace specific configurations.
+  azure:
+    images:
+      # -- Container image of ScalarDL Auditor for Azure Marketplace.
+      scalardbCluster:
+        tag: "4.0.0-SNAPSHOT"
+        image: "scalardl-auditor-azure-payg"
+        registry: "scalar.azurecr.io"
+      # -- Container image of Envoy for Azure Marketplace.
+      envoy:
+        tag: "2.0.0-SNAPSHOT"
+        image: "scalar-envoy"
+        registry: "scalar.azurecr.io"
+
 # -- String to partially override scalardl-audit.fullname template (will maintain the release name)
 nameOverride: ""
 

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -9,7 +9,7 @@ global:
   azure:
     images:
       # -- Container image of ScalarDL Auditor for Azure Marketplace.
-      scalardbCluster:
+      scalardlAuditor:
         tag: "4.0.0-SNAPSHOT"
         image: "scalardl-auditor-azure-payg"
         registry: "scalar.azurecr.io"


### PR DESCRIPTION
## Description

This PR updates the ScalarDL Auditor Helm Chart to support Azure Marketplace.

To list ScalarDL Auditro on the Azure Marketplace, we have to update our helm chart based on the rules of Azure Marketplace. So, I updated ScalarDL Auditor chart as follows:

- Add `global.azure.*` in the `values.yaml` file.
- Update `spec.template.spec.containers[].image` in the `deployment.yaml` file to pull the container image from ACR for Azure Marketplace.
- Add the `azure-extensions-usage-release-identifier` label in the `deployment.yaml` to trace pods and charge license fees by Azure.

You can see what we need to list products on the Azure Marketplace in the following Azure document.

- [Update the Helm chart](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes#update-the-helm-chart)
- [Make updates based on your billing model](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes#make-updates-based-on-your-billing-model)

Also, to reduce the maintenance cost (avoid duplicated maintenance), I updated the current helm chart instead of creating the Azure Marketplace dedicated helm chart. To achieve that, I added the following things:

- Add `global.platform` in the `values.yaml` file.
  - I assume this parameter for switching our helm chart based on platforms (to list on each cloud marketplace, partner catalog or something like that) in the future. In other words, this configuration is not related to Azure Marketplace directly.
  - For example, if you set `global.platform=azure`, ScalarDL Auditor chart use or add the Azure Marketplace dedicated configurations.
  - We need to do the same thing in the Envoy chart (subchart of ScalarDL Auditor chart). So, I decided to add this parameter as [Global Values](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values). We can use this `global.platform` configuration in both ScalarDL Auditor chart (main chart) and Envoy chart (subchart).

Please take a look!

## Related issues and/or PRs

- I updated the Envoy chart in the following PR.
  - https://github.com/scalar-labs/helm-charts/pull/276

## Changes made

- Update `charts/scalardl-audit/templates/auditor/deployment.yaml` to add the Azure Marketplace dedicated configurations.
- Update `charts/scalardl-audit/values.yaml` to add the Azure Marketplace dedicated configurations.
- `charts/scalardl-audit/README.md` and `charts/scalardl-audit/values.schema.json` are updated automatically based on `values.yaml`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A