### PR TITLE
[scalardb-cluster] Support User Labels

### DIFF
--- a/charts/scalardb-cluster/README.md
+++ b/charts/scalardb-cluster/README.md
@@ -52,6 +52,7 @@ Current chart version is `2.0.0-SNAPSHOT`
 | scalardbCluster.logLevel | string | `"INFO"` | The log level of ScalarDB Cluster |
 | scalardbCluster.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalardbCluster.podAnnotations | object | `{}` | Pod annotations for the scalardb-cluster deployment |
+| scalardbCluster.podLabels | object | `{}` | Pod labels for the scalardb-cluster deployment |
 | scalardbCluster.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings. |
 | scalardbCluster.prometheusRule.enabled | bool | `false` | Enable rules for prometheus. |
 | scalardbCluster.prometheusRule.namespace | string | `"monitoring"` | Which namespace prometheus is located. by default monitoring. |

--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -23,10 +23,9 @@ spec:
         {{- toYaml .Values.scalardbCluster.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "scalardb-cluster.selectorLabels" . | nindent 8 }}
-        {{- if .Values.scalardbCluster.podLabels }}
-        {{- toYaml .Values.scalardbCluster.podLabels | nindent 8 }}
-        {{- end }}
+        {{- $podLabels := .Values.scalardbCluster.podLabels | default dict }}
+        {{- $selectorLabels := include "scalardb-cluster.selectorLabels" . | fromYaml }}
+        {{- toYaml (merge $selectorLabels $podLabels) | nindent 8 }}
         {{- if eq .Values.global.platform "azure" }}
         azure-extensions-usage-release-identifier: {{ .Release.Name }}
         {{- end }}

--- a/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         {{- end }}
       labels:
         {{- include "scalardb-cluster.selectorLabels" . | nindent 8 }}
+        {{- if .Values.scalardbCluster.podLabels }}
+        {{- toYaml .Values.scalardbCluster.podLabels | nindent 8 }}
+        {{- end }}
         {{- if eq .Values.global.platform "azure" }}
         azure-extensions-usage-release-identifier: {{ .Release.Name }}
         {{- end }}

--- a/charts/scalardb-cluster/templates/scalardb-cluster/validate-values.yaml
+++ b/charts/scalardb-cluster/templates/scalardb-cluster/validate-values.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.scalardbCluster.podAnnotations }}
+  {{- if hasKey .Values.scalardbCluster.podAnnotations "checksum/config" }}
+    {{- fail "ScalarDB Cluster: \"scalardbCluster.podAnnotations\" cannot contain the key \"checksum/config\" as it is managed by the chart." }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.scalardbCluster.podLabels }}
+  {{- if hasKey .Values.scalardbCluster.podLabels "azure-extensions-usage-release-identifier" }}
+    {{- fail "ScalarDB Cluster: \"scalardbCluster.podLabels\" cannot contain the key \"azure-extensions-usage-release-identifier\" as it is managed by the chart." }}
+  {{- end }}
+{{- end }}

--- a/charts/scalardb-cluster/values.schema.json
+++ b/charts/scalardb-cluster/values.schema.json
@@ -233,6 +233,9 @@
                 "podAnnotations": {
                     "type": "object"
                 },
+                "podLabels": {
+                    "type": "object"
+                },
                 "podSecurityContext": {
                     "type": "object",
                     "properties": {

--- a/charts/scalardb-cluster/values.yaml
+++ b/charts/scalardb-cluster/values.yaml
@@ -249,6 +249,9 @@ scalardbCluster:
   # -- Pod annotations for the scalardb-cluster deployment
   podAnnotations: {}
 
+  # -- Pod labels for the scalardb-cluster deployment
+  podLabels: {}
+
   # -- Resources allowed to the pod.
   resources:
     {}


### PR DESCRIPTION
## Description

This PR adds a new configuration `scalardbCluster.podLabels`.

By using this configuration, users can set arbitrary labels to the pods as follows:

- Values file

  ```yaml
  scalardbCluster:
    podLabels:
      foo: bar
      bar: baz
  ```

- Generated deployment resource

  ```yaml
  apiVersion: apps/v1
  kind: Deployment
  spec:
    template:
      metadata:
        labels:
          app.kubernetes.io/name: scalardb-cluster
          app.kubernetes.io/instance: test
          app.kubernetes.io/app: scalardb-cluster
          bar: baz
          foo: bar
  ```

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add new configuration `scalardbCluster.podLabels`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added a new configuration `scalardbCluster.podLabels`. You can set arbitrary labels to pods.

