### PR TITLE
Exclude monitoring charts from CI for other charts

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -132,6 +132,7 @@ jobs:
 
       - name: Run kubeval
         run: |
+          # Exclude Scalar Monitoring Stack charts because we test them in another CI.
           chart_dirs=$(ls charts | grep -v -e "-monitoring$")
           for chart_dir in ${chart_dirs}; do
             echo "helm dependency build charts/${chart_dir} chart..."

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Run kubeval
         run: |
-          chart_dirs=$(ls charts)
+          chart_dirs=$(ls charts | grep -v -e "-monitoring$")
           for chart_dir in ${chart_dirs}; do
             echo "helm dependency build charts/${chart_dir} chart..."
             helm dependency build charts/${chart_dir}


### PR DESCRIPTION
## Description

This PR fixes the issue of CI.

In the current CI for charts other than Scalar Monitoring Stack, we don't need to check the Scalar Monitoring Stack charts.

However, in that CI, it selects the target charts from the directory information by using the `ls charts` command, which includes Scalar Monitoring Stack charts as a command result.

This causes the CI error like https://github.com/scalar-labs/helm-charts/actions/runs/15011694828/job/42181525214?pr=294.

To fix this issue, I excluded the Scalar Monitoring Stack charts from the CI for charts other than Scalar Monitoring Stack charts.

Please take a look!

## Related issues and/or PRs

- https://github.com/scalar-labs/helm-charts/actions/runs/15011694828/job/42181525214?pr=294

## Changes made

- Exclude Scalar Monitoring Stack charts by using the `ls charts | grep -v -e "-monitoring$"` command.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
