### PR TITLE
[scalardl-auditor] Support User Labels and Annotations

### DIFF
--- a/charts/scalardl-audit/README.md
+++ b/charts/scalardl-audit/README.md
@@ -26,6 +26,8 @@ Current chart version is `3.0.0-SNAPSHOT`
 | auditor.image.version | string | `"4.0.0-SNAPSHOT"` | Docker tag |
 | auditor.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | auditor.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
+| auditor.podAnnotations | object | `{}` | Pod annotations for the scalardl-auditor deployment |
+| auditor.podLabels | object | `{}` | Pod labels for the scalardl-auditor deployment |
 | auditor.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings |
 | auditor.prometheusRule.enabled | bool | `false` | enable rules for prometheus |
 | auditor.prometheusRule.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |

--- a/charts/scalardl-audit/templates/auditor/deployment.yaml
+++ b/charts/scalardl-audit/templates/auditor/deployment.yaml
@@ -19,8 +19,13 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/auditor/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auditor.podAnnotations }}
+        {{- toYaml .Values.auditor.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
-        {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 8 }}
+        {{- $podLabels := .Values.auditor.podLabels | default dict }}
+        {{- $selectorLabels := include "scalardl-audit-auditor.selectorLabels" . | fromYaml }}
+        {{- toYaml (merge $selectorLabels $podLabels) | nindent 8 }}
         {{- if eq .Values.global.platform "azure" }}
         azure-extensions-usage-release-identifier: {{ .Release.Name }}
         {{- end }}

--- a/charts/scalardl-audit/values.schema.json
+++ b/charts/scalardl-audit/values.schema.json
@@ -67,6 +67,12 @@
                 "nodeSelector": {
                     "type": "object"
                 },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
                 "podSecurityContext": {
                     "type": "object",
                     "properties": {

--- a/charts/scalardl-audit/values.yaml
+++ b/charts/scalardl-audit/values.yaml
@@ -333,3 +333,9 @@ auditor:
   authentication:
     # -- Specify the authentication method of ScalarDL. Available value is "digital-signature" or "hmac".
     method: "digital-signature"
+
+  # -- Pod annotations for the scalardl-auditor deployment
+  podAnnotations: {}
+
+  # -- Pod labels for the scalardl-auditor deployment
+  podLabels: {}


### PR DESCRIPTION
## Description

This PR adds a new configuration `auditor.podLabels` and `auditor.podAnnotations`.

By using this configuration, users can set arbitrary labels and annotations to the pods as follows:

- Values file

  ```yaml
  auditor:
    podAnnotations:
      foo: bar
      bar: baz
    podLabels:
      foo: bar
      bar: baz
      app.kubernetes.io/name: foo
      app.kubernetes.io/app: bar
      app.kubernetes.io/instance: baz
  ```

- Generated deployment resource

  ```yaml
  apiVersion: apps/v1
  kind: Deployment
  spec:
    selector:
      matchLabels:
        app.kubernetes.io/name: scalardl-audit
        app.kubernetes.io/instance: test
        app.kubernetes.io/app: auditor
    template:
      metadata:
        annotations:
          checksum/config: 92fc0c92d6b0cbc153eeef648ae05110940629b89bea23eee545ac4be51d58e3
          bar: baz
          foo: bar
        labels:
          app.kubernetes.io/app: auditor
          app.kubernetes.io/instance: test
          app.kubernetes.io/name: scalardl-audit
          bar: baz
          foo: bar
  ```

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add new configurations `auditor.podLabels` and `auditor.podAnnotations`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Regarding the `auditor.podLabels`, this chart merges `selector labels` and `user specified labels`. And, it does not allow overriding the `selector labels` by the `user specified labels`. You can see the details of this behavior in the following comment on the ScalarDB Cluster's PR side.

- https://github.com/scalar-labs/helm-charts/pull/304#discussion_r2289955576

## Release notes

Added a new configuration `auditor.podLabels` and `auditor.podAnnotations`. You can set arbitrary labels and annotations to pods.

