### PR TITLE
[scalardl-auditor] Support HMAC authentication method

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -15,6 +15,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 |-----|------|---------|-------------|
 | auditor.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | auditor.auditorProperties | string | The default minimum necessary values of auditor.properties are set. You can overwrite it with your own auditor.properties. | The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties. |
+| auditor.authentication.method | string | `"digital-signature"` |  |
 | auditor.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | auditor.extraVolumeMounts | list | `[]` | Defines additional volume mounts. |
 | auditor.extraVolumes | list | `[]` | Defines additional volumes. |

--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -15,7 +15,7 @@ Current chart version is `3.0.0-SNAPSHOT`
 |-----|------|---------|-------------|
 | auditor.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | auditor.auditorProperties | string | The default minimum necessary values of auditor.properties are set. You can overwrite it with your own auditor.properties. | The auditor.properties is created based on the values of auditor.scalarAuditorConfiguration by default. If you want to customize auditor.properties, you can override this value with your auditor.properties. |
-| auditor.authentication.method | string | `"digital-signature"` |  |
+| auditor.authentication.method | string | `"digital-signature"` | Specify the authentication method of ScalarDL. Available value is "digital-signature" or "hmac". |
 | auditor.existingSecret | string | `""` | Name of existing secret to use for storing database username and password |
 | auditor.extraVolumeMounts | list | `[]` | Defines additional volume mounts. |
 | auditor.extraVolumes | list | `[]` | Defines additional volumes. |

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-      {{- if not .Values.auditor.extraVolumes }}
+      {{- if and (not .Values.auditor.extraVolumes) (not (eq .Values.auditor.authentication.method "hmac")) }}
         - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
           secret:
             secretName: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
@@ -85,7 +85,7 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.auditor.image.pullPolicy }}
           volumeMounts:
-          {{- if not .Values.auditor.extraVolumeMounts }}
+          {{- if and (not .Values.auditor.extraVolumeMounts) (not (eq .Values.auditor.authentication.method "hmac")) }}
             - name: "{{ .Values.auditor.scalarAuditorConfiguration.secretName }}"
               mountPath: "/keys"
               readOnly: true

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -11,6 +11,14 @@
                 "auditorProperties": {
                     "type": "string"
                 },
+                "authentication": {
+                    "type": "object",
+                    "properties": {
+                        "method": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "existingSecret": {
                     "type": "string"
                 },

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -331,4 +331,5 @@ auditor:
       issuerRef: {}
 
   authentication:
+    # -- Specify the authentication method of ScalarDL. Available value is "digital-signature" or "hmac".
     method: "digital-signature"

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -329,3 +329,6 @@ auditor:
         - localhost
       # -- Issuer references of cert-manager.
       issuerRef: {}
+
+  authentication:
+    method: "digital-signature"


### PR DESCRIPTION
## Description

This PR supports the HMAC authentication method in ScalarDL Auditor chart.

The previous Helm Chart assumes that ScalarDL has only one authentication method `digital-signature`. So, it always tries to mount `auditor-keys` that include a private key and certificate.

However, if users use the HMAC authentication method such a secret is not necessary, and this chart does not need to mount the `auditor-keys` that include a private key and certificate.

This PR introduces the new parameter `auditor.authentication.method`. If you don't specify the `hmac` (i.e., use `digital-signature` that is the default value), this chart tries to mount a secret `auditor-keys`. This is a default behavior, and it's backward-compatible.

If you specify the `hmac`, this chart does not try to mount the secret `auditor-keys`. This is a new behavior that is added by this PR.

Also, this chart provides the feature `extraVolumeMounts`. This feature provides `Mounting arbitrary secret or volumes instead of "auditor-keys"`. If you set `extraVolumeMounts`, this chart does not try to mount the secret `auditor-keys`, too. (This feature is already provided in the current chart, but this feature cannot `disable` mounting the `auditor-keys` completely. This feature must mount other volumes instead of `auditor-keys`.)

In short, the new conditions are as follows:

|                               |`auditor.authentication.method=digital-signature`            |`auditor.authentication.method=hmac`|
|:------------------------------|:-----------------------------------------------------------:|:----------------------------------:|
|`extraVolumeMounts` are NOT set|Try to mount `auditor-keys` (default and backward-compatible)|Not try to mount `auditor-keys`     |
|`extraVolumeMounts` are set    |Not try to mount `auditor-keys`                              |Not try to mount `auditor-keys`     |

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add new value `auditor.authentication.method`.
  - The default value is `digital-signature`.
- Add new condition branch to decide whether this chart tries to mount `auditor-keys` secret or not.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Helm Chart of ScalarDL Auditor supports the HMAC authentication method. Now, you can deploy ScalarDL Auditor without creating a secret resource that includes digital-signature information.
