### PR TITLE
[scalar-manager] Add affinity in `values.yaml` file

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Run kubeval
         run: |
-          chart_dirs=$(ls charts | grep -v -e "-monitoring$")
+          chart_dirs=$(ls charts)
           for chart_dir in ${chart_dirs}; do
             echo "helm dependency build charts/${chart_dir} chart..."
             helm dependency build charts/${chart_dir}

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Run kubeval
         run: |
-          chart_dirs=$(ls charts)
+          chart_dirs=$(ls charts | grep -v -e "-monitoring$")
           for chart_dir in ${chart_dirs}; do
             echo "helm dependency build charts/${chart_dir} chart..."
             helm dependency build charts/${chart_dir}

--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -16,6 +16,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 | global.azure.images.scalarManagerApi | object | `{"image":"scalar-manager-api-azure-payg","registry":"scalar.azurecr.io","tag":""}` | Container image of Scalar Manager for Azure Marketplace. |
 | global.platform | string | `""` | Specify the platform that you use. This configuration is for internal use. |
 | nameOverride | string | `""` |  |
+| scalarManager.affinity | object | `{}` | The affinity/anti-affinity feature, greatly expands the types of constraints you can express. |
 | scalarManager.api.applicationProperties | string | The minimum template of application.properties is set by default. | The application.properties for Scalar Manager. If you want to customize application.properties, you can override this value with your application.properties. |
 | scalarManager.api.image.pullPolicy | string | `"IfNotPresent"` |  |
 | scalarManager.api.image.repository | string | `"ghcr.io/scalar-labs/scalar-manager-api"` |  |

--- a/charts/scalar-manager/values.schema.json
+++ b/charts/scalar-manager/values.schema.json
@@ -81,6 +81,9 @@
         "scalarManager": {
             "type": "object",
             "properties": {
+                "affinity": {
+                    "type": "object"
+                },
                 "api": {
                     "type": "object",
                     "properties": {

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -54,6 +54,9 @@ scalarManager:
 
   tolerations: []
 
+  # -- The affinity/anti-affinity feature, greatly expands the types of constraints you can express.
+  affinity: {}
+
   serviceAccount:
     serviceAccountName: ""
     automountServiceAccountToken: true


### PR DESCRIPTION
## Description

This PR adds the `affinity:` configuration in the `values.yaml` file.

Actually, we can set `affinity` to the Deployment resource (in `deployment.yaml`) because the `deployment.yaml` file already have the affinity configuration.

However, from the user perspective, I think it would be better to set `affinity: {}` as a default value in the `values.yaml` file so that users know they can set the affinity configuration to the Scalar Manager pod.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add `affinity: {}` as a default value in the `values.yaml` file.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
