### PR TITLE
[scalardb-analytics-server] Support User Labels

### DIFF
--- a/charts/scalardb-analytics-server/README.md
+++ b/charts/scalardb-analytics-server/README.md
@@ -18,6 +18,7 @@ Current chart version is `1.0.0-SNAPSHOT`
 | scalarDbAnalyticsServer.imagePullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | scalarDbAnalyticsServer.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint. |
 | scalarDbAnalyticsServer.podAnnotations | object | `{}` | Pod annotations for the scalardb-analytics-server deployment |
+| scalarDbAnalyticsServer.podLabels | object | `{}` | Pod labels for the scalardb-analytics-server deployment |
 | scalarDbAnalyticsServer.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | PodSecurityContext holds pod-level security attributes and common container settings. |
 | scalarDbAnalyticsServer.properties | string | `""` | You can specify your server.properties. |
 | scalarDbAnalyticsServer.resources | object | `{}` | Resources allowed to the pod. |

--- a/charts/scalardb-analytics-server/templates/scalardb-analytics-server/deployment.yaml
+++ b/charts/scalardb-analytics-server/templates/scalardb-analytics-server/deployment.yaml
@@ -22,7 +22,9 @@ spec:
         {{- toYaml .Values.scalarDbAnalyticsServer.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "scalardb-analytics-server.selectorLabels" . | nindent 8 }}
+        {{- $podLabels := .Values.scalarDbAnalyticsServer.podLabels | default dict }}
+        {{- $selectorLabels := include "scalardb-analytics-server.selectorLabels" . | fromYaml }}
+        {{- toYaml (merge $selectorLabels $podLabels) | nindent 8 }}
     spec:
       restartPolicy: Always
       {{- if .Values.scalarDbAnalyticsServer.serviceAccount.serviceAccountName }}

--- a/charts/scalardb-analytics-server/templates/scalardb-analytics-server/validate-values.yaml
+++ b/charts/scalardb-analytics-server/templates/scalardb-analytics-server/validate-values.yaml
@@ -17,3 +17,9 @@
     {{- fail "ScalarDB Analytics Server: \"scalarDbAnalyticsServer.tls.privateKeySecret\" must be set when using user-provided TLS certs (when \"scalarDbAnalyticsServer.tls.enabled\" is \"true\" and \"scalarDbAnalyticsServer.tls.certManager.enabled\" is \"false\")." }}
   {{- end }}
 {{- end }}
+
+{{- if .Values.scalarDbAnalyticsServer.podAnnotations }}
+  {{- if hasKey .Values.scalarDbAnalyticsServer.podAnnotations "checksum/config" }}
+    {{- fail "ScalarDB Analytics Server: \"scalarDbAnalyticsServer.podAnnotations\" cannot contain the key \"checksum/config\" as it is managed by the chart." }}
+  {{- end }}
+{{- end }}

--- a/charts/scalardb-analytics-server/values.schema.json
+++ b/charts/scalardb-analytics-server/values.schema.json
@@ -43,6 +43,9 @@
                 "podAnnotations": {
                     "type": "object"
                 },
+                "podLabels": {
+                    "type": "object"
+                },
                 "podSecurityContext": {
                     "type": "object",
                     "properties": {

--- a/charts/scalardb-analytics-server/values.yaml
+++ b/charts/scalardb-analytics-server/values.yaml
@@ -71,6 +71,9 @@ scalarDbAnalyticsServer:
   # -- Pod annotations for the scalardb-analytics-server deployment
   podAnnotations: {}
 
+  # -- Pod labels for the scalardb-analytics-server deployment
+  podLabels: {}
+
   # -- Resources allowed to the pod.
   resources:
     {}


### PR DESCRIPTION
## Description

This PR adds a new configuration `scalarDbAnalyticsServer.podLabels`.

By using this configuration, users can set arbitrary labels to the pods as follows:

- Values file

  ```yaml
  scalarDbAnalyticsServer:
    podLabels:
      foo: bar
      bar: baz
      app.kubernetes.io/name: foo
      app.kubernetes.io/app: bar
      app.kubernetes.io/instance: baz
  ```

- Generated deployment resource

  ```yaml
  apiVersion: apps/v1
  kind: Deployment
  spec:
    selector:
      matchLabels:
        app.kubernetes.io/name: scalardb-analytics-server
        app.kubernetes.io/instance: test
        app.kubernetes.io/app: scalardb-analytics-server
    template:
      metadata:
        labels:
          app.kubernetes.io/app: scalardb-analytics-server
          app.kubernetes.io/instance: test
          app.kubernetes.io/name: scalardb-analytics-server
          bar: baz
          foo: bar
  ```

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add new configurations `scalarDbAnalyticsServer.podLabels`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This chart merges `selector labels` and `user specified labels`. And, it does not allow overriding the `selector labels` by the `user specified labels`. You can see the details of this behavior in the following comment on the ScalarDB Cluster's PR side.

- https://github.com/scalar-labs/helm-charts/pull/304#discussion_r2289955576

## Release notes

Added a new configuration `scalarDbAnalyticsServer.podLabels`. You can set arbitrary labels to pods.
