### PR TITLE
[scalar-manager] Support Azure Marketplace

### DIFF
--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -12,7 +12,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` |  |
-| global.azure | object | `{"images":{"scalarManager":{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}}}` | Azure Marketplace specific configurations. |
+| global.azure | object | `{"extension":{"resourceId":"DONOTMODIFY"},"identity":{"clientId":"DONOTMODIFY"},"images":{"scalarManager":{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}},"marketplace":{"planId":"DONOTMODIFY"}}` | Azure Marketplace specific configurations. |
 | global.azure.images.scalarManager | object | `{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}` | Container image of Scalar Manager for Azure Marketplace. |
 | global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | nameOverride | string | `""` |  |

--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -11,29 +11,32 @@ Current chart version is `3.0.0-SNAPSHOT`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| api.applicationProperties | string | The minimum template of application.properties is set by default. | The application.properties for Scalar Manager. If you want to customize application.properties, you can override this value with your application.properties. |
-| api.image.pullPolicy | string | `"IfNotPresent"` |  |
-| api.image.repository | string | `"ghcr.io/scalar-labs/scalar-manager-api"` |  |
-| api.image.tag | string | `""` |  |
-| api.resources | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
-| imagePullSecrets[0].name | string | `"reg-docker-secrets"` |  |
+| global.azure | object | `{"images":{"scalarManager":{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}}}` | Azure Marketplace specific configurations. |
+| global.azure.images.scalarManager | object | `{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}` | Container image of Scalar Manager for Azure Marketplace. |
+| global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| replicaCount | int | `1` |  |
-| securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| securityContext.runAsNonRoot | bool | `true` |  |
-| serviceAccount.automountServiceAccountToken | bool | `true` |  |
-| serviceAccount.serviceAccountName | string | `""` |  |
-| tolerations | list | `[]` |  |
-| web.env | list | `[{"name":"GRAFANA_SERVER_URL","value":"http://scalar-monitoring-grafana.monitoring.svc.cluster.local:3000"}]` | The environment variables for Scalar Manager web container. If you want to customize environment variables, you can override this value with your environment variables. |
-| web.image.pullPolicy | string | `"IfNotPresent"` |  |
-| web.image.repository | string | `"ghcr.io/scalar-labs/scalar-manager-web"` |  |
-| web.image.tag | string | `""` |  |
-| web.resources | object | `{}` |  |
-| web.service.port | int | `80` |  |
-| web.service.type | string | `"ClusterIP"` |  |
+| scalarManager.api.applicationProperties | string | The minimum template of application.properties is set by default. | The application.properties for Scalar Manager. If you want to customize application.properties, you can override this value with your application.properties. |
+| scalarManager.api.image.pullPolicy | string | `"IfNotPresent"` |  |
+| scalarManager.api.image.repository | string | `"ghcr.io/scalar-labs/scalar-manager-api"` |  |
+| scalarManager.api.image.tag | string | `""` |  |
+| scalarManager.api.resources | object | `{}` |  |
+| scalarManager.imagePullSecrets[0].name | string | `"reg-docker-secrets"` |  |
+| scalarManager.nodeSelector | object | `{}` |  |
+| scalarManager.podAnnotations | object | `{}` |  |
+| scalarManager.podLabels | object | `{}` |  |
+| scalarManager.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| scalarManager.replicaCount | int | `1` |  |
+| scalarManager.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| scalarManager.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| scalarManager.securityContext.runAsNonRoot | bool | `true` |  |
+| scalarManager.serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| scalarManager.serviceAccount.serviceAccountName | string | `""` |  |
+| scalarManager.tolerations | list | `[]` |  |
+| scalarManager.web.env | list | `[{"name":"GRAFANA_SERVER_URL","value":"http://scalar-monitoring-grafana.monitoring.svc.cluster.local:3000"}]` | The environment variables for Scalar Manager web container. If you want to customize environment variables, you can override this value with your environment variables. |
+| scalarManager.web.image.pullPolicy | string | `"IfNotPresent"` |  |
+| scalarManager.web.image.repository | string | `"ghcr.io/scalar-labs/scalar-manager-web"` |  |
+| scalarManager.web.image.tag | string | `""` |  |
+| scalarManager.web.resources | object | `{}` |  |
+| scalarManager.web.service.port | int | `80` |  |
+| scalarManager.web.service.type | string | `"ClusterIP"` |  |

--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -12,8 +12,8 @@ Current chart version is `3.0.0-SNAPSHOT`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` |  |
-| global.azure | object | `{"extension":{"resourceId":"DONOTMODIFY"},"identity":{"clientId":"DONOTMODIFY"},"images":{"scalarManager":{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}},"marketplace":{"planId":"DONOTMODIFY"}}` | Azure Marketplace specific configurations. |
-| global.azure.images.scalarManager | object | `{"image":"scalardb-cluster-node-azure-payg-premium","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}` | Container image of Scalar Manager for Azure Marketplace. |
+| global.azure | object | `{"extension":{"resourceId":"DONOTMODIFY"},"identity":{"clientId":"DONOTMODIFY"},"images":{"scalarManagerApi":{"image":"scalar-manager-api-azure-payg","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"},"scalarManagerWeb":{"image":"scalar-manager-web-azure-payg","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}},"marketplace":{"planId":"DONOTMODIFY"}}` | Azure Marketplace specific configurations. |
+| global.azure.images.scalarManagerApi | object | `{"image":"scalar-manager-api-azure-payg","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}` | Container image of Scalar Manager for Azure Marketplace. |
 | global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | nameOverride | string | `""` |  |
 | scalarManager.api.applicationProperties | string | The minimum template of application.properties is set by default. | The application.properties for Scalar Manager. If you want to customize application.properties, you can override this value with your application.properties. |

