### PR TITLE
[scalardl-ledger] Support User Labels and Annotations

### DIFF
--- a/charts/scalardl/README.md
+++ b/charts/scalardl/README.md
@@ -42,6 +42,8 @@ Current chart version is `5.0.0-SNAPSHOT`
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.ledgerProperties | string | The default minimum necessary values of ledger.properties are set. You can overwrite it with your own ledger.properties. | The ledger.properties is created based on the values of ledger.scalarLedgerConfiguration by default. If you want to customize ledger.properties, you can override this value with your ledger.properties. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
+| ledger.podAnnotations | object | `{}` | Pod annotations for the scalardl-ledger deployment |
+| ledger.podLabels | object | `{}` | Pod labels for the scalardl-ledger deployment |
 | ledger.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings |
 | ledger.prometheusRule.enabled | bool | `false` | enable rules for prometheus |
 | ledger.prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |

--- a/charts/scalardl/templates/ledger/deployment.yaml
+++ b/charts/scalardl/templates/ledger/deployment.yaml
@@ -19,8 +19,13 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/ledger/configmap.yaml") . | sha256sum }}
+        {{- if .Values.ledger.podAnnotations }}
+        {{- toYaml .Values.ledger.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
-        {{- include "scalardl-ledger.selectorLabels" . | nindent 8 }}
+        {{- $podLabels := .Values.ledger.podLabels | default dict }}
+        {{- $selectorLabels := include "scalardl-ledger.selectorLabels" . | fromYaml }}
+        {{- toYaml (merge $selectorLabels $podLabels) | nindent 8 }}
         {{- if eq .Values.global.platform "azure" }}
         azure-extensions-usage-release-identifier: {{ .Release.Name }}
         {{- end }}

--- a/charts/scalardl/templates/ledger/validate-values.yaml
+++ b/charts/scalardl/templates/ledger/validate-values.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.ledger.podAnnotations }}
+  {{- if hasKey .Values.ledger.podAnnotations "checksum/config" }}
+    {{- fail "ScalarDL Ledger: \"ledger.podAnnotations\" cannot contain the key \"checksum/config\" as it is managed by the chart." }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.ledger.podLabels }}
+  {{- if hasKey .Values.ledger.podLabels "azure-extensions-usage-release-identifier" }}
+    {{- fail "ScalarDL Ledger: \"ledger.podLabels\" cannot contain the key \"azure-extensions-usage-release-identifier\" as it is managed by the chart." }}
+  {{- end }}
+{{- end }}

--- a/charts/scalardl/values.schema.json
+++ b/charts/scalardl/values.schema.json
@@ -179,6 +179,12 @@
                 "nodeSelector": {
                     "type": "object"
                 },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
                 "podSecurityContext": {
                     "type": "object",
                     "properties": {

--- a/charts/scalardl/values.yaml
+++ b/charts/scalardl/values.yaml
@@ -294,3 +294,9 @@ ledger:
         - localhost
       # -- Issuer references of cert-manager.
       issuerRef: {}
+
+  # -- Pod annotations for the scalardl-ledger deployment
+  podAnnotations: {}
+
+  # -- Pod labels for the scalardl-ledger deployment
+  podLabels: {}


### PR DESCRIPTION
## Description

This PR adds a new configuration `ledger.podLabels` and `ledger.podAnnotations`.

By using this configuration, users can set arbitrary labels and annotations to the pods as follows:

- Values file

  ```yaml
  ledger:
    podAnnotations:
      foo: bar
      bar: baz
    podLabels:
      foo: bar
      bar: baz
      app.kubernetes.io/name: foo
      app.kubernetes.io/app: bar
      app.kubernetes.io/instance: baz
  ```

- Generated deployment resource

  ```yaml
  apiVersion: apps/v1
  kind: Deployment
  spec:
    selector:
      matchLabels:
        app.kubernetes.io/name: scalardl
        app.kubernetes.io/instance: test
        app.kubernetes.io/app: ledger
    template:
      metadata:
        annotations:
          checksum/config: d16b9e671f1d185b78cbe2a1e92d559b39dd3e55cb180df9bb2fa863b138e1b1
          bar: baz
          foo: bar
        labels:
          app.kubernetes.io/app: ledger
          app.kubernetes.io/instance: test
          app.kubernetes.io/name: scalardl
          bar: baz
          foo: bar
  ```

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add new configurations `ledger.podLabels` and `ledger.podAnnotations`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Regarding the `ledger.podLabels`, this chart merges `selector labels` and `user specified labels`. And, it does not allow overriding the `selector labels` by the `user specified labels`. You can see the details of this behavior in the following comment on the ScalarDB Cluster's PR side.

- https://github.com/scalar-labs/helm-charts/pull/304#discussion_r2289955576

## Release notes

Added a new configuration `ledger.podLabels` and `ledger.podAnnotations`. You can set arbitrary labels and annotations to pods.
