### PR TITLE
Update k8s versions in CI

### DIFF
--- a/.github/workflows/ci-scalardb-cluster-monitoring.yml
+++ b/.github/workflows/ci-scalardb-cluster-monitoring.yml
@@ -77,11 +77,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.28.15
-          - v1.29.12
-          - v1.30.8
-          - v1.31.4
-          - v1.32.0
+          - v1.30.13
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
 
     steps:
       - name: Checkout
@@ -120,11 +119,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.28.15
-          - v1.29.12
-          - v1.30.8
-          - v1.31.4
-          - v1.32.0
+          - v1.30.13
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-scalardl-auditor-monitoring.yml
+++ b/.github/workflows/ci-scalardl-auditor-monitoring.yml
@@ -77,11 +77,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.28.15
-          - v1.29.12
-          - v1.30.8
-          - v1.31.4
-          - v1.32.0
+          - v1.30.13
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
 
     steps:
       - name: Checkout
@@ -120,11 +119,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.28.15
-          - v1.29.12
-          - v1.30.8
-          - v1.31.4
-          - v1.32.0
+          - v1.30.13
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-scalardl-ledger-monitoring.yml
+++ b/.github/workflows/ci-scalardl-ledger-monitoring.yml
@@ -77,11 +77,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.28.15
-          - v1.29.12
-          - v1.30.8
-          - v1.31.4
-          - v1.32.0
+          - v1.30.13
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
 
     steps:
       - name: Checkout
@@ -120,11 +119,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.28.15
-          - v1.29.12
-          - v1.30.8
-          - v1.31.4
-          - v1.32.0
+          - v1.30.13
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
 
     steps:
       - name: Checkout

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -106,11 +106,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.28.15
-          - v1.29.12
-          - v1.30.8
-          - v1.31.4
-          - v1.32.0
+          - v1.30.13
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
 
     steps:
       - name: Checkout
@@ -158,11 +157,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.28.15
-          - v1.29.12
-          - v1.30.8
-          - v1.31.4
-          - v1.32.0
+          - v1.30.13
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

This PR updates the versions of Kubernetes in the CI.

- Add `1.33`, which is the latest version of Kubernetes.
- Remove `1.28` and `1.29`, which are already the EoL version.
  - I confirmed that each major managed Kubernetes does not support `1.27` now.
    - [EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
    - [AKS](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
    - [GKE](https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions)
    - [OKE](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengaboutk8sversions.htm)

## Related issues and/or PRs

N/A

## Changes made

- Add Kubernetes `1.33`.
- Remove Kubernetes `1.28` and `1.29` since they have already been EoL.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