--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -12,8 +12,8 @@ Current chart version is `3.0.0-SNAPSHOT`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` |  |
-| global.azure | object | `{"extension":{"resourceId":"DONOTMODIFY"},"identity":{"clientId":"DONOTMODIFY"},"images":{"scalarManagerApi":{"image":"scalar-manager-api-azure-payg","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"},"scalarManagerWeb":{"image":"scalar-manager-web-azure-payg","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}},"marketplace":{"planId":"DONOTMODIFY"}}` | Azure Marketplace specific configurations. |
-| global.azure.images.scalarManagerApi | object | `{"image":"scalar-manager-api-azure-payg","registry":"scalar.azurecr.io","tag":"3.0.0-SNAPSHOT"}` | Container image of Scalar Manager for Azure Marketplace. |
+| global.azure | object | `{"extension":{"resourceId":"DONOTMODIFY"},"identity":{"clientId":"DONOTMODIFY"},"images":{"scalarManagerApi":{"image":"scalar-manager-api-azure-payg","registry":"scalar.azurecr.io","tag":""},"scalarManagerWeb":{"image":"scalar-manager-web-azure-payg","registry":"scalar.azurecr.io","tag":""}},"marketplace":{"planId":"DONOTMODIFY"}}` | Azure Marketplace specific configurations. |
+| global.azure.images.scalarManagerApi | object | `{"image":"scalar-manager-api-azure-payg","registry":"scalar.azurecr.io","tag":""}` | Container image of Scalar Manager for Azure Marketplace. |
 | global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | nameOverride | string | `""` |  |
 | scalarManager.api.applicationProperties | string | The minimum template of application.properties is set by default. | The application.properties for Scalar Manager. If you want to customize application.properties, you can override this value with your application.properties. |

--- a/charts/scalar-manager/templates/_helpers.tpl
+++ b/charts/scalar-manager/templates/_helpers.tpl
@@ -55,8 +55,8 @@ app.kubernetes.io/app: scalar-manager
 Create the name of the service account to use
 */}}
 {{- define "scalar-manager.serviceAccountName" -}}
-{{- if .Values.serviceAccount.serviceAccountName }}
-{{- .Values.serviceAccount.serviceAccountName }}
+{{- if .Values.scalarManager.serviceAccount.serviceAccountName }}
+{{- .Values.scalarManager.serviceAccount.serviceAccountName }}
 {{- else }}
 {{- print (include "scalar-manager.fullname" .) "-sa" | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/charts/scalar-manager/templates/scalar-manager/configmap.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "scalar-manager.labels" . | nindent 4 }}
 data:
   scalar-manager-api-application.properties:
-    {{- toYaml .Values.api.applicationProperties | nindent 4 }}
+    {{- toYaml .Values.scalarManager.api.applicationProperties | nindent 4 }}

--- a/charts/scalar-manager/templates/scalar-manager/deployment.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-api
           {{- if eq .Values.global.platform "azure" }}
-          image: "{{ .Values.global.azure.images.scalarManagerApi.registry }}/{{ .Values.global.azure.images.scalarManagerApi.image }}:{{ .Values.global.azure.images.scalarManagerApi.tag }}"
+          image: "{{ .Values.global.azure.images.scalarManagerApi.registry }}/{{ .Values.global.azure.images.scalarManagerApi.image }}:{{ .Values.global.azure.images.scalarManagerApi.tag | default .Chart.AppVersion }}"
           {{- else }}
           image: "{{ .Values.scalarManager.api.image.repository }}:{{ .Values.scalarManager.api.image.tag | default .Chart.AppVersion }}"
           {{- end }}
@@ -46,7 +46,7 @@ spec:
               subPath: scalar-manager-api-application.properties
         - name: {{ .Chart.Name }}-web
           {{- if eq .Values.global.platform "azure" }}
-          image: "{{ .Values.global.azure.images.scalarManagerWeb.registry }}/{{ .Values.global.azure.images.scalarManagerWeb.image }}:{{ .Values.global.azure.images.scalarManagerWeb.tag }}"
+          image: "{{ .Values.global.azure.images.scalarManagerWeb.registry }}/{{ .Values.global.azure.images.scalarManagerWeb.image }}:{{ .Values.global.azure.images.scalarManagerWeb.tag | default .Chart.AppVersion }}"
           {{- else }}
           image: "{{ .Values.scalarManager.web.image.repository }}:{{ .Values.scalarManager.web.image.tag | default .Chart.AppVersion }}"
           {{- end }}

--- a/charts/scalar-manager/templates/scalar-manager/deployment.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/deployment.yaml
@@ -28,7 +28,11 @@ spec:
       automountServiceAccountToken: {{ .Values.scalarManager.serviceAccount.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name }}-api
+          {{- if eq .Values.global.platform "azure" }}
+          image: "{{ .Values.global.azure.images.scalarManagerApi.registry }}/{{ .Values.global.azure.images.scalarManagerApi.image }}:{{ .Values.global.azure.images.scalarManagerApi.tag }}"
+          {{- else }}
           image: "{{ .Values.scalarManager.api.image.repository }}:{{ .Values.scalarManager.api.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           resources:
             {{- toYaml .Values.scalarManager.api.resources | nindent 12 }}
           ports:
@@ -41,7 +45,11 @@ spec:
               mountPath: /app/application.properties
               subPath: scalar-manager-api-application.properties
         - name: {{ .Chart.Name }}-web
+          {{- if eq .Values.global.platform "azure" }}
+          image: "{{ .Values.global.azure.images.scalarManagerWeb.registry }}/{{ .Values.global.azure.images.scalarManagerWeb.image }}:{{ .Values.global.azure.images.scalarManagerWeb.tag }}"
+          {{- else }}
           image: "{{ .Values.scalarManager.web.image.repository }}:{{ .Values.scalarManager.web.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           resources:
             {{- toYaml .Values.scalarManager.web.resources | nindent 12 }}
           env:

--- a/charts/scalar-manager/templates/scalar-manager/deployment.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "scalar-manager.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.scalarManager.replicaCount }}
   selector:
     matchLabels:
       {{- include "scalar-manager.selectorLabels" . | nindent 6 }}
@@ -14,62 +14,62 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/scalar-manager/configmap.yaml") . | sha256sum }}
-        {{- if .Values.podAnnotations }}
-        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- if .Values.scalarManager.podAnnotations }}
+        {{- toYaml .Values.scalarManager.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
         {{- include "scalar-manager.selectorLabels" . | nindent 8 }}
-        {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- if .Values.scalarManager.podLabels }}
+        {{- toYaml .Values.scalarManager.podLabels | nindent 8 }}
         {{- end }}
     spec:
       restartPolicy: Always
       serviceAccountName: {{ include "scalar-manager.serviceAccountName" . }}
-      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.scalarManager.serviceAccount.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name }}-api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.scalarManager.api.image.repository }}:{{ .Values.scalarManager.api.image.tag | default .Chart.AppVersion }}"
           resources:
