### PR TITLE
[scalardl-auditor] Change default container image

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -21,7 +21,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 | auditor.grafanaDashboard.enabled | bool | `false` | enable grafana dashboard |
 | auditor.grafanaDashboard.namespace | string | `"monitoring"` | which namespace grafana dashboard is located. by default monitoring |
 | auditor.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
-| auditor.image.repository | string | `"ghcr.io/scalar-labs/scalar-auditor"` | Docker image |
+| auditor.image.repository | string | `"ghcr.io/scalar-labs/scalardl-auditor-byol"` | Docker image |
 | auditor.image.version | string | `"4.0.0-SNAPSHOT"` | Docker tag |
 | auditor.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | auditor.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |

--- a/charts/scalardl-audit/ci/scalardl-auditor-ct-values.yaml
+++ b/charts/scalardl-audit/ci/scalardl-auditor-ct-values.yaml
@@ -7,3 +7,5 @@ auditor:
     scalar.dl.auditor.cert_holder_id=auditor
     scalar.dl.auditor.cert_path=/keys/certificate
     scalar.dl.auditor.private_key_path=/keys/private-key
+  image:
+    repository: ghcr.io/scalar-labs/scalar-auditor

--- a/charts/scalardl-audit/ci/scalardl-auditor-ct-values.yaml
+++ b/charts/scalardl-audit/ci/scalardl-auditor-ct-values.yaml
@@ -8,4 +8,4 @@ auditor:
     scalar.dl.auditor.cert_path=/keys/certificate
     scalar.dl.auditor.private_key_path=/keys/private-key
   image:
-    repository: ghcr.io/scalar-labs/scalar-auditor
+    repository: ghcr.io/scalar-labs/scalardl-auditor

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -157,7 +157,7 @@ auditor:
 
   image:
     # -- Docker image
-    repository: ghcr.io/scalar-labs/scalar-auditor
+    repository: ghcr.io/scalar-labs/scalardl-auditor-byol
     # -- Docker tag
     version: 4.0.0-SNAPSHOT
     # -- Specify a imagePullPolicy


### PR DESCRIPTION
## Description

This PR changes the default container image in the ScalarDL Auditor chart. The previous default image is only for Scalar internal developers. In other words, users cannot pull that image. So, we decided to change the default image to the BYOL version image. Note that users still need the license key to run this image after they pull it.

## Related issues and/or PRs

N/A

## Changes made

- Change the default container image name from `ghcr.io/scalar-labs/scalar-auditor` to `ghcr.io/scalar-labs/scalardl-auditor-byol`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Change the default container image name of ScalarDL Auditor.
