### PR TITLE
[scalardl-ledger-monitoring] Collect metrics from same namespace only

### DIFF
--- a/charts/scalardl-ledger-monitoring/README.md
+++ b/charts/scalardl-ledger-monitoring/README.md
@@ -123,6 +123,8 @@ Current chart version is `0.0.0-SNAPSHOT`
 | prometheus.enabled | bool | `true` |  |
 | prometheus.kube-state-metrics.customLabels."app.kubernetes.io/app" | string | `"scalardl-ledger-monitoring"` |  |
 | prometheus.kube-state-metrics.enabled | bool | `true` |  |
+| prometheus.kube-state-metrics.rbac.useClusterRole | bool | `false` |  |
+| prometheus.kube-state-metrics.releaseNamespace | bool | `true` |  |
 | prometheus.prometheus-node-exporter.enabled | bool | `false` |  |
 | prometheus.prometheus-pushgateway.enabled | bool | `false` |  |
 | prometheus.server.affinity | object | `{}` |  |

--- a/charts/scalardl-ledger-monitoring/values.schema.json
+++ b/charts/scalardl-ledger-monitoring/values.schema.json
@@ -753,6 +753,17 @@
                         },
                         "enabled": {
                             "type": "boolean"
+                        },
+                        "rbac": {
+                            "type": "object",
+                            "properties": {
+                                "useClusterRole": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "releaseNamespace": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/charts/scalardl-ledger-monitoring/values.yaml
+++ b/charts/scalardl-ledger-monitoring/values.yaml
@@ -398,6 +398,9 @@ prometheus:
     enabled: true
     customLabels:
       app.kubernetes.io/app: "scalardl-ledger-monitoring"
+    releaseNamespace: true
+    rbac:
+      useClusterRole: false
   prometheus-node-exporter:
     enabled: false
   prometheus-pushgateway:


### PR DESCRIPTION
## Description

This PR updates the default configuration of `kube-state-metrics`.

Basically, we assume that the ScalarDL Ledger Monitoring chart collects metrics from the same namespace only as itself is deployed (i.e, it collects metrics of ScalarDL Ledger that is deployed in the same namespace as ScalarDL Ledger Monitoring).

However, in the current default value, `kube-state-metrics` collects metrics from all namespaces. Also, it requires a bit stronger permissions that are applied by using `ClusterRole`.

This PR sets (limits) the target namespace to the same namespace only as itself is deployed, and disables deploying unnecessary `ClusterRole`.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Set the target namespace to the release namespace only.
- Disable deploying unnecessary `ClusterRole`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
