### PR TITLE
[scalar-manager] Support annotations for Service resource

### DIFF
--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -38,5 +38,6 @@ Current chart version is `3.0.0-SNAPSHOT`
 | scalarManager.web.image.repository | string | `"ghcr.io/scalar-labs/scalar-manager-web"` |  |
 | scalarManager.web.image.tag | string | `""` |  |
 | scalarManager.web.resources | object | `{}` |  |
+| scalarManager.web.service.annotations | object | `{}` | Service annotations. For example, you can configure the Load Balancer provided by Cloud Service. |
 | scalarManager.web.service.port | int | `80` |  |
 | scalarManager.web.service.type | string | `"ClusterIP"` |  |

--- a/charts/scalar-manager/templates/scalar-manager/service.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scalar-manager.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.scalarManager.web.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.scalarManager.web.service.type }}
   ports:

--- a/charts/scalar-manager/values.schema.json
+++ b/charts/scalar-manager/values.schema.json
@@ -215,6 +215,9 @@
                         "service": {
                             "type": "object",
                             "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
                                 "port": {
                                     "type": "integer"
                                 },

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -128,6 +128,8 @@ scalarManager:
     service:
       type: ClusterIP
       port: 80
+      # -- Service annotations. For example, you can configure the Load Balancer provided by Cloud Service.
+      annotations: {}
 
     # -- The environment variables for Scalar Manager web container. If you want to customize environment variables, you can override this value with your environment variables.
     env:


### PR DESCRIPTION
## Description

This PR adds the annotations configuration support for the Service resource.

Now, you can set arbitrary annotations to the Service resource.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add new values `scalarManager.web.service.annotations`.
- Set annotations in the `service.yaml` file.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
