### PR TITLE
[scalar-manager] Update default values

### DIFF
--- a/charts/scalar-manager/values.yaml
+++ b/charts/scalar-manager/values.yaml
@@ -84,9 +84,9 @@ scalarManager:
     # -- The application.properties for Scalar Manager. If you want to customize application.properties, you can override this value with your application.properties.
     # @default -- The minimum template of application.properties is set by default.
     applicationProperties: |
-      prometheus.kubernetes-service-label-name=${PROMETHEUS_KUBERNETES_SERVICE_LABEL_NAME:app}
-      prometheus.kubernetes-service-label-value=${PROMETHEUS_KUBERNETES_SERVICE_LABEL_VALUE:kube-prometheus-stack-prometheus}
-      prometheus.kubernetes-service-port-name=${PROMETHEUS_KUBERNETES_SERVICE_PORT_NAME:http-web}
+      prometheus.kubernetes-service-label-name=${PROMETHEUS_KUBERNETES_SERVICE_LABEL_NAME:app.kubernetes.io/name}
+      prometheus.kubernetes-service-label-value=${PROMETHEUS_KUBERNETES_SERVICE_LABEL_VALUE:prometheus}
+      prometheus.kubernetes-service-port-name=${PROMETHEUS_KUBERNETES_SERVICE_PORT_NAME:http}
 
       # Swagger UI configuration
       springdoc.swagger-ui.enabled=${SPRINGDOC_SWAGGER_UI_ENABLED:false}


### PR DESCRIPTION
## Description

This PR updates the default value of Scalar Manager chart.

Previously, we assumed that Prometheus is deployed by using `kube-prometheus-stack`.

However, at the moment, we assume that Prometheus is deployed by using Scalar Monitoring Stack.

Therefore, I updated the default values based on Scalar Monitoring Stack.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Update the default values in the `values.yaml` file.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
