### PR TITLE
[scalar-manager] Remove unnecessary Roles

### DIFF
--- a/charts/scalar-manager/templates/scalar-manager/clusterrole.yaml
+++ b/charts/scalar-manager/templates/scalar-manager/clusterrole.yaml
@@ -6,14 +6,8 @@ metadata:
     {{- include "scalar-manager.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "services", "namespaces", "configmaps", "secrets", "serviceaccounts"]
-    verbs: ["get", "list", "create", "patch", "delete", "update"]
-  - apiGroups: ["batch"]
-    resources: ["cronjobs", "jobs"]
-    verbs: ["get", "list", "create", "delete"]
+    resources: ["pods", "services", "namespaces"]
+    verbs: ["get", "list"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "rolebindings"]
-    verbs: ["get", "list", "create", "delete"]


### PR DESCRIPTION
## Description

This PR removes unnecessary roles from Scalar Manager chart.

Previously, we use use the `Scalar Admin for Kubernetes` helm chart to pause Scalar products from Scalar Manager. In other words, Scalar Manager deploys the `Scalar Admin for Kubernetes` helm chart by using the `helm install` command. And, to deploy the `Scalar Admin for Kubernetes` helm chart, Scalar Manager needed to have several roles (permissions).

However, now Scalar Manager does not use the `Scalar Admin for Kubernetes` helm chart (i.e., it does not run the `helm install` command). Instead of that, Scalar Manager uses the `Scalar Admin for Kubernetes` library directly in its internal.

Therefore, we don't need to allow several permissions to Scalar Manager for deploying `Scalar Admin for Kubernetes` helm chart. This PR removes such unnecessary permissions.

Please take a look!

## Related issues and/or PRs

- This PR fixes #269.

## Changes made

- Remove unnecessary permissions from the `clusterrole.yaml` file.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