-            {{- toYaml .Values.api.resources | nindent 12 }}
+            {{- toYaml .Values.scalarManager.api.resources | nindent 12 }}
           ports:
             - containerPort: 8080
-          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.scalarManager.api.image.pullPolicy }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.scalarManager.securityContext | nindent 12 }}
           volumeMounts:
             - name: api-application-properties-volume
               mountPath: /app/application.properties
               subPath: scalar-manager-api-application.properties
         - name: {{ .Chart.Name }}-web
-          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.scalarManager.web.image.repository }}:{{ .Values.scalarManager.web.image.tag | default .Chart.AppVersion }}"
           resources:
-            {{- toYaml .Values.web.resources | nindent 12 }}
+            {{- toYaml .Values.scalarManager.web.resources | nindent 12 }}
           env:
-            {{- toYaml .Values.web.env | nindent 12 }}
+            {{- toYaml .Values.scalarManager.web.env | nindent 12 }}
           ports:
             - containerPort: 3000
-          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.scalarManager.web.image.pullPolicy }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.scalarManager.securityContext | nindent 12 }}
       volumes:
         - name: api-application-properties-volume
           configMap:
             name: {{ include "scalar-manager.fullname" . }}-api-application-properties
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- with .Values.imagePullSecrets }}
+        {{- toYaml .Values.scalarManager.podSecurityContext | nindent 8 }}
+      {{- with .Values.scalarManager.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.scalarManager.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.scalarManager.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.scalarManager.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/scalar-manager/templates/scalar-manager/service.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/service.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     {{- include "scalar-manager.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.web.service.type }}
+  type: {{ .Values.scalarManager.web.service.type }}
   ports:
     - protocol: TCP
       name: web
-      port: {{ .Values.web.service.port }}
+      port: {{ .Values.scalarManager.web.service.port }}
       targetPort: 3000
   selector:
     {{- include "scalar-manager.selectorLabels" . | nindent 4 }}

--- a/charts/scalar-manager/templates/scalar-manager/serviceaccount.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceAccount.serviceAccountName }}
+{{- if not .Values.scalarManager.serviceAccount.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/scalar-manager/values.schema.json
+++ b/charts/scalar-manager/values.schema.json
@@ -30,7 +30,21 @@
                         "images": {
                             "type": "object",
                             "properties": {
-                                "scalarManager": {
+                                "scalarManagerApi": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "scalarManagerWeb": {
                                     "type": "object",
                                     "properties": {
                                         "image": {

--- a/charts/scalar-manager/values.schema.json
+++ b/charts/scalar-manager/values.schema.json
@@ -2,151 +2,188 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
-        "api": {
-            "type": "object",
-            "properties": {
-                "applicationProperties": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "resources": {
-                    "type": "object"
-                }
-            }
-        },
         "fullnameOverride": {
             "type": "string"
         },
-        "imagePullSecrets": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
+        "global": {
+            "type": "object",
+            "properties": {
+                "azure": {
+                    "type": "object",
+                    "properties": {
+                        "images": {
+                            "type": "object",
+                            "properties": {
+                                "scalarManager": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
+                },
+                "platform": {
+                    "type": "string"
                 }
             }
         },
         "nameOverride": {
             "type": "string"
         },
-        "nodeSelector": {
-            "type": "object"
-        },
-        "podAnnotations": {
-            "type": "object"
-        },
-        "podLabels": {
-            "type": "object"
-        },
-        "podSecurityContext": {
+        "scalarManager": {
             "type": "object",
             "properties": {
-                "seccompProfile": {
+                "api": {
                     "type": "object",
                     "properties": {
-                        "type": {
+                        "applicationProperties": {
                             "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "replicaCount": {
-            "type": "integer"
-        },
-        "securityContext": {
-            "type": "object",
-            "properties": {
-                "allowPrivilegeEscalation": {
-                    "type": "boolean"
-                },
-                "capabilities": {
-                    "type": "object",
-                    "properties": {
-                        "drop": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
                             }
+                        },
+                        "resources": {
+                            "type": "object"
                         }
                     }
                 },
-                "runAsNonRoot": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "automountServiceAccountToken": {
-                    "type": "boolean"
-                },
-                "serviceAccountName": {
-                    "type": "string"
-                }
-            }
-        },
-        "tolerations": {
-            "type": "array"
-        },
-        "web": {
-            "type": "object",
-            "properties": {
-                "env": {
+                "imagePullSecrets": {
                     "type": "array",
                     "items": {
                         "type": "object",
                         "properties": {
                             "name": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": "string"
                             }
                         }
                     }
                 },
-                "image": {
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
                     "type": "object",
                     "properties": {
-                        "pullPolicy": {
-                            "type": "string"
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean"
                         },
-                        "repository": {
-                            "type": "string"
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         },
-                        "tag": {
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "automountServiceAccountToken": {
+                            "type": "boolean"
+                        },
+                        "serviceAccountName": {
                             "type": "string"
                         }
                     }
                 },
-                "resources": {
-                    "type": "object"
+                "tolerations": {
+                    "type": "array"
                 },
-                "service": {
+                "web": {
                     "type": "object",
                     "properties": {
-                        "port": {
-                            "type": "integer"
+                        "env": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         },
-                        "type": {
-                            "type": "string"
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 }

--- a/charts/scalar-manager/values.schema.json
+++ b/charts/scalar-manager/values.schema.json
@@ -11,6 +11,22 @@
                 "azure": {
                     "type": "object",
                     "properties": {
+                        "extension": {
+                            "type": "object",
+                            "properties": {
+                                "resourceId": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "identity": {
+                            "type": "object",
+                            "properties": {
+                                "clientId": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "images": {
                             "type": "object",
                             "properties": {
@@ -27,6 +43,14 @@
                                             "type": "string"
                                         }
                                     }
+                                }
+                            }
+                        },
+                        "marketplace": {
+                            "type": "object",
+                            "properties": {
+                                "planId": {
+                                    "type": "string"
                                 }
                             }
                         }

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -1,125 +1,139 @@
 # Default values for scalar-manager.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 1
+
+global:
+  # -- Specify the platform that you use. This configuration is for internal use.
+  platform: ""
+  # -- Azure Marketplace specific configurations.
+  azure:
+    images:
+      # -- Container image of Scalar Manager for Azure Marketplace.
+      scalarManager:
+        tag: "3.0.0-SNAPSHOT"
+        image: "scalardb-cluster-node-azure-payg-premium"
+        registry: "scalar.azurecr.io"
 
 nameOverride: ""
 
 fullnameOverride: ""
 
-podAnnotations: {}
+scalarManager:
 
-podLabels: {}
+  replicaCount: 1
 
-podSecurityContext:
-  seccompProfile:
-    type: RuntimeDefault
+  podAnnotations: {}
 
-securityContext:
-  capabilities:
-    drop:
-      - ALL
-  runAsNonRoot: true
-  allowPrivilegeEscalation: false
+  podLabels: {}
 
-nodeSelector: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
 
-tolerations: []
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
 
-serviceAccount:
-  serviceAccountName: ""
-  automountServiceAccountToken: true
+  nodeSelector: {}
 
-api:
-  image:
-    repository: ghcr.io/scalar-labs/scalar-manager-api
-    pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
+  tolerations: []
 
-  resources:
-    {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  serviceAccount:
+    serviceAccountName: ""
+    automountServiceAccountToken: true
 
-  # -- The application.properties for Scalar Manager. If you want to customize application.properties, you can override this value with your application.properties.
-  # @default -- The minimum template of application.properties is set by default.
-  applicationProperties: |
-    prometheus.kubernetes-service-label-name=${PROMETHEUS_KUBERNETES_SERVICE_LABEL_NAME:app}
-    prometheus.kubernetes-service-label-value=${PROMETHEUS_KUBERNETES_SERVICE_LABEL_VALUE:kube-prometheus-stack-prometheus}
-    prometheus.kubernetes-service-port-name=${PROMETHEUS_KUBERNETES_SERVICE_PORT_NAME:http-web}
+  api:
+    image:
+      repository: ghcr.io/scalar-labs/scalar-manager-api
+      pullPolicy: IfNotPresent
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: ""
 
-    # Swagger UI configuration
-    springdoc.swagger-ui.enabled=${SPRINGDOC_SWAGGER_UI_ENABLED:false}
-    springdoc.swagger-ui.path=${SPRINGDOC_SWAGGER_UI_PATH:/swagger-ui.html}
+    resources:
+      {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 128Mi
 
-    # CORS configuration
-    app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:*}
-    app.cors.allowed-methods=${APP_CORS_ALLOWED_METHODS:*}
-    app.cors.allowed-headers=${APP_CORS_ALLOWED_HEADERS:*}
+    # -- The application.properties for Scalar Manager. If you want to customize application.properties, you can override this value with your application.properties.
+    # @default -- The minimum template of application.properties is set by default.
+    applicationProperties: |
+      prometheus.kubernetes-service-label-name=${PROMETHEUS_KUBERNETES_SERVICE_LABEL_NAME:app}
+      prometheus.kubernetes-service-label-value=${PROMETHEUS_KUBERNETES_SERVICE_LABEL_VALUE:kube-prometheus-stack-prometheus}
+      prometheus.kubernetes-service-port-name=${PROMETHEUS_KUBERNETES_SERVICE_PORT_NAME:http-web}
 
-    # JWT configuration
-    # Secret key used for signing JWT tokens, minimum 32 characters
-    authentication.providers.static-jwt.secret=${AUTHENTICATION_PROVIDERS_STATIC_JWT_SECRET:example-jwt-secret-with-minimum-32-characters}
-    authentication.providers.static-jwt.issuer-uri=${AUTHENTICATION_PROVIDERS_STATIC_JWT_ISSUER_URI:https://scalar-manager.example.com}
-    authentication.providers.static-jwt.access-token-expiration-time=${AUTHENTICATION_PROVIDERS_STATIC_JWT_ACCESS_TOKEN_EXPIRATION_TIME:1h}
-    authentication.providers.static-jwt.refresh-token-expiration-time=${AUTHENTICATION_PROVIDERS_STATIC_JWT_REFRESH_TOKEN_EXPIRATION_TIME:3d}
+      # Swagger UI configuration
+      springdoc.swagger-ui.enabled=${SPRINGDOC_SWAGGER_UI_ENABLED:false}
+      springdoc.swagger-ui.path=${SPRINGDOC_SWAGGER_UI_PATH:/swagger-ui.html}
 
-    # Initial admin configuration
-    app.initial-admin-user.enabled=${APP_INITIAL_ADMIN_USER_ENABLED:true}
-    app.initial-admin-user.email=${APP_INITIAL_ADMIN_USER_EMAIL:admin@example.com}
-    app.initial-admin-user.name=${APP_INITIAL_ADMIN_USER_NAME:Administrator}
-    app.initial-admin-user.password=${APP_INITIAL_ADMIN_USER_PASSWORD:Password@123!}
+      # CORS configuration
+      app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:*}
+      app.cors.allowed-methods=${APP_CORS_ALLOWED_METHODS:*}
+      app.cors.allowed-headers=${APP_CORS_ALLOWED_HEADERS:*}
 
-    # JPA configuration
-    spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    spring.jpa.show-sql=${SPRING_JPA_SHOW_SQL:false}
-    spring.jpa.properties.hibernate.format_sql=${SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL:false}
+      # JWT configuration
+      # Secret key used for signing JWT tokens, minimum 32 characters
+      authentication.providers.static-jwt.secret=${AUTHENTICATION_PROVIDERS_STATIC_JWT_SECRET:example-jwt-secret-with-minimum-32-characters}
+      authentication.providers.static-jwt.issuer-uri=${AUTHENTICATION_PROVIDERS_STATIC_JWT_ISSUER_URI:https://scalar-manager.example.com}
+      authentication.providers.static-jwt.access-token-expiration-time=${AUTHENTICATION_PROVIDERS_STATIC_JWT_ACCESS_TOKEN_EXPIRATION_TIME:1h}
+      authentication.providers.static-jwt.refresh-token-expiration-time=${AUTHENTICATION_PROVIDERS_STATIC_JWT_REFRESH_TOKEN_EXPIRATION_TIME:3d}
 
-    # Database configuration
-    spring.datasource.url=jdbc:postgresql://${DATABASE_HOST:scalar-manager-postgres-postgresql}:${DATABASE_PORT:5432}/${DATABASE_NAME:scalar-manager}
-    spring.datasource.username=${DATABASE_USERNAME:scalar-manager}
-    spring.datasource.password=${DATABASE_PASSWORD:scalar-manager}
-    spring.datasource.driver-class-name=org.postgresql.Driver
+      # Initial admin configuration
+      app.initial-admin-user.enabled=${APP_INITIAL_ADMIN_USER_ENABLED:true}
+      app.initial-admin-user.email=${APP_INITIAL_ADMIN_USER_EMAIL:admin@example.com}
+      app.initial-admin-user.name=${APP_INITIAL_ADMIN_USER_NAME:Administrator}
+      app.initial-admin-user.password=${APP_INITIAL_ADMIN_USER_PASSWORD:Password@123!}
 
+      # JPA configuration
+      spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
+      spring.jpa.show-sql=${SPRING_JPA_SHOW_SQL:false}
+      spring.jpa.properties.hibernate.format_sql=${SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL:false}
 
-web:
-  image:
-    repository: ghcr.io/scalar-labs/scalar-manager-web
-    pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
+      # Database configuration
+      spring.datasource.url=jdbc:postgresql://${DATABASE_HOST:scalar-manager-postgres-postgresql}:${DATABASE_PORT:5432}/${DATABASE_NAME:scalar-manager}
+      spring.datasource.username=${DATABASE_USERNAME:scalar-manager}
+      spring.datasource.password=${DATABASE_PASSWORD:scalar-manager}
+      spring.datasource.driver-class-name=org.postgresql.Driver
 
-  service:
-    type: ClusterIP
-    port: 80
+  web:
+    image:
+      repository: ghcr.io/scalar-labs/scalar-manager-web
+      pullPolicy: IfNotPresent
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: ""
 
-  # -- The environment variables for Scalar Manager web container. If you want to customize environment variables, you can override this value with your environment variables.
-  env:
-    # Currently, the GRAFANA_SERVER_URL is set to the Grafana service url installed in the monitoring namespace.
-    - name: GRAFANA_SERVER_URL
-      value: http://scalar-monitoring-grafana.monitoring.svc.cluster.local:3000
+    service:
+      type: ClusterIP
+      port: 80
 
-  resources:
-    {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+    # -- The environment variables for Scalar Manager web container. If you want to customize environment variables, you can override this value with your environment variables.
+    env:
+      # Currently, the GRAFANA_SERVER_URL is set to the Grafana service url installed in the monitoring namespace.
+      - name: GRAFANA_SERVER_URL
+        value: http://scalar-monitoring-grafana.monitoring.svc.cluster.local:3000
 
-imagePullSecrets:
-  - name: reg-docker-secrets
+    resources:
+      {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 128Mi
+
+  imagePullSecrets:
+    - name: reg-docker-secrets

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -18,9 +18,13 @@ global:
       resourceId: "DONOTMODIFY" # application's Azure Resource ID, Azure populates this value at deployment time
     images:
       # -- Container image of Scalar Manager for Azure Marketplace.
-      scalarManager:
+      scalarManagerApi:
         tag: "3.0.0-SNAPSHOT"
-        image: "scalardb-cluster-node-azure-payg-premium"
+        image: "scalar-manager-api-azure-payg"
+        registry: "scalar.azurecr.io"
+      scalarManagerWeb:
+        tag: "3.0.0-SNAPSHOT"
+        image: "scalar-manager-web-azure-payg"
         registry: "scalar.azurecr.io"
 
 nameOverride: ""

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -8,14 +8,14 @@ global:
   # -- Azure Marketplace specific configurations.
   azure:
     identity:
-      # Application's Managed Service Identity (MSI) Client ID. ClientID can be used to generate authentication token to communicate to external services like Microsoft Marketplace Metering API
-      clientId: "DONOTMODIFY" # Azure populates this value at deployment time
+      # Application's Managed Service Identity (MSI) Client ID. ClientID can be used to generate authentication token to communicate to external services like Microsoft Marketplace Metering API.Azure populates this value at deployment time
+      clientId: "DONOTMODIFY"
     marketplace:
-      # id of the plan purchased for the Azure Marketplace Kubernetes application,to be used in usage event payload to metering api, for more information please refer: https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-metering-service-apis
-      planId: "DONOTMODIFY" # Azure populates this value at deployment time
+      # id of the plan purchased for the Azure Marketplace Kubernetes application,to be used in usage event payload to metering api, for more information please refer: https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-metering-service-apis . Azure populates this value at deployment time. Azure populates this value at deployment time.
+      planId: "DONOTMODIFY"
     extension:
-      # resource id of the Azure Marketplace Kubernetes application,to be used in usage event payload to metering api, for more information please refer: https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-metering-service-apis
-      resourceId: "DONOTMODIFY" # application's Azure Resource ID, Azure populates this value at deployment time
+      # resource id of the Azure Marketplace Kubernetes application,to be used in usage event payload to metering api, for more information please refer: https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-metering-service-apis .
+      resourceId: "DONOTMODIFY"
     images:
       # -- Container image of Scalar Manager for Azure Marketplace.
       scalarManagerApi:

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -7,6 +7,15 @@ global:
   platform: ""
   # -- Azure Marketplace specific configurations.
   azure:
+    identity:
+      # Application's Managed Service Identity (MSI) Client ID. ClientID can be used to generate authentication token to communicate to external services like Microsoft Marketplace Metering API
+      clientId: "DONOTMODIFY" # Azure populates this value at deployment time
+    marketplace:
+      # id of the plan purchased for the Azure Marketplace Kubernetes application,to be used in usage event payload to metering api, for more information please refer: https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-metering-service-apis
+      planId: "DONOTMODIFY" # Azure populates this value at deployment time
+    extension:
+      # resource id of the Azure Marketplace Kubernetes application,to be used in usage event payload to metering api, for more information please refer: https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-metering-service-apis
+      resourceId: "DONOTMODIFY" # application's Azure Resource ID, Azure populates this value at deployment time
     images:
       # -- Container image of Scalar Manager for Azure Marketplace.
       scalarManager:

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -19,11 +19,11 @@ global:
     images:
       # -- Container image of Scalar Manager for Azure Marketplace.
       scalarManagerApi:
-        tag: "3.0.0-SNAPSHOT"
+        tag: ""
         image: "scalar-manager-api-azure-payg"
         registry: "scalar.azurecr.io"
       scalarManagerWeb:
-        tag: "3.0.0-SNAPSHOT"
+        tag: ""
         image: "scalar-manager-web-azure-payg"
         registry: "scalar.azurecr.io"
 


### PR DESCRIPTION
## Description

This PR updates the Scalar Manager Helm Chart to support Azure Marketplace.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

Mainly, this PR has two updates:

1. Support Azure Marketplace Pay As You Go listing.
1. Add the root key `scalarManager` in the `values.yaml` file to make `createUIDefinition.json` and `mainTemplate.json` simple.

### 1. Support Azure Marketplace Pay As You Go listing

To list Scalar Manager on the Azure Marketplace, we have to update our helm chart based on the rules of Azure Marketplace. So, I updated Scalar Manager chart as follows:

- Add `global.azure.*` in the `values.yaml` file.
- Update `spec.template.spec.containers[].image` in the `deployment.yaml` file to pull the container image from ACR for Azure Marketplace.

You can see what we need to list products on the Azure Marketplace in the following Azure document.

- [Update the Helm chart](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes#update-the-helm-chart)
- [Make updates based on your billing model](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes#make-updates-based-on-your-billing-model)

Also, to reduce the maintenance cost (avoid duplicated maintenance), I updated the current helm chart instead of creating the Azure Marketplace dedicated helm chart. To achieve that, I added the following things:

- Add `global.platform` in the `values.yaml` file.
  - I assume this parameter for switching our helm chart based on platforms (to list on each cloud marketplace, partner catalog or something like that) in the future. In other words, this configuration is not related to Azure Marketplace directly.
  - For example, if you set `global.platform=azure`, Scalar Manager chart use or add the Azure Marketplace dedicated configurations.

### 2. Add the root key `scalarManager` in the `values.yaml` file

We want to accept the whole of the `custom values file` as YAML in the UI (Portal) when users deploy Scalar Manager from the Azure Marketplace.

To achieve that, we need to specify the JSON key `scalarManager` in the `mainTemplate.json` file as follows:

- `mainTemplate.json` file
  ```json
            "properties": {
                "extensionType": "[variables('clusterExtensionTypeName')]",
                "autoUpgradeMinorVersion": true,
                "releaseTrain": "[variables('releaseTrain')]",
                "configurationSettings": {
                  "global.platform": "azure",
                  "scalarManager": "[parameters('helmCustomValues').scalarManager]"
                }
            },
  ```
  Note: This `mainTemplate.json` file defines input/output operations of Azure Marketplace deployment. The input comes from the UI (Portal). Users enter the custom values file (YAML) in the Portal. The entered values are passed to this `mainTemplate.json` file and it sends the entered YAML configuration to Helm as an output.

If we don't have such the root key `scalarManager`, we need to set a lot of keys in the `mainTemplate.json` file as follows:

- `mainTemplate.json` file
  ```json
            "properties": {
                "extensionType": "[variables('clusterExtensionTypeName')]",
                "autoUpgradeMinorVersion": true,
                "releaseTrain": "[variables('releaseTrain')]",
                "configurationSettings": {
                  "global.platform": "azure",
                  "replicaCount": "[parameters('helmCustomValues').replicaCount]",
                  "podAnnotations": "[parameters('helmCustomValues').podAnnotations]",
                  "podLabels": "[parameters('helmCustomValues').podLabels]",
                  "podSecurityContext": "[parameters('helmCustomValues').podSecurityContext]",
                  "securityContext": "[parameters('helmCustomValues').securityContext]",
                  "nodeSelector": "[parameters('helmCustomValues').nodeSelector]",
                  "tolerations": "[parameters('helmCustomValues').tolerations]",
                  "serviceAccount": "[parameters('helmCustomValues').serviceAccount]",
                  "api": "[parameters('helmCustomValues').api]",
                  "web": "[parameters('helmCustomValues').web]"
                }
            },
  ```

This configuration is a bit annoying to maintain and a bit difficult to test. So, I want to make the `mainTemplate.json` file simple by using the root key `scalarManager`.

This is why I want to add the root key `scalarManager` in the Scalar Manager Helm Chart.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
