### PR TITLE
Update k8s versions in CI

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -177,7 +177,7 @@ jobs:
           fi
 
       - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@v1.7.0
+        uses: helm/kind-action@v1.11.0
         with:
           config: .github/kind-cluster.yaml
           node_image: kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -98,11 +98,11 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.27.16
-          - v1.28.13
-          - v1.29.8
-          - v1.30.4
-          - v1.31.0
+          - v1.28.15
+          - v1.29.12
+          - v1.30.8
+          - v1.31.4
+          - v1.32.0
 
     steps:
       - name: Checkout
@@ -149,11 +149,11 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.27.16
-          - v1.28.13
-          - v1.29.8
-          - v1.30.4
-          - v1.31.0
+          - v1.28.15
+          - v1.29.12
+          - v1.30.8
+          - v1.31.4
+          - v1.32.0
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

This PR updates the versions of Kubernetes in the CI.

- Add `1.32` which is the latest version of Kubernetes.
- Remove `1.27` which is already the EoL version.
  - I confirmed that each major managed Kubernetes does not support `1.27` now.
    - [EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
    - [AKS](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
    - [GKE](https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions)
    - [OKE](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengaboutk8sversions.htm)

## Related issues and/or PRs

N/A

## Changes made

- Add Kubernetes `1.32`.
- Remove Kubernetes `1.27` since it has already been EoL.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
