### PR TITLE
Add helm repo add commands for Monitoring Stack in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Add Helm repos
         run: |
           helm repo add scalar https://scalar-labs.github.io/helm-charts
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1


### PR DESCRIPTION
## Description

This PR fixes the error in the release workflow.

Now, we have Scalar Monitoring Stack helm charts, and they depend on other community helm charts, Prometheus, Grafana, Loki, and Alloy.

So, we need to add the Helm repositories of those charts in the release workflow.

Please take a look when you have time!

## Related issues and/or PRs

- https://github.com/scalar-labs/helm-charts/actions/runs/14633020472/job/41058688388

## Changes made

- Add `helm add` command in the release workflow.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A

