### PR TITLE
[scalardl-ledger] Make Envoy optional

### DIFF
--- a/charts/scalardl/templates/ledger/service.yaml
+++ b/charts/scalardl/templates/ledger/service.yaml
@@ -1,3 +1,27 @@
+{{- if not .Values.envoy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scalardl.fullname" . }}-endpoint
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-ledger.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ledger.service.annotations | nindent 4 }}
+spec:
+  type: {{ .Values.ledger.service.type }}
+  sessionAffinity: None
+  ports:
+  {{- range $key, $value := .Values.ledger.service.ports }}
+  {{- if or (eq $key "scalardl") (eq $key "scalardl-priv") }}
+    - name: {{ $key }}
+      {{- toYaml $value | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  selector:
+    {{- include "scalardl-ledger.selectorLabels" . | nindent 4 }}
+{{- end }}
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,13 +32,13 @@ metadata:
   annotations:
     {{- toYaml .Values.ledger.service.annotations | nindent 4 }}
 spec:
-  type: {{ .Values.ledger.service.type }}
+  type: ClusterIP
   clusterIP: None
   sessionAffinity: None
   ports:
   {{- range $key, $value := .Values.ledger.service.ports }}
     - name: {{ $key }}
-{{ toYaml $value | indent 6 }}
+      {{- toYaml $value | nindent 6 }}
   {{- end }}
   selector:
     {{- include "scalardl-ledger.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Description

This PR add a new service resource `scalardl-ledger-endpoint` to access ScalarDL Ledger directly from clients without Envoy.

Previously, the Envoy proxy is mandatory if users access ScalarDL Ledger from the outside of Kubernetes.

However, the additional 1 hop (i.e., Envoy proxy) from the network perspective, it might have a performance impact.

Therefore, we decided to make the Envoy proxy optional.

In this case, we need to add a new service to access ScalarDL Ledger directly from clients without Envoy.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add a new Service `scalardl-ledger-endpoint` to access ScalarDL Ledger directly without Envoy.
- Minor improvement for the existing Headless Service.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

If you set `envoy.enabled` to `true` in the values file, you can see the Envoy pod and Envoy service as follows. This is the same behavior as the previous one. In other words, this is a backward-compatible behavior.

- Ledger / Pods (`envoy.enabled=true`)

```console
$ kubectl get pod -n ledger
NAME                                     READY   STATUS    RESTARTS   AGE
scalardl-ledger-envoy-5497478899-lmnvx   1/1     Running   0          7m12s
scalardl-ledger-ledger-54c4cc74d-md6ml   1/1     Running   0          7m12s
scalardl-ledger-ledger-54c4cc74d-n42ss   1/1     Running   0          7m12s
scalardl-ledger-ledger-54c4cc74d-phk68   1/1     Running   0          7m12s
```

- Ledger / Service (`envoy.enabled=true`)

```console
$ kubectl get svc -n ledger
NAME                            TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
scalardl-ledger-envoy           LoadBalancer   10.98.160.147    127.0.0.1     50051:30509/TCP,50052:31818/TCP   7m15s
scalardl-ledger-envoy-metrics   ClusterIP      10.108.151.186   <none>        9001/TCP                          7m15s
scalardl-ledger-headless        ClusterIP      None             <none>        50051/TCP,50053/TCP,50052/TCP     7m15s
scalardl-ledger-metrics         ClusterIP      10.97.39.166     <none>        8080/TCP                          7m15s
```

---

If you set `envoy.enabled` to `false` in the values file, you can see the new service `scalardl-ledger-endpoint`, and the Envoy pods and services disappear as follows. This is a new behavior that has been added in this PR.

- Ledger / Pods (`envoy.enabled=false`)

```console
$ kubectl get pod -n ledger
NAME                                     READY   STATUS    RESTARTS   AGE
scalardl-ledger-ledger-54c4cc74d-5pv9m   1/1     Running   0          27s
scalardl-ledger-ledger-54c4cc74d-lcf5l   1/1     Running   0          27s
scalardl-ledger-ledger-54c4cc74d-tc2f9   1/1     Running   0          27s
```

- Ledger / Service (`envoy.enabled=false`)

```console
$ kubectl get svc -n ledger
NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)                           AGE
scalardl-ledger-endpoint   LoadBalancer   10.99.106.15   127.0.0.1     50051:31967/TCP,50052:31564/TCP   33s
scalardl-ledger-headless   ClusterIP      None           <none>        50051/TCP,50053/TCP,50052/TCP     33s
scalardl-ledger-metrics    ClusterIP      10.101.88.17   <none>        8080/TCP                          33s
```

---

Also, I checked whether we can execute contracts via this `scalardl-ledger-endpoint` from the client as follows, just in case.

```console
root@scalardl-client:/scalardl-java-client-sdk# cat client.properties
# Ledger configuration
scalar.dl.client.server.host=scalardl-ledger-endpoint.ledger.svc.cluster.local

# Auditor configuration
scalar.dl.client.auditor.enabled=true
scalar.dl.client.auditor.host=scalardl-auditor-endpoint.auditor.svc.cluster.local

# Client configuration
scalar.dl.client.authentication_method=hmac
scalar.dl.client.entity.id=client
scalar.dl.client.entity.identity.hmac.secret_key=scalardl-hmac-client-secert-key
```
```console
root@scalardl-client:/scalardl-java-client-sdk# client/bin/scalardl generic-contracts execute-contract --properties client.properties \
> --contract-id object.Put \
> --contract-argument '{"object_id": "a.txt", "hash_value": "5c7440fb2273a247f78aadefbc511c680a84e7d44004abfaedef2b145151dab0", "metadata": {"note": "created"}}'
```
```console
root@scalardl-client:/scalardl-java-client-sdk# client/bin/scalardl generic-contracts execute-contract --properties client.properties \
> --contract-id object.Get \
> --contract-argument '{"object_id": "a.txt"}'
Contract result:
{
  "object_id" : "a.txt",
  "hash_value" : "5c7440fb2273a247f78aadefbc511c680a84e7d44004abfaedef2b145151dab0",
  "metadata" : {
    "note" : "created"
  }
}
```

---

In addition to that, I checked whether we can pause the ScalarDL Ledger by using Scalar Admin for Kubernetes (that utilizes the Headless Service `scalardl-ledger-headless`), just in case. As a result, it worked fine as follows:

- The status of Scalar Admin for Kubernetes pod.

  ```console
  $ kubectl -n ledger get pod
  NAME                                     READY   STATUS      RESTARTS   AGE
  job-scalar-admin-for-kubernetes-vzg6g    0/1     Completed   0          5s
  scalardl-ledger-ledger-54c4cc74d-5pv9m   1/1     Running     0          62m
  scalardl-ledger-ledger-54c4cc74d-lcf5l   1/1     Running     0          62m
  scalardl-ledger-ledger-54c4cc74d-tc2f9   1/1     Running     0          62m
  ```

- Log of ScalarDL Ledger pods

  ```console
  scalardl-ledger-ledger-54c4cc74d-tc2f9 scalardl-ledger 2025-09-12 07:11:03,248 [WARN  com.scalar.dl.ledger.server.AdminService] Paused
  scalardl-ledger-ledger-54c4cc74d-lcf5l scalardl-ledger 2025-09-12 07:11:03,248 [WARN  com.scalar.dl.ledger.server.AdminService] Paused
  scalardl-ledger-ledger-54c4cc74d-5pv9m scalardl-ledger 2025-09-12 07:11:03,248 [WARN  com.scalar.dl.ledger.server.AdminService] Paused
  scalardl-ledger-ledger-54c4cc74d-lcf5l scalardl-ledger 2025-09-12 07:11:03,291 [WARN  com.scalar.dl.ledger.server.AdminService] Unpaused
  scalardl-ledger-ledger-54c4cc74d-tc2f9 scalardl-ledger 2025-09-12 07:11:03,291 [WARN  com.scalar.dl.ledger.server.AdminService] Unpaused
  scalardl-ledger-ledger-54c4cc74d-5pv9m scalardl-ledger 2025-09-12 07:11:03,295 [WARN  com.scalar.dl.ledger.server.AdminService] Unpaused
  ```

## Release notes

Added a new service. Now, you can access ScalarDL Ledger directly without Envoy.

