### PR TITLE
[scalardb-cluster] Update icon URL

### DIFF
--- a/charts/scalardb-cluster/Chart.yaml
+++ b/charts/scalardb-cluster/Chart.yaml
@@ -6,8 +6,9 @@ version: 2.0.0-SNAPSHOT
 appVersion: 4.0.0-SNAPSHOT
 kubeVersion: ">= 1.31.0-0"
 deprecated: false
-icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
+icon: https://developers.scalar-labs.com/img/scalardb-logo-01.svg
 keywords:
+- database
 - scalardb
 - scalardb-cluster
 - grpc


### PR DESCRIPTION
## Description

This PR updates the icon URL in the `Chart.yaml` file.

The current URL is broken, and it shows a broken image icon in the OpenShift web console.

To fix this issue, we published the new icon URL on the doc site.

I applied the new URL to the helm chart.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Update icon URL.
- Add `database` to the keyword.
  - This might be necessary for proper categorization in the OpenShift web console.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- I will update other charts when I apply other updates related to Red Hat Ecosystem Catalog in the future.

## Release notes

N/A
