### PR TITLE
[scalardl-ledger] Change default container image

### DIFF
--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -37,7 +37,7 @@ Current chart version is `5.0.0-SNAPSHOT`
 | ledger.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | ledger.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
-| ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
+| ledger.image.repository | string | `"ghcr.io/scalar-labs/scalardl-ledger"` | Docker image |
 | ledger.image.version | string | `"4.0.0-SNAPSHOT"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.ledgerProperties | string | The default minimum necessary values of ledger.properties are set. You can overwrite it with your own ledger.properties. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -125,7 +125,7 @@ ledger:
 
   image:
     # -- Docker image
-    repository: ghcr.io/scalar-labs/scalar-ledger
+    repository: ghcr.io/scalar-labs/scalardl-ledger
     # -- Docker tag
     version: 4.0.0-SNAPSHOT
     # -- Specify a imagePullPolicy


### PR DESCRIPTION
## Description

This PR changes the default container image in the ScalarDL Ledger chart. The previous default image is only for Scalar internal developers. In other words, users cannot pull that image. So, we decided to change the default image to the OSS version image.

## Related issues and/or PRs

N/A

## Changes made

- Change the default container image name from `ghcr.io/scalar-labs/scalar-ledger` to `ghcr.io/scalar-labs/scalardl-ledger`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Change the default container image name of ScalarDL Ledger.
