### PR TITLE
[scalardl-auditor] Make Envoy optional

### DIFF
--- a/charts/scalardl-audit/templates/auditor/service.yaml
+++ b/charts/scalardl-audit/templates/auditor/service.yaml
@@ -1,3 +1,27 @@
+{{- if not .Values.envoy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scalardl-audit.fullname" . }}-endpoint
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scalardl-audit-auditor.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.auditor.service.annotations | nindent 4 }}
+spec:
+  type: {{ .Values.auditor.service.type }}
+  sessionAffinity: None
+  ports:
+  {{- range $key, $value := .Values.auditor.service.ports }}
+  {{- if or (eq $key "scalardl-auditor") (eq $key "scalardl-auditor-priv") }}
+    - name: {{ $key }}
+      {{- toYaml $value | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  selector:
+    {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 4 }}
+{{- end }}
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,13 +32,13 @@ metadata:
   annotations:
     {{- toYaml .Values.auditor.service.annotations | nindent 4 }}
 spec:
-  type: {{ .Values.auditor.service.type }}
+  type: ClusterIP
   clusterIP: None
   sessionAffinity: None
   ports:
   {{- range $key, $value := .Values.auditor.service.ports }}
     - name: {{ $key }}
-{{ toYaml $value | indent 6 }}
+      {{- toYaml $value | nindent 6 }}
   {{- end }}
   selector:
     {{- include "scalardl-audit-auditor.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Description

This PR add a new service resource `scalardl-auditor-endpoint` to access ScalarDL Auditor directly from clients without Envoy.

Previously, the Envoy proxy is mandatory if users access ScalarDL Auditor from the outside of Kubernetes.

However, the additional 1 hop (i.e., Envoy proxy) from the network perspective, it might have a performance impact.

Therefore, we decided to make the Envoy proxy optional.

In this case, we need to add a new service to access ScalarDL Auditor directly from clients without Envoy.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add a new Service `scalardl-auditor-endpoint` to access ScalarDL Auditor directly without Envoy.
- Minor improvement for the existing Headless Service.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

If you set `envoy.enabled` to `true` in the values file, you can see the Envoy pod and Envoy service as follows. This is the same behavior as the previous one. In other words, this is a backward-compatible behavior.

- Auditor / Pods (`envoy.enabled=true`)

```console
$ kubectl get pod -n auditor
NAME                                       READY   STATUS    RESTARTS   AGE
scalardl-auditor-auditor-c74bddd6c-2jwk5   1/1     Running   0          4m14s
scalardl-auditor-auditor-c74bddd6c-5wnrn   1/1     Running   0          4m14s
scalardl-auditor-auditor-c74bddd6c-sfh4j   1/1     Running   0          4m14s
scalardl-auditor-envoy-bb647f45c-bwgnx     1/1     Running   0          4m14s
```

- Auditor / Service (`envoy.enabled=true`)

```console
$ kubectl get svc -n auditor
NAME                             TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
scalardl-auditor-envoy           LoadBalancer   10.107.153.70   127.0.0.1     40051:31173/TCP,40052:31525/TCP   4m18s
scalardl-auditor-envoy-metrics   ClusterIP      10.96.251.186   <none>        9001/TCP                          4m18s
scalardl-auditor-headless        ClusterIP      None            <none>        40051/TCP,40053/TCP,40052/TCP     4m18s
scalardl-auditor-metrics         ClusterIP      10.105.40.63    <none>        8080/TCP                          4m18s
```

---

If you set `envoy.enabled` to `false` in the values file, you can see the new service `scalardl-auditor-endpoint`, and the Envoy pods and services disappear as follows. This is a new behavior that has been added in this PR.

- Auditor / Pods (`envoy.enabled=false`)

```console
$ kubectl get pod -n auditor
NAME                                       READY   STATUS    RESTARTS   AGE
scalardl-auditor-auditor-c74bddd6c-g5qn4   1/1     Running   0          26s
scalardl-auditor-auditor-c74bddd6c-rzh2z   1/1     Running   0          26s
scalardl-auditor-auditor-c74bddd6c-s29nn   1/1     Running   0          26s
```

- Auditor / Service (`envoy.enabled=false`)

```console
$ kubectl get svc -n auditor
NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
scalardl-auditor-endpoint   LoadBalancer   10.101.65.96     127.0.0.1     40051:30926/TCP,40052:30275/TCP   31s
scalardl-auditor-headless   ClusterIP      None             <none>        40051/TCP,40053/TCP,40052/TCP     31s
scalardl-auditor-metrics    ClusterIP      10.111.149.201   <none>        8080/TCP                          31s
```

---

Also, I checked whether we can execute contracts via this `scalardl-auditor-endpoint` from the client as follows, just in case.

```console
root@scalardl-client:/scalardl-java-client-sdk# cat client.properties
# Ledger configuration
scalar.dl.client.server.host=scalardl-ledger-endpoint.ledger.svc.cluster.local

# Auditor configuration
scalar.dl.client.auditor.enabled=true
scalar.dl.client.auditor.host=scalardl-auditor-endpoint.auditor.svc.cluster.local

# Client configuration
scalar.dl.client.authentication_method=hmac
scalar.dl.client.entity.id=client
scalar.dl.client.entity.identity.hmac.secret_key=scalardl-hmac-client-secert-key
```
```console
root@scalardl-client:/scalardl-java-client-sdk# client/bin/scalardl generic-contracts execute-contract --properties client.properties \
> --contract-id object.Put \
> --contract-argument '{"object_id": "a.txt", "hash_value": "5c7440fb2273a247f78aadefbc511c680a84e7d44004abfaedef2b145151dab0", "metadata": {"note": "created"}}'
```
```console
root@scalardl-client:/scalardl-java-client-sdk# client/bin/scalardl generic-contracts execute-contract --properties client.properties \
> --contract-id object.Get \
> --contract-argument '{"object_id": "a.txt"}'
Contract result:
{
  "object_id" : "a.txt",
  "hash_value" : "5c7440fb2273a247f78aadefbc511c680a84e7d44004abfaedef2b145151dab0",
  "metadata" : {
    "note" : "created"
  }
}
```

---

In addition to that, I checked whether we can pause the ScalarDL Auditor by using Scalar Admin for Kubernetes (that utilizes the Headless Service `scalardl-auditor-headless`), just in case. As a result, it worked fine as follows:

- The status of Scalar Admin for Kubernetes pod.

  ```console
  $ kubectl get pod -n auditor
  NAME                                       READY   STATUS      RESTARTS   AGE
  job-scalar-admin-for-kubernetes-8fjw2      0/1     Completed   0          6s
  scalardl-auditor-auditor-c74bddd6c-g5qn4   1/1     Running     0          66m
  scalardl-auditor-auditor-c74bddd6c-rzh2z   1/1     Running     0          66m
  scalardl-auditor-auditor-c74bddd6c-s29nn   1/1     Running     0          66m
  ```

- Log of ScalarDL Auditor pods

  ```console
  scalardl-auditor-auditor-c74bddd6c-rzh2z scalardl-audit-auditor 2025-09-12 07:15:17,930 [WARN  com.scalar.dl.ledger.server.AdminService] Paused
  scalardl-auditor-auditor-c74bddd6c-g5qn4 scalardl-audit-auditor 2025-09-12 07:15:17,930 [WARN  com.scalar.dl.ledger.server.AdminService] Paused
  scalardl-auditor-auditor-c74bddd6c-s29nn scalardl-audit-auditor 2025-09-12 07:15:17,930 [WARN  com.scalar.dl.ledger.server.AdminService] Paused
  scalardl-auditor-auditor-c74bddd6c-rzh2z scalardl-audit-auditor 2025-09-12 07:15:17,964 [WARN  com.scalar.dl.ledger.server.AdminService] Unpaused
  scalardl-auditor-auditor-c74bddd6c-s29nn scalardl-audit-auditor 2025-09-12 07:15:17,965 [WARN  com.scalar.dl.ledger.server.AdminService] Unpaused
  scalardl-auditor-auditor-c74bddd6c-g5qn4 scalardl-audit-auditor 2025-09-12 07:15:17,965 [WARN  com.scalar.dl.ledger.server.AdminService] Unpaused
  ```

## Release notes

Added a new service. Now, you can access ScalarDL Auditor directly without Envoy.

