### PR TITLE
Update k8s versions in CI

### DIFF
--- a/.github/ct-all.yaml
+++ b/.github/ct-all.yaml
@@ -13,3 +13,5 @@ excluded-charts:
   - scalardb-cluster-monitoring
   - scalardl-ledger-monitoring
   - scalardl-auditor-monitoring
+  - scalardb
+  - scalardb-graphql

--- a/.github/workflows/ci-scalardb-cluster-monitoring.yml
+++ b/.github/workflows/ci-scalardb-cluster-monitoring.yml
@@ -77,10 +77,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout
@@ -119,10 +119,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-scalardl-auditor-monitoring.yml
+++ b/.github/workflows/ci-scalardl-auditor-monitoring.yml
@@ -77,10 +77,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout
@@ -119,10 +119,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-scalardl-ledger-monitoring.yml
+++ b/.github/workflows/ci-scalardl-ledger-monitoring.yml
@@ -77,10 +77,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout
@@ -119,10 +119,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout

--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -99,10 +99,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout
@@ -148,10 +148,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

This PR updates the versions of Kubernetes in the CI.

- Add `1.35`, which is the latest version of Kubernetes.
- Remove `1.31`, which is already the EoL version.
  - I confirmed that each major managed Kubernetes does not support `1.31` now.
    - [EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
    - [AKS](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
    - [GKE](https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions)
    - [OKE](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengaboutk8sversions.htm)

You can see the test result in the following actions page:

- All charts other than monitoring stacks
  - https://github.com/scalar-labs/helm-charts/actions/runs/24022706377
- Monitoring Stacks
  - https://github.com/scalar-labs/helm-charts/actions/runs/24021082503
  - https://github.com/scalar-labs/helm-charts/actions/runs/24021090569
  - https://github.com/scalar-labs/helm-charts/actions/runs/24021095543

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add Kubernetes `1.35`.
- Remove Kubernetes `1.31` since it has already reached EoL.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I updated the official documents in the following PRs:

- https://github.com/scalar-labs/docs-internal-scalardb/pull/2283
- https://github.com/scalar-labs/docs-internal-scalardl/pull/869

## Release notes

N/A
