### PR TITLE
[scalar-manager] Update how to configure service ports

### DIFF
--- a/charts/scalar-manager/README.md
+++ b/charts/scalar-manager/README.md
@@ -38,5 +38,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 | scalarManager.web.image.repository | string | `"ghcr.io/scalar-labs/scalar-manager-web"` |  |
 | scalarManager.web.image.tag | string | `""` |  |
 | scalarManager.web.resources | object | `{}` |  |
-| scalarManager.web.service.port | int | `80` |  |
+| scalarManager.web.service.ports.web.port | int | `80` |  |
+| scalarManager.web.service.ports.web.protocol | string | `"TCP"` |  |
+| scalarManager.web.service.ports.web.targetPort | int | `3000` |  |
 | scalarManager.web.service.type | string | `"ClusterIP"` |  |

--- a/charts/scalar-manager/templates/scalar-manager/service.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/service.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   type: {{ .Values.scalarManager.web.service.type }}
   ports:
-    - protocol: TCP
-      name: web
-      port: {{ .Values.scalarManager.web.service.port }}
-      targetPort: 3000
+  {{- range $key, $value := .Values.scalarManager.web.service.ports }}
+    - name: {{ $key }}
+{{ toYaml $value | indent 6 }}
+  {{- end }}
   selector:
     {{- include "scalar-manager.selectorLabels" . | nindent 4 }}

--- a/charts/scalar-manager/values.schema.json
+++ b/charts/scalar-manager/values.schema.json
@@ -215,8 +215,24 @@
                         "service": {
                             "type": "object",
                             "properties": {
-                                "port": {
-                                    "type": "integer"
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "web": {
+                                            "type": "object",
+                                            "properties": {
+                                                "port": {
+                                                    "type": "integer"
+                                                },
+                                                "protocol": {
+                                                    "type": "string"
+                                                },
+                                                "targetPort": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
+                                    }
                                 },
                                 "type": {
                                     "type": "string"

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -134,7 +134,7 @@ scalarManager:
         web:
           # Public port of Scalar Manager Web service.
           port: 80
-          # Internal port that Scalar Manager Web container listens.
+          # Internal port number that Scalar Manager Web container listens.
           targetPort: 3000
           # Protocol that Scalar Manager Web service listens.
           protocol: TCP

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -127,7 +127,14 @@ scalarManager:
 
     service:
       type: ClusterIP
-      port: 80
+      ports:
+        web:
+          # Public port of Scalar Manager Web service.
+          port: 80
+          # Internal port that Scalar Manager Web container listens.
+          targetPort: 3000
+          # Protocol that Scalar Manager Web service listens.
+          protocol: TCP
 
     # -- The environment variables for Scalar Manager web container. If you want to customize environment variables, you can override this value with your environment variables.
     env:

--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -134,7 +134,7 @@ scalarManager:
         web:
           # Public port of Scalar Manager Web service.
           port: 80
-          # Internal port number that Scalar Manager Web container listens.
+          # Internal port that Scalar Manager Web container listens.
           targetPort: 3000
           # Protocol that Scalar Manager Web service listens.
           protocol: TCP


### PR DESCRIPTION
## Description

This PR changes `How to configure the ports configuration of service resource`.

The main reason is that the previous configuration differs from other Scalar Helm Charts a little.

From the users (how to configure) and maintenance perspective, I want to use the same way as long as possible (i.e., I want to keep consistency between several Scalar Helm Charts).

This updated way is the same way as Envoy, ScalarDB Cluster, and ScalarDL.

- Envoy
  - https://github.com/scalar-labs/helm-charts/blob/envoy-2.6.0/charts/envoy/values.yaml#L58-L65
  - https://github.com/scalar-labs/helm-charts/blob/envoy-2.6.0/charts/envoy/templates/service.yaml#L12-L16
- ScalarDB Cluster
  - https://github.com/scalar-labs/helm-charts/blob/scalardb-cluster-1.7.1/charts/scalardb-cluster/values.yaml#L204-L211
  - https://github.com/scalar-labs/helm-charts/blob/scalardb-cluster-1.7.1/charts/scalardb-cluster/templates/scalardb-cluster/service.yaml#L14-L18
- ScalarDL Ledger
  - https://github.com/scalar-labs/helm-charts/blob/scalardl-4.9.2/charts/scalardl/values.yaml#L180-L201
  - https://github.com/scalar-labs/helm-charts/blob/scalardl-4.9.2/charts/scalardl/templates/ledger/service.yaml#L14-L18
- ScalarDL Auditor
  - https://github.com/scalar-labs/helm-charts/blob/scalardl-audit-2.9.2/charts/scalardl-audit/values.yaml#L213-L234
  - https://github.com/scalar-labs/helm-charts/blob/scalardl-audit-2.9.2/charts/scalardl-audit/templates/auditor/service.yaml#L14-L18

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Make the whole of `ports` settings configurable by using the `values.yaml` file.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This update is backward-incompatible. So, I will include this update in the next major version release `v3`.

## Release notes

N/A
